### PR TITLE
Allow configuration of VLAN tag type in ACL rule

### DIFF
--- a/Dockerfile.tests
+++ b/Dockerfile.tests
@@ -1,6 +1,6 @@
 FROM ubuntu:latest
 
-ENV OVSV="2.7.3"
+ENV OVSV="2.8.1"
 
 ENV AG="apt-get -qqy --no-install-recommends"
 ENV DEBIAN_FRONTEND=noninteractive

--- a/Dockerfile.tests
+++ b/Dockerfile.tests
@@ -1,6 +1,6 @@
 FROM ubuntu:latest
 
-ENV OVSV="2.8.1"
+ENV OVSV="2.7.3"
 
 ENV AG="apt-get -qqy --no-install-recommends"
 ENV DEBIAN_FRONTEND=noninteractive

--- a/faucet/valve_acl.py
+++ b/faucet/valve_acl.py
@@ -23,6 +23,20 @@ except ImportError:
     from faucet import valve_of
 
 
+def push_vlan(vlan_vid):
+    """Push a VLAN tag with optional selection of eth type."""
+    vid = vlan_vid
+    vlan_eth_type = None
+    if isinstance(vlan_vid, dict):
+        vid = vlan_vid['vid']
+        if 'eth_type' in vlan_vid:
+            vlan_eth_type = vlan_vid['eth_type']
+    if vlan_eth_type is None:
+        return valve_of.push_vlan_act(vid)
+    else:
+        return valve_of.push_vlan_act(vid, eth_type=vlan_eth_type)
+
+
 def rewrite_vlan(output_dict):
     """Implement actions to rewrite VLAN headers."""
     vlan_actions = []
@@ -31,16 +45,15 @@ def rewrite_vlan(output_dict):
             vlan_actions.append(valve_of.pop_vlan())
     # if vlan tag is specified, push it.
     if 'vlan_vid' in output_dict:
-        vlan_actions.extend(
-            valve_of.push_vlan_act(output_dict['vlan_vid']))
+        vlan_actions.extend(push_vlan(output_dict['vlan_vid']))
     # swap existing VID
     elif 'swap_vid' in output_dict:
         vlan_actions.append(
             valve_of.set_vlan_vid(output_dict['swap_vid']))
     # or, if a list, push them all (all with type Q).
     elif 'vlan_vids' in output_dict:
-        for vid in output_dict['vlan_vids']:
-            vlan_actions.extend(valve_of.push_vlan_act(vid))
+        for vlan_vid in output_dict['vlan_vids']:
+            vlan_actions.extend(push_vlan(vlan_vid))
     return vlan_actions
 
 

--- a/tests/faucet_mininet_test_base.py
+++ b/tests/faucet_mininet_test_base.py
@@ -251,10 +251,11 @@ class FaucetTestBase(unittest.TestCase):
             self.net = None
         faucet_mininet_test_util.return_free_ports(
             self.ports_sock, self._test_name())
-        ovs_log_dir = os.environ['OVS_LOGDIR']
-        if ovs_log_dir and os.path.exists(ovs_log_dir):
-            for ovs_log in glob.glob(os.path.join(ovs_log_dir, '*.log')):
-                shutil.copy(ovs_log, self.tmpdir)
+        if 'OVS_LOGDIR' in os.environ:
+            ovs_log_dir = os.environ['OVS_LOGDIR']
+            if ovs_log_dir and os.path.exists(ovs_log_dir):
+                for ovs_log in glob.glob(os.path.join(ovs_log_dir, '*.log')):
+                    shutil.copy(ovs_log, self.tmpdir)
         # must not be any controller exception.
         self.verify_no_exception(self.env['faucet']['FAUCET_EXCEPTION_LOG'])
         for _, debug_log_name in self._get_ofchannel_logs():


### PR DESCRIPTION
            actions:
                output:
                    vlan_vids: [{vid: 123, eth_type: 0x88a8}, 456]

If eth_type is present, it is used instead of default (0x8100).

