### PR TITLE
Example config fixes

### DIFF
--- a/etc/ryu/faucet/faucet.yaml
+++ b/etc/ryu/faucet/faucet.yaml
@@ -34,7 +34,7 @@ dps:
             2:
                 native_vlan: 100
                 name: "VLAN 2001"
-                acl_in: 100
+                acl_in: 101
     windscale-faucet-1:
         dp_id: 0x2
         description: "Josh's experimental AT-X930"

--- a/etc/ryu/faucet/gauge.yaml
+++ b/etc/ryu/faucet/gauge.yaml
@@ -10,7 +10,8 @@ watchers:
         type: 'port_stats'
         dps: ['windscale-faucet-1']
         interval: 10
-        db: 'influx'
+        #db: 'influx'
+        db: 'prometheus'
     flow_table_poller:
         type: 'flow_table'
         dps: ['windscale-faucet-1']


### PR DESCRIPTION
This PR fixes two issues:

Our example faucet.yaml config refers to a non-existent ACL rule which causes faucet to have an exception on startup.

Our example gauge configuration doesn't turn on prometheus support by default.