### PR TITLE
remove hardcoded port 1 from faucet_mininet_test_unit.py

### DIFF
--- a/tests/faucet_mininet_test_unit.py
+++ b/tests/faucet_mininet_test_unit.py
@@ -394,7 +394,7 @@ class FaucetUntaggedPrometheusGaugeTest(FaucetUntaggedTest):
         self.wait_dp_status(1, controller='gauge')
         self.assertIsNotNone(self.scrape_prometheus_var(
             'faucet_pbr_version', any_labels=True, controller='gauge', retries=3))
-        labels = {'port_name': '1'}
+        labels = {'port_name': self.port_map["port_1"]}
         last_p1_bytes_in = 0
         for _ in range(2):
             updated_counters = False


### PR DESCRIPTION
The `faucet_mininet_test_unit.FaucetUntaggedPrometheusGaugeTest.test_untagged` test case was checking always the statistics related to port `1` instead of using the dynamic value specified in `hw_switch_config.yaml`. Now it uses `self.port_map["port_1"]` instead