### PR TITLE
Add valve_util.get_setting() and use it instead of os.getenv().

### DIFF
--- a/faucet/dp.py
+++ b/faucet/dp.py
@@ -24,6 +24,7 @@ from faucet.conf import Conf
 from faucet.port import Port
 from faucet.vlan import VLAN
 from faucet.valve_table import ValveTable, ValveGroupTable
+from faucet.valve_util import get_setting
 from faucet import valve_acl
 from faucet import valve_of
 
@@ -133,7 +134,7 @@ class DP(Conf):
         # How often to advertise (eg. IPv6 RAs)
         'proactive_learn': True,
         # whether proactive learning is enabled for IP nexthops
-        'pipeline_config_dir': '/etc/ryu/faucet',
+        'pipeline_config_dir': get_setting('FAUCET_PIPELINE_DIR'),
         # where config files for pipeline are stored (if any).
         'use_idle_timeout': False,
         # Turn on/off the use of idle timeout for src_table, default OFF.

--- a/faucet/gauge.py
+++ b/faucet/gauge.py
@@ -32,7 +32,7 @@ from ryu.controller import ofp_event
 from faucet import valve_of
 from faucet.config_parser import watcher_parser
 from faucet.gauge_prom import GaugePrometheusClient
-from faucet.valve_util import dpid_log, get_logger, kill_on_exception, get_sys_prefix
+from faucet.valve_util import dpid_log, get_logger, kill_on_exception, get_setting
 from faucet.watcher import watcher_factory
 
 
@@ -57,16 +57,10 @@ class Gauge(app_manager.RyuApp):
 
     def __init__(self, *args, **kwargs):
         super(Gauge, self).__init__(*args, **kwargs)
-        sysprefix = get_sys_prefix()
-        self.config_file = os.getenv(
-            'GAUGE_CONFIG', sysprefix + '/etc/ryu/faucet/gauge.yaml')
-        self.loglevel = os.getenv(
-            'GAUGE_LOG_LEVEL', logging.INFO)
-        self.exc_logfile = os.getenv(
-            'GAUGE_EXCEPTION_LOG',
-            sysprefix + '/var/log/ryu/faucet/gauge_exception.log')
-        self.logfile = os.getenv(
-            'GAUGE_LOG', sysprefix + '/var/log/ryu/faucet/gauge.log')
+        self.config_file = get_setting('GAUGE_CONFIG')
+        self.loglevel = get_setting('GAUGE_LOG_LEVEL')
+        self.exc_logfile = get_setting('GAUGE_EXCEPTION_LOG')
+        self.logfile = get_setting('GAUGE_LOG')
 
         # Setup logging
         self.logger = get_logger(
@@ -91,7 +85,6 @@ class Gauge(app_manager.RyuApp):
     @kill_on_exception(exc_logname)
     def _load_config(self):
         """Load Gauge config."""
-        self.config_file = os.getenv('GAUGE_CONFIG', self.config_file)
         new_confs = watcher_parser(self.config_file, self.logname, self.prom_client)
         new_watchers = {}
         configured_dpids = set()

--- a/faucet/valve_util.py
+++ b/faucet/valve_util.py
@@ -58,6 +58,27 @@ def get_sys_prefix():
     return sysprefix
 
 
+_PREFIX = get_sys_prefix()
+DEFAULTS = {
+    'FAUCET_CONFIG': _PREFIX + '/etc/ryu/faucet/faucet.yaml',
+    'FAUCET_LOG_LEVEL': 'INFO',
+    'FAUCET_LOG': _PREFIX + '/var/log/ryu/faucet/faucet.log',
+    'FAUCET_EXCEPTION_LOG': _PREFIX + '/var/log/ryu/faucet/faucet_exception.log',
+    'FAUCET_PROMETHEUS_PORT': '9302',
+    'FAUCET_PROMETHEUS_ADDR': '',
+    'FAUCET_PIPELINE_DIR': _PREFIX + '/etc/ryu/faucet',
+    'GAUGE_CONFIG': _PREFIX + '/etc/ryu/faucet/gauge.yaml',
+    'GAUGE_LOG_LEVEL': 'INFO',
+    'GAUGE_EXCEPTION_LOG': _PREFIX + '/var/log/ryu/faucet/gauge_exception.log',
+    'GAUGE_LOG': _PREFIX + '/var/log/ryu/faucet/gauge.log',
+}
+
+
+def get_setting(name):
+    """Returns value of specified configuration setting."""
+    return os.getenv(name, DEFAULTS[name])
+
+
 def get_logger(logname, logfile, loglevel, propagate):
     """Create and return a logger object."""
     logger = logging.getLogger(logname)


### PR DESCRIPTION
This pull request introduces a `get_setting` accessor to replace os.getenv() in obtaining the setting environment variables. The defaults for all the environment variables are now centralized in valve_util. In addition, there is a new FAUCET_PIPELINE_DIR setting for the `pipeline_dir` default used in dp.py.

It was possible for a local environment change to FAUCET_CONFIG/GAUGE_CONFIG to change the config file path when it was reloaded -- I removed this. I'm not sure if this was used. (see reload_config in faucet.py/_load_config in gauge.py).

I'm not sure why there is a per-datapath pipeline_dir setting; I can understand why a "pipeline_file" setting might be useful for specific datapaths.