### PR TITLE
keep track of src_ip for learning hosts, if exists

### DIFF
--- a/faucet/faucet.py
+++ b/faucet/faucet.py
@@ -356,7 +356,7 @@ class Faucet(app_manager.RyuApp):
         msg.data = msg.data[:valve_of.MAX_PACKET_IN_BYTES]
 
         # eth/VLAN header only
-        pkt, eth_pkt, vlan_vid, eth_type = valve_packet.parse_packet_in_pkt(
+        pkt, eth_pkt, vlan_vid, eth_type, src_ip = valve_packet.parse_packet_in_pkt(
             msg.data, max_len=valve_packet.ETH_VLAN_HEADER_SIZE)
         if vlan_vid is None:
             self.logger.info(
@@ -371,7 +371,7 @@ class Faucet(app_manager.RyuApp):
                 'packet for unknown VLAN %u from %s', vlan_vid, dpid_log(dp_id))
             return
         pkt_meta = valve.parse_rcv_packet(
-            in_port, vlan_vid, eth_type, msg.data, msg.total_len, pkt, eth_pkt)
+            in_port, vlan_vid, eth_type, msg.data, msg.total_len, pkt, eth_pkt, src_ip)
         other_valves = [other_valve for other_valve in list(self.valves.values()) if valve != other_valve]
 
         # pylint: disable=no-member

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -644,10 +644,10 @@ class Valve(object):
         ofmsgs = []
         if learn_port is not None:
             ofmsgs.extend(self.host_manager.learn_host_on_vlan_ports(
-                learn_port, pkt_meta.vlan, pkt_meta.eth_src))
+                learn_port, pkt_meta.vlan, pkt_meta.eth_src, pkt_meta.src_ip))
         return ofmsgs
 
-    def parse_rcv_packet(self, in_port, vlan_vid, eth_type, data, orig_len, pkt, eth_pkt):
+    def parse_rcv_packet(self, in_port, vlan_vid, eth_type, data, orig_len, pkt, eth_pkt, src_ip):
         """Parse a received packet into a PacketMeta instance.
 
         Args:
@@ -658,6 +658,7 @@ class Valve(object):
             orig_len (int): Original length of packet.
             pkt (ryu.lib.packet.packet): parsed packet received.
             ekt_pkt (ryu.lib.packet.ethernet): parsed Ethernet header.
+            src_ip (str): Source IP address if exists, otherwise None
         Returns:
             PacketMeta instance.
         """
@@ -666,7 +667,7 @@ class Valve(object):
         vlan = self.dp.vlans[vlan_vid]
         port = self.dp.ports[in_port]
         return valve_packet.PacketMeta(
-            data, orig_len, pkt, eth_pkt, port, vlan, eth_src, eth_dst, eth_type)
+            data, orig_len, pkt, eth_pkt, port, vlan, eth_src, eth_dst, eth_type, src_ip)
 
     def update_config_metrics(self, metrics):
         """Update gauge/metrics for configuration.

--- a/faucet/valve_host.py
+++ b/faucet/valve_host.py
@@ -192,7 +192,7 @@ class ValveHostManager(object):
 
         return ofmsgs
 
-    def learn_host_on_vlan_ports(self, port, vlan, eth_src, delete_existing=True):
+    def learn_host_on_vlan_ports(self, port, vlan, eth_src, src_ip, delete_existing=True):
         """Learn a host on a port."""
         now = time.time()
         ofmsgs = []
@@ -241,8 +241,8 @@ class ValveHostManager(object):
         vlan.add_cache_host(eth_src, port, now)
 
         self.logger.info(
-            'learned %s on %s on VLAN %u (%u hosts total)' % (
-                eth_src, port, vlan.vid, vlan.hosts_count()))
+            'learned %s on %s on VLAN %u with IP %s (%u hosts total)' % (
+                eth_src, port, vlan.vid, src_ip, vlan.hosts_count()))
 
         return ofmsgs
 
@@ -320,7 +320,7 @@ class ValveHostFlowRemovedManager(ValveHostManager):
             entry = vlan.host_cache[eth_dst]
             if not entry.expired:
                 ofmsgs.extend(self.learn_host_on_vlan_ports(
-                    entry.port, vlan, eth_dst, False))
+                    entry.port, vlan, eth_dst, None, False))
                 self.logger.info(
                     'refreshing host %s from vlan %u' % (eth_dst, vlan.vid))
         return ofmsgs

--- a/tests/test_valve.py
+++ b/tests/test_valve.py
@@ -192,8 +192,15 @@ vlans:
         pkt, eth_type = build_pkt(match)
         pkt.serialize()
         eth_pkt = valve_packet.parse_eth_pkt(pkt)
+        src_ip = None
+        for p in pkt:
+            try:
+                if p.protocol_name in 'arp':
+                    src_ip = p.src_ip
+            except Exception as e:
+                pass
         pkt_meta = self.valve.parse_rcv_packet(
-            port, vid, eth_type, pkt.data, len(pkt.data), pkt, eth_pkt)
+            port, vid, eth_type, pkt.data, len(pkt.data), pkt, eth_pkt, src_ip)
         rcv_packet_ofmsgs = self.valve.rcv_packet(
             other_valves=[], pkt_meta=pkt_meta)
         self.table.apply_ofmsgs(rcv_packet_ofmsgs)


### PR DESCRIPTION
if there is no `src_ip` it gets stored as `None`.  Currently only packets with a `protocol_name` of `ipv4`, `ipv6`, and `arp` are used to capture a `src_ip`.