### PR TITLE
Optionally detect config file changes on disk and apply new config without needing HUP.

### DIFF
--- a/faucet/dp.py
+++ b/faucet/dp.py
@@ -18,6 +18,8 @@
 
 import collections
 import copy
+
+from datadiff import diff
 import networkx
 
 from faucet.acl import ACL
@@ -664,8 +666,8 @@ class DP(Conf):
                                 port_no, old_acl_id, new_acl_id))
                     else:
                         changed_ports.add(port_no)
-                        logger.info('port %s reconfigured (%s -> %s)' % (
-                            port_no, old_port.to_conf(), new_port.to_conf()))
+                        logger.info('port %s reconfigured (%s)' % (
+                            port_no, diff(old_port.to_conf(), new_port.to_conf(), context=1)))
                 elif new_port.acl_in in changed_acls:
                     # If the port has ACL changed.
                     changed_acl_ports.add(port_no)

--- a/faucet/faucet.py
+++ b/faucet/faucet.py
@@ -102,6 +102,7 @@ class Faucet(app_manager.RyuApp):
         self.loglevel = get_setting('FAUCET_LOG_LEVEL')
         self.logfile = get_setting('FAUCET_LOG')
         self.exc_logfile = get_setting('FAUCET_EXCEPTION_LOG')
+        self.stat_reload = get_setting('FAUCET_CONFIG_STAT_RELOAD')
 
         # Create dpset object for querying Ryu's DPSet application
         self.dpset = kwargs['dpset']
@@ -286,8 +287,8 @@ class Faucet(app_manager.RyuApp):
                 new_config_file_stats = valve_util.stat_config_files(
                     self.config_hashes)
                 if new_config_file_stats != self.config_file_stats:
-                    # TODO: send config reload request.
-                    # self.send_event('Faucet', EventFaucetReconfigure())
+                    if self.stat_reload:
+                        self.send_event('Faucet', EventFaucetReconfigure())
                     if self.config_file_stats and new_config_file_stats:
                         self.logger.info('config file(s) changed on disk: %s' % (
                             diff(self.config_file_stats, new_config_file_stats, context=1)))

--- a/faucet/valve_util.py
+++ b/faucet/valve_util.py
@@ -61,6 +61,7 @@ def get_sys_prefix():
 _PREFIX = get_sys_prefix()
 DEFAULTS = {
     'FAUCET_CONFIG': _PREFIX + '/etc/ryu/faucet/faucet.yaml',
+    'FAUCET_CONFIG_STAT_RELOAD': '',
     'FAUCET_LOG_LEVEL': 'INFO',
     'FAUCET_LOG': _PREFIX + '/var/log/ryu/faucet/faucet.log',
     'FAUCET_EXCEPTION_LOG': _PREFIX + '/var/log/ryu/faucet/faucet_exception.log',
@@ -108,7 +109,7 @@ def stat_config_files(config_hashes):
     for config_file in list(config_hashes.keys()):
         try:
             config_file_stat = os.stat(config_file)
-        except FileNotFoundError:
+        except OSError:
             continue
         config_files_stats[config_file] = (
             config_file_stat.st_size,

--- a/faucet/valve_util.py
+++ b/faucet/valve_util.py
@@ -100,3 +100,18 @@ def dpid_log(dpid):
 def btos(b_str):
     """Return byte array/string as string."""
     return b_str.encode('utf-8').decode('utf-8', 'strict')
+
+
+def stat_config_files(config_hashes):
+    """Return dict of a subset of stat attributes on config files."""
+    config_files_stats = {}
+    for config_file in list(config_hashes.keys()):
+        try:
+            config_file_stat = os.stat(config_file)
+        except FileNotFoundError:
+            continue
+        config_files_stats[config_file] = (
+            config_file_stat.st_size,
+            config_file_stat.st_mtime,
+            config_file_stat.st_ctime)
+    return config_files_stats

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 couchdb
+datadiff
 dpkt
 influxdb
 ipaddress


### PR DESCRIPTION
Environment variable FAUCET_CONFIG_STAT_RELOAD must be set to not-empty.

E.g.

docker run -e FAUCET_CONFIG_STAT_RELOAD=1 -t faucet/faucet

