### PR TITLE
Allow logging to stdout/err:

### DIFF
--- a/faucet/valve_util.py
+++ b/faucet/valve_util.py
@@ -94,8 +94,18 @@ def get_bool_setting(name):
 
 def get_logger(logname, logfile, loglevel, propagate):
     """Create and return a logger object."""
+
+    stream_handlers = {
+        'STDOUT': sys.stdout,
+        'STDERR': sys.stderr,
+    }
+
+    try:
+        logger_handler = logging.StreamHandler(stream_handlers[logfile])
+    except KeyError:
+        logger_handler = WatchedFileHandler(logfile)
+
     logger = logging.getLogger(logname)
-    logger_handler = WatchedFileHandler(logfile)
     log_fmt = '%(asctime)s %(name)-6s %(levelname)-8s %(message)s'
     logger_handler.setFormatter(
         logging.Formatter(log_fmt, '%b %d %H:%M:%S'))


### PR DESCRIPTION
faucet@faucet:~/faucet$ PYTHONPATH=. FAUCET_LOG=STDOUT FAUCET_EXCEPTION_LOG=STDERR ryu-manager faucet.faucet
loading app faucet.faucet
loading app ryu.controller.ofp_handler
creating context faucet_experimental_api
instantiating app None of DPSet
creating context dpset
instantiating app faucet.faucet of Faucet
instantiating app ryu.controller.ofp_handler of OFPHandler
Nov 27 23:55:09 faucet INFO     Add new datapath DPID 260367051208429 (0xeccd6d9936ed)
Nov 27 23:55:09 faucet ERROR    features_handler: unknown datapath DPID 123917682135232 (0x70b3d56cd0c0)