### PR TITLE
When an OFError occurs, correlate with the offending XID.

### DIFF
--- a/faucet/faucet.py
+++ b/faucet/faucet.py
@@ -239,6 +239,9 @@ class Faucet(app_manager.RyuApp):
                 **valve.base_prom_labels).inc()
             flow_msg.datapath = ryu_dp
             ryu_dp.send_msg(flow_msg)
+            if valve.recent_ofmsgs.full():
+                valve.recent_ofmsgs.get()
+            valve.recent_ofmsgs.put(flow_msg)
 
     def _get_valve(self, ryu_dp, handler_name, msg=None):
         """Get Valve instance to response to an event.
@@ -447,7 +450,13 @@ class Faucet(app_manager.RyuApp):
             return
         self.metrics.of_errors.labels( # pylint: disable=no-member
             **valve.base_prom_labels).inc()
-        self.logger.error('OFError %s from %s', msg, dpid_log(dp_id))
+        error_txt = msg
+        while not valve.recent_ofmsgs.empty():
+            flow_msg = valve.recent_ofmsgs.get()
+            if msg.xid == flow_msg.xid:
+                error_txt = '%s caused by %s' % (msg, flow_msg)
+                break
+        self.logger.error('%s OFError %s', dpid_log(dp_id), error_txt)
 
     @set_ev_cls(ofp_event.EventOFPSwitchFeatures, CONFIG_DISPATCHER) # pylint: disable=no-member
     @kill_on_exception(exc_logname)

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -19,6 +19,7 @@
 
 import logging
 import time
+import queue
 
 from collections import namedtuple
 
@@ -65,6 +66,7 @@ class Valve(object):
     DEC_TTL = True
     L3 = False
     base_prom_labels = None
+    recent_ofmsgs = queue.Queue(maxsize=32)
 
     def __init__(self, dp, logname):
         self.dp = dp


### PR DESCRIPTION
Dec 03 17:03:32 faucet ERROR    DPID 1004415909 (0x3bde2ba5) OFError version=0x4,msg_type=0x1,msg_len=0x4c,xid=0xf167218c,OFPErrorMsg(code=9,data=byt
earray(b'\x04\x0e\x00H\xf1g!\x8c\x00\x00\x00\x00Z\xdc\x15\xc0\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00#\x8b\xff\xff\xff\xff\x00\x00\x0
0\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x17\x80\x00\x00\x04\x00\x00\x00\x01\x80\x00\x14\x01'),type=4) caused by version=0x4,msg_type=0xe,ms
g_len=0x48,xid=0xf167218c,OFPFlowMod(buffer_id=4294967295,command=0,cookie=1524372928,cookie_mask=0,flags=0,hard_timeout=0,idle_timeout=0,instruction
s=[],match=OFPMatch(oxm_fields={'in_port': 1, 'tcp_dst': 5001, 'ip_proto': 6}),out_group=0,out_port=0,priority=9099,table_id=0)