### PR TITLE
Add documentation of config to Conf object source files

### DIFF
--- a/faucet/acl.py
+++ b/faucet/acl.py
@@ -20,7 +20,35 @@ from faucet.conf import Conf
 
 
 class ACL(Conf):
-    """Implement FAUCET configuration for an ACL."""
+    """Contains the state for an ACL, including the configuration.
+
+ACL Config
+===========
+
+ACLs are configured under the 'acls' configuration block. The acls block
+contains a dictionary of individual acls each keyed by its name.
+
+Each acl contains a list of rules, a packet will have the first matching rule
+applied to it.
+
+Each rule is a dictionary containing the single key 'rule' with the value the
+matches and actions for the rule.
+
+The matches are key/values based on the ryu RESTFul API.
+The key 'actions' contains a dictionary with keys/values as follows:
+* allow (bool): if True allow the packet to continue through the Faucet
+    pipeline, if False drop the packet.
+* meter (str): meter to apply to the packet
+* output (dict): used to output a packet directly. details below.
+
+The output action contains a dictionary with the following elements:
+* port (int or string): the port to output the packet to
+* swap_vid (int): rewrite the vlan vid of the packet when outputting
+* failover (dict): Output with a failover port. The following elements can be
+    configured.
+    * group_id (int): the ofp group id to use for the group
+    * ports (list): a list of the ports the packet can be output through
+"""
 
     # Resolved port numbers which are mirror action destinations.
     mirror_destinations = set()

--- a/faucet/acl.py
+++ b/faucet/acl.py
@@ -23,7 +23,6 @@ class ACL(Conf):
     """Contains the state for an ACL, including the configuration.
 
 ACL Config
-===========
 
 ACLs are configured under the 'acls' configuration block. The acls block
 contains a dictionary of individual acls each keyed by its name.
@@ -36,18 +35,20 @@ matches and actions for the rule.
 
 The matches are key/values based on the ryu RESTFul API.
 The key 'actions' contains a dictionary with keys/values as follows:
-* allow (bool): if True allow the packet to continue through the Faucet
-    pipeline, if False drop the packet.
-* meter (str): meter to apply to the packet
-* output (dict): used to output a packet directly. details below.
+
+ * allow (bool): if True allow the packet to continue through the Faucet
+     pipeline, if False drop the packet.
+ * meter (str): meter to apply to the packet
+ * output (dict): used to output a packet directly. details below.
 
 The output action contains a dictionary with the following elements:
-* port (int or string): the port to output the packet to
-* swap_vid (int): rewrite the vlan vid of the packet when outputting
-* failover (dict): Output with a failover port. The following elements can be
-    configured.
-    * group_id (int): the ofp group id to use for the group
-    * ports (list): a list of the ports the packet can be output through
+
+ * port (int or string): the port to output the packet to
+ * swap_vid (int): rewrite the vlan vid of the packet when outputting
+ * failover (dict): Output with a failover port. The following elements can be
+     configured.
+     * group_id (int): the ofp group id to use for the group
+     * ports (list): a list of the ports the packet can be output through
 """
 
     # Resolved port numbers which are mirror action destinations.

--- a/faucet/dp.py
+++ b/faucet/dp.py
@@ -34,7 +34,91 @@ from faucet import valve_of
 # have a default value, and their descriptor must come
 # immediately after being set. See below for example.
 class DP(Conf):
-    """Implement FAUCET configuration for a datapath."""
+    """Stores state related to a datapath controlled by Faucet, including
+configuration.
+
+Datapath Configuration
+======================
+
+DP configuration is entered in the 'dps' configuration block. The 'dps'
+configuration contains a dictionary of configuration blocks each
+containing the configuration for one datapath. The keys can either be
+string names given to the datapath, or the OFP datapath id.
+
+The following elements can be configured for each datapath (at the
+dps/<name or dp_id>/ level of the configuration file):
+
+* dp_id (int): the OFP datapath-id of this datapath. Defaults to the
+    configuration key
+* name (string): a name to reference the datapath by. Defaults to the
+    configuration key
+* hardware (string): the hardware model of the datapath. Defaults to "Open
+    vSwitch". Other options can be seen in the documentation for valve.py
+* ignore_learn_ins (int): Ignore every approx nth packet for learning.
+    2 will ignore 1 out of 2 packets; 3 will ignore 1 out of 3 packets.  This
+    limits control plane activity when learning new hosts rapidly.  Flooding
+    will still be done by the dataplane even with a packet is ignored for
+    learning purposes. Defaults to 3.
+* drop_broadcast_source_address (bool): If True, Faucet will drop any packet
+    from a broadcast source address: Defaults to True.
+* drop_bpdu (bool): If True, Faucet will drop all STP BPDUs arriving at
+    the datapath. NB: Faucet does not handle BPDUs itself, if you disable this
+    then you either need to configure an ACL to catch BDPUs or Faucet will
+    forward them as though they were normal traffic. Defaults to True.
+* drop_spoofed_faucet_mac (bool): If True, Faucet will drop any packet
+    it receives with an ethernet source address equal to a MAC address that
+    Faucet is using. Defaults to True.
+* drop_lldp (bool): If True, Faucet will drop all LLDP traffic arriving at
+    the datapath. NB: Faucet does not handle LLDP itself, if you disable this
+    then you either need to configure an ACL to handle LLDP packets or Faucet
+    will forward them as though they were normal traffic. Defaults to True.
+* group_table (bool): If True, Faucet will use the OpenFlow Group tables to
+    flood packets. This is an experimental feature that is not fully supported
+    by all devices and may not interoperate with all features of faucet.
+    Defaults to False
+* group_table_routing (bool): If True, Faucet will use the OpenFlow Group
+    tables to combine the actions for each next hop.
+* max_hosts_per_resolve_cycle (int): Limit the number of hosts resolved per
+    cycle. Defaults to 5.
+* max_host_fib_retry_count (int): Limit the number of times Faucet will attempt
+    to resolve a next-hop's l2 address. Defaults to 10.
+* max_resolve_backoff_time (int): When resolving next hop l2 addresses, Faucet
+    will back off exponentially until it reaches this value. Defaults to 32.
+* learn_jitter (int): In order to reduce load on the controller Faucet will
+    randomly vary the timeout for learnt mac addresses by up to this number of
+    seconds. Defaults to 10.
+* learn_ban_timeout (int): When a host is rapidly moving between ports Faucet
+    will stop learning mac addresses on one of the ports for this number of
+    seconds. Defaults to 10.
+* advertise_interval (int): Interval between sending IPv6 Router
+    Advertisements. Defaults to 30.
+* proactive_learn (bool): When False directly connected hosts are added to the
+    list of targets to resolve whenever Faucet sees a packet from them (eg a
+    neighbour solicitation or for l2 learning etc.). When
+    proactive_learn is True Faucet will forward all packets to unknown IPv6
+    addresses in directly connected subnets to the controller and then attempt
+    to resolve the destination addresses. This causes more controller traffic
+    and could be a DOS vector, but causes fewer lost packets when resolving
+    addresses. Defaults to True.
+* pipeline_config_dir (str): the location of the faucet pipeline file. By
+    default it will attempt to read from FAUCET_PIPELINE_DIR environment
+    variable.
+
+Further sublevels of configuration can be configured as follows:
+* interfaces: contains the config block for Port configuration
+    (documented in port.py)
+* interface_ranges: contains the config blocks for sets of multiple interfaces.
+    The configuration entered here will be used as the defaults for these
+    interfaces. This can be overwritten by configuring those interfaces
+    directly. The format for the configuration key is a comma separated string.
+    The elements can either be the name or number of an interface or a range
+    of port numbers eg: "1-6,8,port9".
+* stack: Contains the configuration block for stacking. Stacking is an
+    experimental approach to loop prevention that is still under development.
+    This can be configured as follows:
+    * priority (int): currently setting any value for stack priority indicates
+        that this datapath should be the root for the stacking topology.
+"""
 
     acls = None
     vlans = None

--- a/faucet/dp.py
+++ b/faucet/dp.py
@@ -38,7 +38,6 @@ class DP(Conf):
 configuration.
 
 Datapath Configuration
-======================
 
 DP configuration is entered in the 'dps' configuration block. The 'dps'
 configuration contains a dictionary of configuration blocks each
@@ -48,51 +47,51 @@ string names given to the datapath, or the OFP datapath id.
 The following elements can be configured for each datapath (at the
 dps/<name or dp_id>/ level of the configuration file):
 
-* dp_id (int): the OFP datapath-id of this datapath. Defaults to the
+ * dp_id (int): the OFP datapath-id of this datapath. Defaults to the
     configuration key
-* name (string): a name to reference the datapath by. Defaults to the
+ * name (string): a name to reference the datapath by. Defaults to the
     configuration key
-* hardware (string): the hardware model of the datapath. Defaults to "Open
+ * hardware (string): the hardware model of the datapath. Defaults to "Open
     vSwitch". Other options can be seen in the documentation for valve.py
-* ignore_learn_ins (int): Ignore every approx nth packet for learning.
+ * ignore_learn_ins (int): Ignore every approx nth packet for learning.
     2 will ignore 1 out of 2 packets; 3 will ignore 1 out of 3 packets.  This
     limits control plane activity when learning new hosts rapidly.  Flooding
     will still be done by the dataplane even with a packet is ignored for
     learning purposes. Defaults to 3.
-* drop_broadcast_source_address (bool): If True, Faucet will drop any packet
+ * drop_broadcast_source_address (bool): If True, Faucet will drop any packet
     from a broadcast source address: Defaults to True.
-* drop_bpdu (bool): If True, Faucet will drop all STP BPDUs arriving at
+ * drop_bpdu (bool): If True, Faucet will drop all STP BPDUs arriving at
     the datapath. NB: Faucet does not handle BPDUs itself, if you disable this
     then you either need to configure an ACL to catch BDPUs or Faucet will
     forward them as though they were normal traffic. Defaults to True.
-* drop_spoofed_faucet_mac (bool): If True, Faucet will drop any packet
+ * drop_spoofed_faucet_mac (bool): If True, Faucet will drop any packet
     it receives with an ethernet source address equal to a MAC address that
     Faucet is using. Defaults to True.
-* drop_lldp (bool): If True, Faucet will drop all LLDP traffic arriving at
+ * drop_lldp (bool): If True, Faucet will drop all LLDP traffic arriving at
     the datapath. NB: Faucet does not handle LLDP itself, if you disable this
     then you either need to configure an ACL to handle LLDP packets or Faucet
     will forward them as though they were normal traffic. Defaults to True.
-* group_table (bool): If True, Faucet will use the OpenFlow Group tables to
+ * group_table (bool): If True, Faucet will use the OpenFlow Group tables to
     flood packets. This is an experimental feature that is not fully supported
     by all devices and may not interoperate with all features of faucet.
     Defaults to False
-* group_table_routing (bool): If True, Faucet will use the OpenFlow Group
+ * group_table_routing (bool): If True, Faucet will use the OpenFlow Group
     tables to combine the actions for each next hop.
-* max_hosts_per_resolve_cycle (int): Limit the number of hosts resolved per
+ * max_hosts_per_resolve_cycle (int): Limit the number of hosts resolved per
     cycle. Defaults to 5.
-* max_host_fib_retry_count (int): Limit the number of times Faucet will attempt
-    to resolve a next-hop's l2 address. Defaults to 10.
-* max_resolve_backoff_time (int): When resolving next hop l2 addresses, Faucet
+ * max_host_fib_retry_count (int): Limit the number of times Faucet will
+    attempt to resolve a next-hop's l2 address. Defaults to 10.
+ * max_resolve_backoff_time (int): When resolving next hop l2 addresses, Faucet
     will back off exponentially until it reaches this value. Defaults to 32.
-* learn_jitter (int): In order to reduce load on the controller Faucet will
+ * learn_jitter (int): In order to reduce load on the controller Faucet will
     randomly vary the timeout for learnt mac addresses by up to this number of
     seconds. Defaults to 10.
-* learn_ban_timeout (int): When a host is rapidly moving between ports Faucet
+ * learn_ban_timeout (int): When a host is rapidly moving between ports Faucet
     will stop learning mac addresses on one of the ports for this number of
     seconds. Defaults to 10.
-* advertise_interval (int): Interval between sending IPv6 Router
+ * advertise_interval (int): Interval between sending IPv6 Router
     Advertisements. Defaults to 30.
-* proactive_learn (bool): When False directly connected hosts are added to the
+ * proactive_learn (bool): When False directly connected hosts are added to the
     list of targets to resolve whenever Faucet sees a packet from them (eg a
     neighbour solicitation or for l2 learning etc.). When
     proactive_learn is True Faucet will forward all packets to unknown IPv6
@@ -100,22 +99,24 @@ dps/<name or dp_id>/ level of the configuration file):
     to resolve the destination addresses. This causes more controller traffic
     and could be a DOS vector, but causes fewer lost packets when resolving
     addresses. Defaults to True.
-* pipeline_config_dir (str): the location of the faucet pipeline file. By
+ * pipeline_config_dir (str): the location of the faucet pipeline file. By
     default it will attempt to read from FAUCET_PIPELINE_DIR environment
     variable.
 
 Further sublevels of configuration can be configured as follows:
-* interfaces: contains the config block for Port configuration
+
+ * interfaces: contains the config block for Port configuration
     (documented in port.py)
-* interface_ranges: contains the config blocks for sets of multiple interfaces.
-    The configuration entered here will be used as the defaults for these
-    interfaces. This can be overwritten by configuring those interfaces
+ * interface_ranges: contains the config blocks for sets of multiple
+    interfaces. The configuration entered here will be used as the defaults for
+    these interfaces. This can be overwritten by configuring those interfaces
     directly. The format for the configuration key is a comma separated string.
-    The elements can either be the name or number of an interface or a range
-    of port numbers eg: "1-6,8,port9".
-* stack: Contains the configuration block for stacking. Stacking is an
+    The elements can either be the name or number of an interface or a range of
+    port numbers eg: "1-6,8,port9".
+ * stack: Contains the configuration block for stacking. Stacking is an
     experimental approach to loop prevention that is still under development.
     This can be configured as follows:
+
     * priority (int): currently setting any value for stack priority indicates
         that this datapath should be the root for the stacking topology.
 """

--- a/faucet/port.py
+++ b/faucet/port.py
@@ -21,7 +21,60 @@ from faucet.valve_of import ignore_port
 
 
 class Port(Conf):
-    """Implement FAUCET configuration for a port."""
+    """Stores state for ports, including the configuration.
+
+Interface Configuration
+==================
+
+Interface configuration is found under the 'interfaces' configuration block
+within the config for a datapath. IE:
+/dps/<dp name or dp_id>/interfaces/<port name or ofp port number>/
+
+The defaults for groups of interfaces can be configured under:
+/dps/<dp name or dp_id>/interface-ranges/<interface range specification>
+
+<interface range specification> is a string containing a comma separated list
+of port numbers, port names or port ranges (in the form of 2 integers separated
+by a dash).
+
+The following elements can be configured for each port:
+
+* number (int): the OFP port number for this port. Defaults to the
+    configuration key.
+* name (string): a name to reference this port by. Defaults to the
+    configuration key.
+* description (str): an arbitrary description for this port.
+* enabled (bool): Allow packets to be forwarded through this port. Defaults to
+    True.
+* native_vlan (int): The vlan associated with untagged packets arriving and
+    leaving this interface.
+* tagged_vlans (list of ints): The vlans associated with tagged packets
+    arriving and leaving this interfaces.
+* acl_in (int or string): The acl that should be applied to all packets
+    arriving on this port.
+* permanent_learn (bool): When True Faucet will only learn the first MAC
+    address on this interface. All packets with an ethernet src address not
+    equal to that MAC address will be dropped.
+* unicast_flood (bool): If False unicast packets will not be flooded to this
+    port. Defaults to True.
+* mirror (str or int): Mirror all packets recieved and transmitted on this port
+    to the port specified (by name or by port number)
+* max_hosts (int): the maximum number of mac addresses that can be learnt on
+    this port. Defaults to 255
+* hairpin (bool): If True it allows packets arriving on this port to be output
+    to this port. This is necessary to allow routing between two vlans on this
+    port, or for use with a WIFI radio port. Defaults to False.
+* lacp (int): If not 0 this will enable experimental passive LACP support for
+    this port. The value supplied will be the LAG ID. Defaults to 0.
+* loop_protect (bool): Experimental loop protection. TODO: explain how this
+    works.
+
+Further configuration sublevels can be configured as follows:
+stack:
+    * dp (str or int): the name or dp_id of the dp connected to this port
+    * port (str or int): the name or port number of the port on the remote dp
+        connected to this port
+    """
 
     name = None
     number = None

--- a/faucet/port.py
+++ b/faucet/port.py
@@ -24,7 +24,6 @@ class Port(Conf):
     """Stores state for ports, including the configuration.
 
 Interface Configuration
-==================
 
 Interface configuration is found under the 'interfaces' configuration block
 within the config for a datapath. IE:
@@ -39,38 +38,40 @@ by a dash).
 
 The following elements can be configured for each port:
 
-* number (int): the OFP port number for this port. Defaults to the
+ * number (int): the OFP port number for this port. Defaults to the
     configuration key.
-* name (string): a name to reference this port by. Defaults to the
+ * name (string): a name to reference this port by. Defaults to the
     configuration key.
-* description (str): an arbitrary description for this port.
-* enabled (bool): Allow packets to be forwarded through this port. Defaults to
+ * description (str): an arbitrary description for this port.
+ * enabled (bool): Allow packets to be forwarded through this port. Defaults to
     True.
-* native_vlan (int): The vlan associated with untagged packets arriving and
+ * native_vlan (int): The vlan associated with untagged packets arriving and
     leaving this interface.
-* tagged_vlans (list of ints): The vlans associated with tagged packets
+ * tagged_vlans (list of ints): The vlans associated with tagged packets
     arriving and leaving this interfaces.
-* acl_in (int or string): The acl that should be applied to all packets
+ * acl_in (int or string): The acl that should be applied to all packets
     arriving on this port.
-* permanent_learn (bool): When True Faucet will only learn the first MAC
+ * permanent_learn (bool): When True Faucet will only learn the first MAC
     address on this interface. All packets with an ethernet src address not
     equal to that MAC address will be dropped.
-* unicast_flood (bool): If False unicast packets will not be flooded to this
+ * unicast_flood (bool): If False unicast packets will not be flooded to this
     port. Defaults to True.
-* mirror (str or int): Mirror all packets recieved and transmitted on this port
-    to the port specified (by name or by port number)
-* max_hosts (int): the maximum number of mac addresses that can be learnt on
+ * mirror (str or int): Mirror all packets recieved and transmitted on this
+    port to the port specified (by name or by port number)
+ * max_hosts (int): the maximum number of mac addresses that can be learnt on
     this port. Defaults to 255
-* hairpin (bool): If True it allows packets arriving on this port to be output
+ * hairpin (bool): If True it allows packets arriving on this port to be output
     to this port. This is necessary to allow routing between two vlans on this
     port, or for use with a WIFI radio port. Defaults to False.
-* lacp (int): If not 0 this will enable experimental passive LACP support for
+ * lacp (int): If not 0 this will enable experimental passive LACP support for
     this port. The value supplied will be the LAG ID. Defaults to 0.
-* loop_protect (bool): Experimental loop protection. TODO: explain how this
+ * loop_protect (bool): Experimental loop protection. TODO: explain how this
     works.
 
 Further configuration sublevels can be configured as follows:
-stack:
+
+ * stack:
+
     * dp (str or int): the name or dp_id of the dp connected to this port
     * port (str or int): the name or port number of the port on the remote dp
         connected to this port

--- a/faucet/vlan.py
+++ b/faucet/vlan.py
@@ -41,32 +41,32 @@ class VLAN(Conf):
     """Contains state for one VLAN, including its configuration.
 
 VLAN Config
-===========
 
 VLANs are configured under the 'vlans' configuration block. The vlans block
 contains a dictionary of individual vlans each keyed by the vid or name for
 that vlan.
 
 The following elements can be configured for each vlan, at the level
-/vlans/<vid or vlan name>/
-* name (str): a name that can be used to refer to this vlan. Defaults to the
+/vlans/<vid or vlan name>/:
+
+ * name (str): a name that can be used to refer to this vlan. Defaults to the
     configuration key.
-* vid (int): the vid for the vlan. Defaults to the configuration key.
-* acl_in (int or str): The acl that should be applied to all packets
+ * vid (int): the vid for the vlan. Defaults to the configuration key.
+ * acl_in (int or str): The acl that should be applied to all packets
     arriving on this vlan.
-* faucet_vips (list of IP address with prefix strings): The ip address for
+ * faucet_vips (list of IP address with prefix strings): The ip address for
     Faucet's interface on this vlan
-* faucet_mac (MAC address Str): The MAC address for Faucet's interface on this
+ * faucet_mac (MAC address Str): The MAC address for Faucet's interface on this
     vlan. Defaults to '0e:00:00:00:00:01'. It is recommended that if you use
     routing on this vlan you modify this field.
-* bgp_as (int): the local AS number to used when speaking BGP
-* bgp_server_addresses (list): ???
-* bgp_routerid (str): the router id to use when speaking BGP
-* bgp_neighbour_addresses (list of strings): the list of BGP neighbours
-* bgp_neighbour_as (int): the AS Number for the BGP neighbours
-* max_hosts (int): The maximum number of mac addresses that can be learnt on
+ * bgp_as (int): the local AS number to used when speaking BGP
+ * bgp_server_addresses (list): ???
+ * bgp_routerid (str): the router id to use when speaking BGP
+ * bgp_neighbour_addresses (list of strings): the list of BGP neighbours
+ * bgp_neighbour_as (int): the AS Number for the BGP neighbours
+ * max_hosts (int): The maximum number of mac addresses that can be learnt on
     this vlan. Defaults to 255.
-* unicast_flood (bool): If False packets to unknown ethernet destination MAC
+ * unicast_flood (bool): If False packets to unknown ethernet destination MAC
     addresses will be dropped rather than flooded.
 
 static routes can be configured on this vlan in the routes configuration block
@@ -74,8 +74,9 @@ static routes can be configured on this vlan in the routes configuration block
 The routes configuration block contains a list of dictionaries. Each dictionary
 contains a single key 'route' which then contains the configuration for the
 static route. The following elements should be configured:
-* ip_dst (subnet string): the destination IP subnet for this route.
-* ip_gw (ip address string): the next hop for this route
+
+ * ip_dst (subnet string): the destination IP subnet for this route.
+ * ip_gw (ip address string): the next hop for this route
 """
 
 # Note: while vlans are configured once for each datapath, there will be a

--- a/faucet/vlan.py
+++ b/faucet/vlan.py
@@ -38,7 +38,48 @@ class HostCacheEntry(object):
 
 
 class VLAN(Conf):
-    """Implement FAUCET configuration for a VLAN."""
+    """Contains state for one VLAN, including its configuration.
+
+VLAN Config
+===========
+
+VLANs are configured under the 'vlans' configuration block. The vlans block
+contains a dictionary of individual vlans each keyed by the vid or name for
+that vlan.
+
+The following elements can be configured for each vlan, at the level
+/vlans/<vid or vlan name>/
+* name (str): a name that can be used to refer to this vlan. Defaults to the
+    configuration key.
+* vid (int): the vid for the vlan. Defaults to the configuration key.
+* acl_in (int or str): The acl that should be applied to all packets
+    arriving on this vlan.
+* faucet_vips (list of IP address with prefix strings): The ip address for
+    Faucet's interface on this vlan
+* faucet_mac (MAC address Str): The MAC address for Faucet's interface on this
+    vlan. Defaults to '0e:00:00:00:00:01'. It is recommended that if you use
+    routing on this vlan you modify this field.
+* bgp_as (int): the local AS number to used when speaking BGP
+* bgp_server_addresses (list): ???
+* bgp_routerid (str): the router id to use when speaking BGP
+* bgp_neighbour_addresses (list of strings): the list of BGP neighbours
+* bgp_neighbour_as (int): the AS Number for the BGP neighbours
+* max_hosts (int): The maximum number of mac addresses that can be learnt on
+    this vlan. Defaults to 255.
+* unicast_flood (bool): If False packets to unknown ethernet destination MAC
+    addresses will be dropped rather than flooded.
+
+static routes can be configured on this vlan in the routes configuration block
+(/vlans/<vid or vlan name>/routes/)
+The routes configuration block contains a list of dictionaries. Each dictionary
+contains a single key 'route' which then contains the configuration for the
+static route. The following elements should be configured:
+* ip_dst (subnet string): the destination IP subnet for this route.
+* ip_gw (ip address string): the next hop for this route
+"""
+
+# Note: while vlans are configured once for each datapath, there will be a
+# separate vlan object created for each datapath that the vlan appears on
 
     name = None
     dp_id = None

--- a/faucet/watcher_conf.py
+++ b/faucet/watcher_conf.py
@@ -27,47 +27,53 @@ class WatcherConf(Conf):
     """Stores the state and configuration to monitor a single stat.
 
 Watcher Config
-==============
 
 Watchers are configured in the watchers config block in the config for gauge.
 
 The following elements can be configured for each watcher, at the level of
-/watchers/<watcher name>/
-* type (string): The type of watcher (IE what stat this watcher monitors). The
+/watchers/<watcher name>/:
+
+ * type (string): The type of watcher (IE what stat this watcher monitors). The
     types are 'port_state', 'port_stats' or 'flow_table'
-* dps (list): A list of dps that should be monitored with this watcher.
-* db (string): The db that will be used to store the data once it is retreived.
-* interval (int): if this watcher requires polling the switch, it will monitor
+ * dps (list): A list of dps that should be monitored with this watcher.
+ * db (string): The db that will be used to store the data once it is
+    retreived.
+ * interval (int): if this watcher requires polling the switch, it will monitor
     at this interval
 
 The config for a db should be created in the gauge config file under the dbs
 config block.
 
 The following elements can be configured for each db, at the level of
-/dbs/<db name>/
-* type (string): the type of db. The available types are 'text' and 'influx'
+/dbs/<db name>/:
+
+ * type (string): the type of db. The available types are 'text' and 'influx'
     for port_state, 'text', 'influx'and 'prometheus' for port_stats and 'text'
     and 'gaugedb' for flow_table
+
 The following config elements then depend on the type.
 For text:
-* file (string): the filename of the file to write output to.
-* compress (bool): compress (with gzip) flow_table output while writing it
+
+ * file (string): the filename of the file to write output to.
+ * compress (bool): compress (with gzip) flow_table output while writing it
+
 For influx:
-* influx_db (str): The name of the influxdb database. Defaults to 'faucet'.
-* influx_host (str): The host where the influxdb is reachable. Defaults to
+ * influx_db (str): The name of the influxdb database. Defaults to 'faucet'.
+ * influx_host (str): The host where the influxdb is reachable. Defaults to
     'localhost'.
-* influx_port (int): The port that the influxdb host will listen on. Defaults to
+ * influx_port (int): The port that the influxdb host will listen on. Defaults to
     8086.
-* influx_user (str): The username for accessing influxdb. Defaults to ''.
-* influx_pwd (str): The password for accessing influxdb. Defaults to ''.
-* influx_timeout (int): The timeout in seconds for connecting to influxdb.
+ * influx_user (str): The username for accessing influxdb. Defaults to ''.
+ * influx_pwd (str): The password for accessing influxdb. Defaults to ''.
+ * influx_timeout (int): The timeout in seconds for connecting to influxdb.
     Defaults to 10.
-* influx_retries (int): The number of times to retry connecting to influxdb after
-    failure. Defaults to 3.
-For Prometheus
-* prometheus_port (int): The port used to export prometheus data. Defaults to
+ * influx_retries (int): The number of times to retry connecting to influxdb
+    after failure. Defaults to 3.
+
+For Prometheus:
+ * prometheus_port (int): The port used to export prometheus data. Defaults to
     9303.
-* prometheus_addr (ip addr str): The address used to export prometheus data.
+ * prometheus_addr (ip addr str): The address used to export prometheus data.
     Defaults to '127.0.0.1'.
 """
 

--- a/faucet/watcher_conf.py
+++ b/faucet/watcher_conf.py
@@ -24,7 +24,52 @@ from faucet.conf import Conf
 
 
 class WatcherConf(Conf):
-    """Gauge watcher configuration."""
+    """Stores the state and configuration to monitor a single stat.
+
+Watcher Config
+==============
+
+Watchers are configured in the watchers config block in the config for gauge.
+
+The following elements can be configured for each watcher, at the level of
+/watchers/<watcher name>/
+* type (string): The type of watcher (IE what stat this watcher monitors). The
+    types are 'port_state', 'port_stats' or 'flow_table'
+* dps (list): A list of dps that should be monitored with this watcher.
+* db (string): The db that will be used to store the data once it is retreived.
+* interval (int): if this watcher requires polling the switch, it will monitor
+    at this interval
+
+The config for a db should be created in the gauge config file under the dbs
+config block.
+
+The following elements can be configured for each db, at the level of
+/dbs/<db name>/
+* type (string): the type of db. The available types are 'text' and 'influx'
+    for port_state, 'text', 'influx'and 'prometheus' for port_stats and 'text'
+    and 'gaugedb' for flow_table
+The following config elements then depend on the type.
+For text:
+* file (string): the filename of the file to write output to.
+* compress (bool): compress (with gzip) flow_table output while writing it
+For influx:
+* influx_db (str): The name of the influxdb database. Defaults to 'faucet'.
+* influx_host (str): The host where the influxdb is reachable. Defaults to
+    'localhost'.
+* influx_port (int): The port that the influxdb host will listen on. Defaults to
+    8086.
+* influx_user (str): The username for accessing influxdb. Defaults to ''.
+* influx_pwd (str): The password for accessing influxdb. Defaults to ''.
+* influx_timeout (int): The timeout in seconds for connecting to influxdb.
+    Defaults to 10.
+* influx_retries (int): The number of times to retry connecting to influxdb after
+    failure. Defaults to 3.
+For Prometheus
+* prometheus_port (int): The port used to export prometheus data. Defaults to
+    9303.
+* prometheus_addr (ip addr str): The address used to export prometheus data.
+    Defaults to '127.0.0.1'.
+"""
 
     db = None # pylint: disable=invalid-name
     dp = None # pylint: disable=invalid-name


### PR DESCRIPTION
It would be good for someone to do a basic editing check of this. Not sure how this will render with the readthedocs stuff but I figured it would be best to get it up and on git earlier rather than later.