### PR TITLE
Event socket permissions checks

### DIFF
--- a/faucet/faucet_experimental_event.py
+++ b/faucet/faucet_experimental_event.py
@@ -88,7 +88,7 @@ class FaucetExperimentalEventNotifier(object):
                 try:
                     sock.sendall(event_bytes)
                 except (socket.error, IOError) as err:
-                    self.logger.info('event client disconnected' % err)
+                    self.logger.info('event client disconnected: %s', err)
                     return
             hub.sleep(0.1)
 


### PR DESCRIPTION
Fixes #1388, we now gracefully handle the case that we don't have permissions to access to the socket directory.