### PR TITLE
Implement targeted_gw_resolution

### DIFF
--- a/faucet/valve_route.py
+++ b/faucet/valve_route.py
@@ -373,11 +373,8 @@ class ValveRouteManager(object):
                 if vlan.targeted_gw_resolution:
                     port = nexthop_cache_entry.port
                     if last_retry_time is None and port is not None:
-                        vid = None
-                        if vlan.port_is_tagged(port):
-                            vid = vlan.vid
-                        pkt = self._neighbor_resolver_pkt(vlan, vid, faucet_vip, ip_gw)
-                        resolve_flows = [valve_of.packetout(nexthop_cache_entry.port.number, pkt.data)]
+                        resolve_flows = [vlan.pkt_out_port(
+                            self._neighbor_resolver_pkt, port, faucet_vip, ip_gw)]
                 if last_retry_time is None:
                     self.logger.info(
                         'resolving %s (%u flows) on VLAN %u' % (

--- a/faucet/vlan.py
+++ b/faucet/vlan.py
@@ -100,6 +100,7 @@ class VLAN(Conf):
         'proactive_nd_limit': None,
         # Don't proactively ND for hosts if over this limit (None unlimited)
         'targeted_gw_resolution': True,
+        # If True, and a gateway has been resolved, target the first re-resolution attempt to the same port rather than flooding.
         }
 
     defaults_types = {

--- a/faucet/vlan.py
+++ b/faucet/vlan.py
@@ -99,7 +99,7 @@ class VLAN(Conf):
         # Don't proactively ARP for hosts if over this limit (None unlimited)
         'proactive_nd_limit': None,
         # Don't proactively ND for hosts if over this limit (None unlimited)
-        'targeted_gw_resolution': True,
+        'targeted_gw_resolution': False,
         # If True, and a gateway has been resolved, target the first re-resolution attempt to the same port rather than flooding.
         }
 
@@ -124,6 +124,7 @@ class VLAN(Conf):
         'vid': int,
         'proactive_arp_limit': int,
         'proactive_nd_limit': int,
+        'targeted_gw_resolution': bool,
     }
 
     def __init__(self, _id, dp_id, conf=None):

--- a/faucet/vlan.py
+++ b/faucet/vlan.py
@@ -63,6 +63,7 @@ class VLAN(Conf):
     max_hosts = None
     unicast_flood = None
     acl_in = None
+    targeted_gw_resolution = None
     proactive_arp_limit = None
     proactive_nd_limit = None
     # Define dynamic variables with prefix dyn_ to distinguish from variables set
@@ -98,6 +99,7 @@ class VLAN(Conf):
         # Don't proactively ARP for hosts if over this limit (None unlimited)
         'proactive_nd_limit': None,
         # Don't proactively ND for hosts if over this limit (None unlimited)
+        'targeted_gw_resolution': True,
         }
 
     defaults_types = {

--- a/faucet/vlan.py
+++ b/faucet/vlan.py
@@ -318,6 +318,13 @@ class VLAN(Conf):
     def untagged_flood_ports(self, exclude_unicast):
         return self.flood_ports(self.untagged, exclude_unicast)
 
+    def pkt_out_port(self, packet_builder, port, *args):
+        vid = None
+        if self.port_is_tagged(port):
+            vid = self.vid
+        pkt = packet_builder(self, vid, *args)
+        return valve_of.packetout(port.number, pkt.data)
+
     def flood_pkt(self, packet_builder, *args):
         ofmsgs = []
         for vid, ports in (

--- a/tests/faucet_mininet_test_unit.py
+++ b/tests/faucet_mininet_test_unit.py
@@ -3255,6 +3255,27 @@ vlans:
             self.swap_host_macs(first_host, second_host)
 
 
+class FaucetTaggedTargetedResolutionIPv4RouteTest(FaucetTaggedIPv4RouteTest):
+
+    CONFIG_GLOBAL = """
+vlans:
+    100:
+        description: "tagged"
+        faucet_vips: ["10.0.0.254/24"]
+        targeted_gw_resolution: True
+        routes:
+            - route:
+                ip_dst: "10.0.1.0/24"
+                ip_gw: "10.0.0.1"
+            - route:
+                ip_dst: "10.0.2.0/24"
+                ip_gw: "10.0.0.2"
+            - route:
+                ip_dst: "10.0.3.0/24"
+                ip_gw: "10.0.0.2"
+"""
+
+
 class FaucetTaggedProactiveNeighborIPv4RouteTest(FaucetTaggedTest):
 
     CONFIG_GLOBAL = """


### PR DESCRIPTION
vlans:
    100:
        faucet_vips: ["10.0.0.254/24"]
        targeted_gw_resolution: True

If a host has been resolved as a gateway successfully, on the first retry only, target the re-resolution attempt (ARP or NS) directly to the last known port. If not successful, subsequent retries will be flooded as normal.

This reduces gateway resolution workload and gateway resolution noise generally.

