### PR TITLE
Update rasp pi build script to use our new docker tag system.

### DIFF
--- a/docker/build-faucet-pi-on-pi.sh
+++ b/docker/build-faucet-pi-on-pi.sh
@@ -29,10 +29,18 @@ build_tag()
     cd ../../ && \
     $DOCKER build -t $DOCKER_ID_USER/faucet-pi:$tag -f Dockerfile.pi . && \
     $DOCKER build -t $DOCKER_ID_USER/gauge-pi:$tag -f Dockerfile.pi-gauge . && \
+    $DOCKER tag $DOCKER_ID_USER/faucet-base-pi:$tag $DOCKER_ID_USER/gauge-pi:latest && \
+    $DOCKER tag $DOCKER_ID_USER/faucet-python3-pi:$tag $DOCKER_ID_USER/gauge-pi:latest && \
+    $DOCKER tag $DOCKER_ID_USER/faucet-pi:$tag $DOCKER_ID_USER/gauge-pi:latest && \
+    $DOCKER tag $DOCKER_ID_USER/gauge-pi:$tag $DOCKER_ID_USER/gauge-pi:latest && \
     $DOCKER push $DOCKER_ID_USER/faucet-base-pi:$tag && \
     $DOCKER push $DOCKER_ID_USER/faucet-python3-pi:$tag && \
     $DOCKER push $DOCKER_ID_USER/faucet-pi:$tag && \
-    $DOCKER push $DOCKER_ID_USER/gauge-pi:$tag
+    $DOCKER push $DOCKER_ID_USER/gauge-pi:$tag && \
+    $DOCKER push $DOCKER_ID_USER/faucet-base-pi:latest && \
+    $DOCKER push $DOCKER_ID_USER/faucet-python3-pi:latest && \
+    $DOCKER push $DOCKER_ID_USER/faucet-pi:latest && \
+    $DOCKER push $DOCKER_ID_USER/gauge-pi:latest
 }
 
 # Build any tags missing from Docker Hub.
@@ -41,8 +49,6 @@ if [ "$MISSINGTAGS" != "" ] ; then
 	build_tag $tag $tag
     done
 fi
-
-build_tag latest master
 
 for s in created exited ; do
     for i in `$DOCKER ps --filter status=$s -q --no-trunc` ; do


### PR DESCRIPTION
latest will now point to latest released version of faucet rather than faucet@master on git.