### PR TITLE
Proof of concept for Faucet launcher script

### DIFF
--- a/faucet/__main__.py
+++ b/faucet/__main__.py
@@ -1,0 +1,74 @@
+"""Launch forwarder script for Faucet/Gauge"""
+
+# Copyright (C) 2015 Brad Cowie, Christopher Lorier and Joe Stringer.
+# Copyright (C) 2015 Research and Education Advanced Network New Zealand Ltd.
+# Copyright (C) 2015--2017 The Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import os
+import sys
+
+
+def parse_args():
+    """Parse Faucet/Gauge arguments.
+
+    Returns:
+        argparse.Namespace: command line arguments
+    """
+    args = argparse.ArgumentParser(
+        prog='faucet', description='Faucet SDN Controller')
+    args.add_argument(
+        '-v', '--version', action='store_true', help='print version and exit')
+    args.add_argument('--gauge', action='store_true', help='run Gauge instead')
+    args.add_argument(
+        '--ryu-app',
+        action='append',
+        help='add Ryu app (can be specified multiple times)',
+        metavar='APP')
+    return args.parse_args()
+
+
+def print_version():
+    """Print version number and exit."""
+    from pbr.version import VersionInfo
+    version = VersionInfo('faucet').semantic_version().release_string()
+    print('Faucet %s' % version)
+    sys.exit(0)
+
+
+def main():
+    """Main program."""
+    args = parse_args()
+
+    # Checking version number?
+    if args.version:
+        print_version()
+
+    # Running Faucet or Gauge?
+    ryu_args = ['faucet.faucet']
+    if args.gauge:
+        ryu_args = ['faucet.gauge']
+
+    # Check for additional Ryu apps.
+    if args.ryu_app:
+        ryu_args.extend(args.ryu_app)
+
+    # Replace current process with ryu-manager from PATH (no PID change).
+    ryu_args.insert(0, 'ryu-manager')
+    os.execvp('ryu-manager', ryu_args)
+
+
+if __name__ == '__main__':
+    main()

--- a/faucet/__main__.py
+++ b/faucet/__main__.py
@@ -44,7 +44,8 @@ def print_version():
     """Print version number and exit."""
     from pbr.version import VersionInfo
     version = VersionInfo('faucet').semantic_version().release_string()
-    print('Faucet %s' % version)
+    message = 'Faucet %s' % version
+    print(message)
     sys.exit(0)
 
 


### PR DESCRIPTION
Here is a start on a Faucet launcher script. The goal is to make Faucet slightly easier to use from the command line. Under the covers, it just runs ryu-manager.

To run faucet:  `python -m faucet`
To run gauge:  `python -m faucet --gauge`

Faucet and Gauge continue to use environment variables for configuration. Future changes could translate arguments to environment variables as needed.

```console
$ python -m faucet --help
usage: faucet [-h] [-v] [--gauge] [--ryu-app APP]

Faucet SDN Controller

optional arguments:
  -h, --help     show this help message and exit
  -v, --version  print version and exit
  --gauge        run Gauge instead
  --ryu-app APP  add Ryu app (can be specified multiple times)
```

There are several Ryu arguments that still need to be handled before this could replace ryu-manager in the integration tests:

```python
    args.add_argument('--verbose', action='store_true')
    args.add_argument('--use-stderr', action='store_true')
    args.add_argument('--wsapi-host')
    args.add_argument('--wsapi-port', type=int)
    args.add_argument('--ofp-listen-host', default='')
    args.add_argument('--ofp-tcp-listen-port', type=int, default=6653)
    args.add_argument('--ctl-privkey', type=file_contents_type)
    args.add_argument('--ctl-cert', type=file_contents_type)
    args.add_argument('--ca-certs', type=file_contents_type)
    args.add_argument('--pid-file')
    args.add_argument('--config-file')    # Ryu's private config file
```