### PR TITLE
Add output_only option to interface.

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -353,6 +353,10 @@ OFP port number ranges (eg. 1-6).
       - boolean
       - True
       - If False unicast packets will not be flooded to this port.
+    * - output_only
+      - boolean
+      - False
+      - If True, no packets will be accepted from this port.
 
 Stacking (Interfaces)
 ~~~~~~~~~~~~~~~~~~~~~

--- a/faucet/dp.py
+++ b/faucet/dp.py
@@ -55,6 +55,7 @@ configuration.
     high_priority = None
     stack = None
     stack_ports = None
+    output_only_ports = None
     ignore_learn_ins = None
     drop_broadcast_source_address = None
     drop_spoofed_faucet_mac = None
@@ -196,6 +197,7 @@ configuration.
         self.ports = {}
         self.routers = {}
         self.stack_ports = []
+        self.output_only_ports = []
 
     def __str__(self):
         return self.name
@@ -275,10 +277,9 @@ configuration.
         """Add a port to this DP."""
         port_num = port.number
         self.ports[port_num] = port
-        if port.mirror is not None:
-            # other configuration entries ignored
-            return
-        if port.stack is not None:
+        if port.output_only:
+            self.output_only_ports.append(port)
+        elif port.stack is not None:
             self.stack_ports.append(port)
 
     def add_vlan(self, vlan):

--- a/faucet/dp.py
+++ b/faucet/dp.py
@@ -431,11 +431,12 @@ configuration.
                     if port.mirror in port_by_name:
                         mirror_from_port[port] = port_by_name[port.mirror]
                     else:
-                        assert port.mirror in self.ports, 'could not find port %s in %s' % (port.mirror, self.name)
+                        assert port.mirror in self.ports, 'could not find port %s in %s' % (
+                            port.mirror, self.name)
                         mirror_from_port[self.ports[port.mirror]] = port
             for port, mirror_destination_port in list(mirror_from_port.items()):
                 port.mirror = mirror_destination_port.number
-                mirror_destination_port.mirror_destination = True
+                mirror_destination_port.output_only = True
 
         def resolve_acls():
             """Resolve config references in ACLs."""
@@ -512,7 +513,7 @@ configuration.
                         raise InvalidConfigError(err)
                     for port_no in acl.mirror_destinations:
                         port = self.ports[port_no]
-                        port.mirror_destination = True
+                        port.output_only = True
 
             def resolve_acl(conf):
                 assert conf.acl_in in self.acls, (

--- a/faucet/port.py
+++ b/faucet/port.py
@@ -116,7 +116,7 @@ class Port(Conf):
             'Port number invalid: %s' % self.number)
 
     def finalize(self):
-        assert self.vlans() or self.stack, '%s must have a VLAN or be a stack port' % self
+        assert self.vlans() or self.stack or self.output_only, '%s must have a VLAN, be a stack port, or have output_only: True' % self
         assert not (self.vlans() and self.stack), '%s cannot have stack and VLANs on same port' % self
         super(Port, self).finalize()
 

--- a/faucet/port.py
+++ b/faucet/port.py
@@ -30,7 +30,6 @@ class Port(Conf):
     permanent_learn = None
     unicast_flood = None
     mirror = None
-    mirror_destination = None
     native_vlan = None
     tagged_vlans = []
     acl_in = None
@@ -44,6 +43,7 @@ class Port(Conf):
     dyn_lacp_up = None
     dyn_lacp_updated_time = None
     dyn_last_ban_time = None
+    output_only = None
 
     defaults = {
         'number': None,
@@ -55,7 +55,6 @@ class Port(Conf):
         'unicast_flood': True,
         # if True, do classical unicast flooding on this port (False floods ND/ARP/bcast only).
         'mirror': None,
-        'mirror_destination': False,
         'native_vlan': None,
         # Set untagged VLAN on this port.
         'tagged_vlans': None,
@@ -72,6 +71,8 @@ class Port(Conf):
         # if non 0 (LAG ID), experimental LACP support enabled on this port.
         'loop_protect': False,
         # if True, do simple loop protection on this port.
+        'output_only': False,
+        # if True, all packets input from this port are dropped.
     }
 
     defaults_types = {
@@ -82,7 +83,6 @@ class Port(Conf):
         'permanent_learn': bool,
         'unicast_flood': bool,
         'mirror': (str, int),
-        'mirror_destination': bool,
         'native_vlan': (str, int),
         'tagged_vlans': list,
         'acl_in': (str, int),

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -280,17 +280,17 @@ class Valve(object):
         ofmsgs = []
         all_port_nums = set(discovered_port_nums)
 
-        # add stack ports
         for port in self.dp.stack_ports:
+            all_port_nums.add(port.number)
+
+        for port in self.dp.output_only_ports:
             all_port_nums.add(port.number)
 
         # add vlan ports
         for vlan in list(self.dp.vlans.values()):
-            for port in vlan.get_ports():
-                all_port_nums.add(port.number)
-            for port in vlan.output_only_ports():
-                all_port_nums.add(port.number)
             if vlan.get_ports():
+                for port in vlan.get_ports():
+                    all_port_nums.add(port.number)
                 ofmsgs.extend(self._add_vlan(vlan))
             vlan.reset_host_cache()
 

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -288,7 +288,7 @@ class Valve(object):
         for vlan in list(self.dp.vlans.values()):
             for port in vlan.get_ports():
                 all_port_nums.add(port.number)
-            for port in vlan.mirror_destination_ports():
+            for port in vlan.output_only_ports():
                 all_port_nums.add(port.number)
             if vlan.get_ports():
                 ofmsgs.extend(self._add_vlan(vlan))
@@ -472,8 +472,7 @@ class Valve(object):
             if not port.running():
                 continue
 
-            # Port is a mirror destination; drop all input packets
-            if port.mirror_destination:
+            if port.output_only:
                 ofmsgs.append(vlan_table.flowdrop(
                     match=vlan_table.match(in_port=port_num),
                     priority=self.dp.highest_priority))
@@ -542,17 +541,13 @@ class Valve(object):
             port.dyn_phys_up = False
             self.logger.info('%s down' % port)
 
-            # TODO: when mirroring an entire port, we install flows
-            # in eth_dst output a copy to the mirror port. If the mirror
-            # port goes down then those flows will be deleted stopping
-            # forwarding for that host. They are garbage collected by
-            # hard timeout anyway, but it would be good to "relearn them".
-            if port.lacp:
-                ofmsgs.extend(self.lacp_down(port))
-            elif not port.mirror_destination:
-                ofmsgs.extend(self._port_delete_flows_state(port))
-            for vlan in port.vlans():
-                vlans_with_deleted_ports.add(vlan)
+            if not port.output_only:
+                if port.lacp:
+                    ofmsgs.extend(self.lacp_down(port))
+                else:
+                    ofmsgs.extend(self._port_delete_flows_state(port))
+                for vlan in port.vlans():
+                    vlans_with_deleted_ports.add(vlan)
 
         for vlan in vlans_with_deleted_ports:
             ofmsgs.extend(self.flood_manager.build_flood_rules(

--- a/faucet/vlan.py
+++ b/faucet/vlan.py
@@ -300,9 +300,9 @@ class VLAN(Conf):
         """Return list of ports that are mirrored on this VLAN."""
         return [port for port in self.get_ports() if port.mirror]
 
-    def mirror_destination_ports(self):
-        """Return list of ports that are mirrored to, on this VLAN."""
-        return [port for port in self.get_ports() if port.mirror_destination]
+    def output_only_ports(self):
+        """Return list of ports that are output only on this VLAN."""
+        return [port for port in self.get_ports() if port.output_only]
 
     def lags(self):
         """Return dict of LAGs mapped to member ports."""

--- a/faucet/vlan.py
+++ b/faucet/vlan.py
@@ -300,10 +300,6 @@ class VLAN(Conf):
         """Return list of ports that are mirrored on this VLAN."""
         return [port for port in self.get_ports() if port.mirror]
 
-    def output_only_ports(self):
-        """Return list of ports that are output only on this VLAN."""
-        return [port for port in self.get_ports() if port.output_only]
-
     def lags(self):
         """Return dict of LAGs mapped to member ports."""
         lacp_ports = [port for port in self.get_ports() if port.lacp]

--- a/tests/faucet_mininet_test_base.py
+++ b/tests/faucet_mininet_test_base.py
@@ -738,8 +738,12 @@ dbs:
                         if flow_dict['hard_timeout'] < hard_timeout:
                             continue
                     if actions is not None:
-                        if not set(actions).issubset(set(flow_dict['actions'])):
-                            continue
+                        if actions:
+                            if not set(actions).issubset(set(flow_dict['actions'])):
+                                continue
+                        else:
+                            if flow_dict['actions']:
+                                continue
                     if match is not None:
                         if match_exact:
                             if match.items() != flow_dict['match'].items():

--- a/tests/faucet_mininet_test_unit.py
+++ b/tests/faucet_mininet_test_unit.py
@@ -2679,6 +2679,31 @@ class FaucetZodiacUntaggedACLTest(FaucetUntaggedACLTest):
         self.ping_all_when_learned()
 
 
+class FaucetUntaggedOutputOnlyTest(FaucetUntaggedTest):
+
+    CONFIG = """
+        interfaces:
+            %(port_1)d:
+                output_only: True
+                description: "b1"
+            %(port_2)d:
+                native_vlan: 100
+                description: "b2"
+            %(port_3)d:
+                number: %(port_3)d
+                native_vlan: 100
+                description: "b3"
+            %(port_4)d:
+                native_vlan: 100
+                description: "b4"
+"""
+
+    def test_untagged(self):
+        first_host, second_host, third_host = self.net.hosts[:3]
+        self.assertEqual(100.0, self.net.ping((first_host, second_host)))
+        self.assertEqual(0, self.net.ping((third_host, second_host)))
+
+
 class FaucetUntaggedACLMirrorTest(FaucetUntaggedTest):
 
     CONFIG_GLOBAL = """

--- a/tests/faucet_mininet_test_unit.py
+++ b/tests/faucet_mininet_test_unit.py
@@ -2699,6 +2699,10 @@ class FaucetUntaggedOutputOnlyTest(FaucetUntaggedTest):
 """
 
     def test_untagged(self):
+        self.wait_until_matching_flow(
+            {u'in_port': int(self.port_map['port_1'])},
+            table_id=self.VLAN_TABLE,
+            actions=[])
         first_host, second_host, third_host = self.net.hosts[:3]
         self.assertEqual(100.0, self.net.ping((first_host, second_host)))
         self.assertEqual(0, self.net.ping((third_host, second_host)))


### PR DESCRIPTION
Configuring output_only: True on an interface, adds an explicit drop rule for all packets from that interface (for accounting).

ACLs/mirror to a port,  implicitly enable output_only: True on that port.

