### PR TITLE
valve_flowreorder should take meter_mod messages into consideration

### DIFF
--- a/faucet/valve_of.py
+++ b/faucet/valve_of.py
@@ -72,6 +72,17 @@ def is_groupmod(ofmsg):
     return isinstance(ofmsg, parser.OFPGroupMod)
 
 
+def is_metermod(ofmsg):
+    """Return True if OF message is a MeterMod.
+
+    Args:
+        ofmsg: ryu.ofproto.ofproto_v1_3_parser message.
+    Returns:
+        bool: True if is a MeterMod
+    """
+    return isinstance(ofmsg, parser.OFPMeterMod)
+
+
 def is_flowdel(ofmsg):
     """Return True if flow message is a FlowMod and a delete.
 
@@ -97,6 +108,20 @@ def is_groupdel(ofmsg):
     """
     if (is_groupmod(ofmsg) and
             (ofmsg.command == ofp.OFPGC_DELETE)):
+        return True
+    return False
+
+
+def is_meterdel(ofmsg):
+    """Return True if OF message is a MeterMod and command is delete.
+
+    Args:
+        ofmsg: ryu.ofproto.ofproto_v1_3_parser message.
+    Returns:
+        bool: True if is a MeterMod delete
+    """
+    if (is_metermod(ofmsg) and
+            (ofmsg.command == ofp.OFPMC_DELETE)):
         return True
     return False
 
@@ -558,7 +583,7 @@ def valve_flowreorder(input_ofmsgs):
     groupadd_ofmsgs = []
     nondelete_ofmsgs = []
     for ofmsg in input_ofmsgs:
-        if is_flowdel(ofmsg) or is_groupdel(ofmsg):
+        if is_flowdel(ofmsg) or is_groupdel(ofmsg) or is_meterdel(ofmsg):
             delete_ofmsgs.append(ofmsg)
         elif is_groupadd(ofmsg):
             # The same group_id may be deleted/added multiple times


### PR DESCRIPTION
`valve_flowreorder()` already reorganises the list of messages that must be sent to the switch to send them in the following order:
1. flow_mod delete, group_mod delete
2. barrier
3. group_mod add
4. barrier
5. everything else

This doesn't take into consideration meters, which should be treated similarly to groups:
1. flow_mod delete, group_mod delete, meter_mod delete
2. barrier
3. group_mod add, meter_mod add
4. barrier
5. everything else