### PR TITLE
Implement trivial LLDP beacon service (and fix for ACL description in rules).

### DIFF
--- a/faucet/dp.py
+++ b/faucet/dp.py
@@ -195,6 +195,7 @@ configuration.
 
     lldp_beacon_defaults_types = {
         'send_interval': int,
+        'max_per_interval': int,
     }
 
     wildcard_table = ValveTable(
@@ -204,16 +205,13 @@ configuration.
     def __init__(self, _id, dp_id, conf):
         """Constructs a new DP object"""
         super(DP, self).__init__(_id, dp_id, conf)
-        if self.lldp_beacon:
-            self._check_conf_types(self.lldp_beacon, self.lldp_beacon_defaults_types)
-        if self.stack:
-            self._check_conf_types(self.stack, self.stack_defaults_types)
         self.acls = {}
         self.vlans = {}
         self.ports = {}
         self.routers = {}
         self.stack_ports = []
         self.output_only_ports = []
+        self.lldp_beacon_ports = []
 
     def __str__(self):
         return self.name
@@ -227,6 +225,10 @@ configuration.
             'DP %s must have at least one interface' % self)
         # To prevent L2 learning from timing out before L3 can refresh
         assert self.timeout >= self.arp_neighbor_timeout, 'L2 timeout must be >= L3 timeout'
+        if self.lldp_beacon:
+            self._check_conf_types(self.lldp_beacon, self.lldp_beacon_defaults_types)
+        if self.stack:
+            self._check_conf_types(self.stack, self.stack_defaults_types)
 
     def _configure_tables(self):
         """Configure FAUCET pipeline of tables with matches."""
@@ -297,6 +299,8 @@ configuration.
             self.output_only_ports.append(port)
         elif port.stack is not None:
             self.stack_ports.append(port)
+        if port.lldp_beacon_enabled():
+            self.lldp_beacon_ports.append(port)
 
     def resolve_stack_topology(self, dps):
         """Resolve inter-DP config for stacking."""

--- a/faucet/dp.py
+++ b/faucet/dp.py
@@ -227,6 +227,8 @@ configuration.
         assert self.timeout >= self.arp_neighbor_timeout, 'L2 timeout must be >= L3 timeout'
         if self.lldp_beacon:
             self._check_conf_types(self.lldp_beacon, self.lldp_beacon_defaults_types)
+            assert len(self.lldp_beacon) == len(self.lldp_beacon_defaults_types), (
+                'all lldp_beacon config (%s) must be specified' % self.lldp_beacon_defaults_types.keys())
         if self.stack:
             self._check_conf_types(self.stack, self.stack_defaults_types)
 

--- a/faucet/dp.py
+++ b/faucet/dp.py
@@ -79,6 +79,7 @@ configuration.
     meters = {}
     timeout = None
     arp_neighbor_timeout = None
+    lldp_beacon = {}
 
     # Values that are set to None will be set using set_defaults
     # they are included here for testing and informational purposes

--- a/faucet/port.py
+++ b/faucet/port.py
@@ -156,11 +156,10 @@ class Port(Conf):
     def to_conf(self):
         result = super(Port, self).to_conf()
         if 'stack' in result and result['stack'] is not None:
-            if 'dp' in self.stack and 'port' in self.stack:
-                result['stack'] = {
-                    'dp': str(self.stack['dp']),
-                    'port': str(self.stack['port'])
-                }
+            result['stack'] = {
+                'dp': str(self.stack['dp']),
+                'port': str(self.stack['port'])
+            }
         return result
 
     def vlans(self):
@@ -180,4 +179,4 @@ class Port(Conf):
 
     def lldp_beacon_enabled(self):
         """Return True if LLDP beacon enabled on this port."""
-        return self.lldp_beacon and self.lldp_beacon.get('enabled', False)
+        return self.lldp_beacon and self.lldp_beacon.get('enable', False)

--- a/faucet/port.py
+++ b/faucet/port.py
@@ -73,6 +73,8 @@ class Port(Conf):
         # if True, do simple loop protection on this port.
         'output_only': False,
         # if True, all packets input from this port are dropped.
+        'lldp_beacon_enable': False,
+        # if True, LLDP beacon service is enabled on this port.
     }
 
     defaults_types = {
@@ -92,10 +94,20 @@ class Port(Conf):
         'lacp': int,
         'loop_protect': bool,
         'output_only': bool,
+        'lldp_beacon_enable': bool,
+    }
+
+    stack_defaults_types = {
+        'dp': str,
+        'port': (str, int),
     }
 
     def __init__(self, _id, dp_id, conf=None):
         super(Port, self).__init__(_id, dp_id, conf)
+        if self.stack:
+            self._check_conf_types(self.stack, self.stack_defaults_types)
+            for stack_config in list(self.stack_defaults_types.keys()):
+                assert stack_config in self.stack, 'stack %s must be defined' % stack_config
         self.dyn_phys_up = False
 
     def __str__(self):

--- a/faucet/port.py
+++ b/faucet/port.py
@@ -156,10 +156,9 @@ class Port(Conf):
     def to_conf(self):
         result = super(Port, self).to_conf()
         if 'stack' in result and result['stack'] is not None:
-            result['stack'] = {
-                'dp': str(self.stack['dp']),
-                'port': str(self.stack['port'])
-            }
+            result['stack'] = {}
+            for stack_config in list(self.stack_defaults_types.keys()):
+                result['stack'][stack_config] = self.stack[stack_config]
         return result
 
     def vlans(self):

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -342,6 +342,13 @@ class Valve(object):
         return ofmsgs
 
     def send_lldp_beacons(self):
+        """Called periodically to send LLDP beacon packets."""
+        # TODO: the beacon service should be able to send configurable TLVs.
+        # TODO: the beacon service is specifically NOT to discover topology.
+        # It is intended to facilitate physical troubleshooting (e.g.
+        # a standard cable tester can display OF port information)
+        # A seperate system will be used to probe link/neighbor activity,
+        # addressing issues such as authenticity of the probes.
         ofmsgs = []
         if self.dp.lldp_beacon_ports:
             now = time.time()

--- a/faucet/valve_acl.py
+++ b/faucet/valve_acl.py
@@ -100,6 +100,8 @@ def build_acl_entry(rule_conf, acl_allow_inst, meters, port_num=None, vlan_vid=N
         if attrib == 'cookie':
             acl_cookie = attrib_value
             continue
+        if attrib == 'description':
+            continue
         if attrib == 'actions':
             allow = False
             allow_specified = False

--- a/tests/faucet_mininet_test_unit.py
+++ b/tests/faucet_mininet_test_unit.py
@@ -1401,6 +1401,7 @@ vlans:
 acls:
     1:
         - rule:
+            description: "rule 1"
             cookie: 1234
             dl_type: 0x800
             ip_proto: 6


### PR DESCRIPTION
Send basic LLDP beacon on configured ports. Intended to send custom TLVs (such as voice VLANs). 
Not a topology discovery or verification service.
dp:
        lldp_beacon:
            send_interval: 5
            max_per_interval: 5
        interfaces:
            1:
                native_vlan: 100
                lldp_beacon:
                    enable: True
