### PR TITLE
LLDP beacon service can configure arbitrary org-specific TLVs

### DIFF
--- a/faucet/dp.py
+++ b/faucet/dp.py
@@ -228,7 +228,7 @@ configuration.
         if self.lldp_beacon:
             self._check_conf_types(self.lldp_beacon, self.lldp_beacon_defaults_types)
             assert len(self.lldp_beacon) == len(self.lldp_beacon_defaults_types), (
-                'all lldp_beacon config (%s) must be specified' % self.lldp_beacon_defaults_types.keys())
+                'all lldp_beacon config (%s) must be specified' % list(self.lldp_beacon_defaults_types.keys()))
         if self.stack:
             self._check_conf_types(self.stack, self.stack_defaults_types)
 

--- a/faucet/port.py
+++ b/faucet/port.py
@@ -38,7 +38,7 @@ class Port(Conf):
     hairpin = None
     loop_protect = None
     output_only = None
-    lldp_beacon = None
+    lldp_beacon = {}
 
     dyn_learn_ban_count = 0
     dyn_phys_up = False

--- a/faucet/port.py
+++ b/faucet/port.py
@@ -107,6 +107,13 @@ class Port(Conf):
 
     lldp_beacon_defaults_types = {
         'enable': bool,
+        'org_tlvs': list,
+    }
+
+    lldp_org_tlv_defaults_types = {
+        'oui': int,
+        'subtype': int,
+        'info': str,
     }
 
     def __init__(self, _id, dp_id, conf=None):
@@ -136,8 +143,20 @@ class Port(Conf):
                 assert stack_config in self.stack, 'stack %s must be defined' % stack_config
         if self.lldp_beacon:
             self._check_conf_types(self.lldp_beacon, self.lldp_beacon_defaults_types)
-            if self.lldp_beacon_enabled:
+            if self.lldp_beacon_enabled():
                 assert self.native_vlan, 'native_vlan must be defined for LLDP beacon'
+                org_tlvs = []
+                for org_tlv in self.lldp_beacon['org_tlvs']:
+                    self._check_conf_types(org_tlv, self.lldp_org_tlv_defaults_types)
+                    assert len(org_tlv) == len(self.lldp_org_tlv_defaults_types), (
+                        'missing org_tlv config')
+                    try:
+                        org_tlv['info'] = bytearray.fromhex(org_tlv['info'])
+                    except ValueError:
+                        assert False, 'org_tlv info not hex string: %s' % org_tlv['info']
+                    org_tlv['oui'] = bytearray.fromhex('%6.6x' % org_tlv['oui'])
+                    org_tlvs.append(org_tlv)
+                self.lldp_beacon['org_tlvs'] = org_tlvs
 
     def finalize(self):
         assert self.vlans() or self.stack or self.output_only, (

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -359,11 +359,14 @@ class Valve(object):
                 if (port.dyn_last_lldp_beacon_time is None or
                         port.dyn_last_lldp_beacon_time < cutoff_beacon_time):
                     chassis_id = str(port.native_vlan.faucet_mac)
+                    org_tlvs = []
+                    for org_tlv in port.lldp_beacon['org_tlvs']:
+                        org_tlvs.append(
+                            (org_tlv['oui'], org_tlv['subtype'], org_tlv['info']))
                     lldp_beacon_pkt = valve_packet.lldp_beacon(
                         port.native_vlan.faucet_mac,
-                        chassis_id,
-                        str(port.number).encode('utf-8'),
-                        ttl)
+                        chassis_id, port.number, ttl,
+                        org_tlvs=org_tlvs)
                     ofmsgs.append(
                         valve_of.packetout(
                             port.number, lldp_beacon_pkt.data))

--- a/tests/faucet_mininet_test_unit.py
+++ b/tests/faucet_mininet_test_unit.py
@@ -180,6 +180,8 @@ class FaucetUntaggedLLDPTest(FaucetUntaggedTest):
                 description: "b1"
                 lldp_beacon:
                     enable: True
+                    org_tlvs:
+                        - {oui: 0x12bb, subtype: 2, info: "01406500"}
             %(port_2)d:
                 native_vlan: 100
                 description: "b2"
@@ -203,6 +205,10 @@ class FaucetUntaggedLLDPTest(FaucetUntaggedTest):
         self.assertTrue(
             re.search(lldp_required, tcpdump_txt),
             msg='%s: %s' % (lldp_required, tcpdump_txt))
+        voice_vlan_required = r'Application type \[voice\] \(0x01\), Flags \[Tagged\]Vlan id 50'
+        self.assertTrue(
+            re.search(voice_vlan_required, tcpdump_txt),
+            msg='%s: %s' % (voice_vlan_required, tcpdump_txt))
 
 
 class FaucetUntaggedMeterParseTest(FaucetUntaggedTest):


### PR DESCRIPTION
        interfaces:
            1:
                native_vlan: 100
                lldp_beacon:
                    enable: True
                    org_tlvs:
                        - {oui: 0x12bb, subtype: 2, info: "01406500"}

for example, encodes voice tagged VLAN 50.