### PR TITLE
Implement port level opstatus_reconf option.

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -323,8 +323,8 @@ OFP port number ranges (eg. 1-6).
     * - mirror
       - integer or string
       - None
-      - Mirror all packets recieved and transmitted on this port to the port
-        specified (by name or by port number)
+      - Mirror all packets recieved and transmitted on the port
+        specified (by name or by port number), to this port.
     * - name
       - string
       - The configuration key.
@@ -361,6 +361,11 @@ OFP port number ranges (eg. 1-6).
       - boolean
       - False
       - If True, no packets will be accepted from this port.
+    * - opstatus_reconf
+      - boolean
+      - True
+      - If True, FAUCET will reconfigure the pipeline based on operational status of the port.
+
 
 Stacking (Interfaces)
 ~~~~~~~~~~~~~~~~~~~~~

--- a/faucet/port.py
+++ b/faucet/port.py
@@ -39,6 +39,7 @@ class Port(Conf):
     loop_protect = None
     output_only = None
     lldp_beacon = {} # type: dict
+    op_status_reconf = None
 
     dyn_learn_ban_count = 0
     dyn_phys_up = False
@@ -78,6 +79,8 @@ class Port(Conf):
         # if True, all packets input from this port are dropped.
         'lldp_beacon': {},
         # LLDP beacon configuration for this port.
+        'opstatus_reconf': True,
+        # If True, configure pipeline if operational status of port changes.
     }
 
     defaults_types = {
@@ -98,6 +101,7 @@ class Port(Conf):
         'loop_protect': bool,
         'output_only': bool,
         'lldp_beacon': dict,
+        'opstatus_reconf': bool,
     }
 
     stack_defaults_types = {

--- a/tests/faucet_mininet_test_base.py
+++ b/tests/faucet_mininet_test_base.py
@@ -709,6 +709,8 @@ dbs:
             old_matches = {
                 'tcp_dst': 'tp_dst',
                 'ip_proto': 'nw_proto',
+                'eth_dst': 'dl_dst',
+                'eth_type': 'dl_type',
             }
             if match is not None:
                 for new_match, old_match in list(old_matches.items()):


### PR DESCRIPTION
At a port level, you can now say:

interfaces:
  1:
    description: "static port"
    opstatus_reconf: False

This causes FAUCET to ignore the operational status of a port (meaning all flows relevant to this port will be left in place, even if the switch notifies that the port is down).

This is useful, for example to minimize flow changes for low performance OFAs, or to maintain ACL counters.