### PR TITLE
avoid hardcoded port in FaucetDeleteConfigReloadTest

### DIFF
--- a/tests/faucet_mininet_test_unit.py
+++ b/tests/faucet_mininet_test_unit.py
@@ -1613,7 +1613,7 @@ class FaucetDeleteConfigReloadTest(FaucetConfigReloadTestBase):
         conf = self._get_conf()
         del conf['dps'][self.DP_NAME]['interfaces']
         conf['dps'][self.DP_NAME]['interfaces'] = {
-            99: {
+            int(self.port_map['port_1']): {
                 'native_vlan': '100',
                 'tagged_vlans': ['200'],
             }


### PR DESCRIPTION
`FaucetDeleteConfigReloadTest` uses port 99 in the configuration file, which causes NoviFlow switches to complain about a BAD_MATCH / BAD_VALUE since this port doesn't exist.     
Would the test achieve its goal if one of the ports of `hw_switch_config.yaml` is used instead?   
I tried running it on OVS and it passes with this change, but I don't know if we actually need to use a different port.