### PR TITLE
Noviflow docs update for faucet v1.6.18

### DIFF
--- a/docs/vendors/noviflow/README_noviflow.rst
+++ b/docs/vendors/noviflow/README_noviflow.rst
@@ -23,27 +23,37 @@ In this example, the server running FAUCET is 10.0.1.8; configuration for CPN in
 
 .. code-block:: none
 
-  set config controller controllergroup 1 controllerid 1 priority 1 ipaddr 10.0.1.8 port 6653 security none
+  set config controller controllergroup faucet controllerid 1 priority 1 ipaddr 10.0.1.8 port 6653 security none
+  set config controller controllergroup gauge controllerid 1 priority 1 ipaddr 10.0.1.8 port 6654 security none
   set config switch dpid 0x1
 
 Configure the tables
 ^^^^^^^^^^^^^^^^^^^^
 
-  These matches are known to pass the unit tests as of FAUCET 1.6.4, but take care to adjust
-  ACL table matches and any changes for future versions.
+These matches are known to pass the unit tests as of FAUCET 1.6.18, but take care to adjust
+ACL tables matches based on the type of ACL rules defined in the configuration file.
+Different FAUCET releases may also use different match fields in the other tables.
 
 .. code-block:: none
 
-   set config pipeline tablesizes 1024 1024 1024 1024 1024 1024 1024 1024 1024 tablewidths 80 40 40 40 40 40 40 40 40
-   set config table tableid 0 matchfields 0 3 4 5 6 10 14 23 29 31
+   set config pipeline tablesizes 1524 1024 1024 1024 1024 1024 1024 1024 1024 tablewidths 80 40 40 40 40 40 40 40 40
+   set config table tableid 0 matchfields 0 3 4 5 6 10 11 12 13 14 23 29 31
    set config table tableid 1 matchfields 0 3 4 5 6
    set config table tableid 2 matchfields 0 5 6 10 11 12 14
-   set config table tableid 3 matchfields 0 3 4 5 6 10 29
+   set config table tableid 3 matchfields 0 3 4 5 6 10
    set config table tableid 4 matchfields 5 6 12
    set config table tableid 5 matchfields 5 6 27
-   set config table tableid 6 matchfields 3 5 10 23
+   set config table tableid 6 matchfields 3 5 10 23 29
    set config table tableid 7 matchfields 0 3 6
    set config table tableid 8 matchfields 0 3 6
+
+Note that this table configuration will allow most of the automated test cases to pass, except FaucetIPv6TupleTest
+(which requires IPv6 Src and Dst matching in the ACL table). In order to run this test, table 0 must be
+configured as follows:
+
+.. code-block:: none
+
+  set config table tableid 0 matchfields 0 5 6 10 26 27 13 14
 
 Create faucet.yaml
 ^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
A couple of minor changes to configure the table match fields in NoviFlow switches for the automated test cases:
- icmpv6 match moved to table 6 instead of 3
- add match fields for FaucetIPv6TupleTest 