### PR TITLE
Provide sensible defaults for system_name and port_descr LLDP TLVs

### DIFF
--- a/faucet/conf.py
+++ b/faucet/conf.py
@@ -64,9 +64,12 @@ class Conf(object):
                     conf_key, conf_value, conf_type, type(conf_value))
 
     def _set_unknown_conf(self, conf, conf_types):
-        for conf_key in list(conf_types.keys()):
+        for conf_key, conf_type in list(conf_types.items()):
             if conf_key not in conf:
-                conf[conf_key] = None
+                if conf_type == list:
+                    conf[conf_key] = []
+                else:
+                    conf[conf_key] = None
         return conf
 
     def update(self, conf):

--- a/faucet/dp.py
+++ b/faucet/dp.py
@@ -196,6 +196,7 @@ configuration.
     lldp_beacon_defaults_types = {
         'send_interval': int,
         'max_per_interval': int,
+        'system_name': str,
     }
 
     wildcard_table = ValveTable(
@@ -227,8 +228,14 @@ configuration.
         assert self.timeout >= self.arp_neighbor_timeout, 'L2 timeout must be >= L3 timeout'
         if self.lldp_beacon:
             self._check_conf_types(self.lldp_beacon, self.lldp_beacon_defaults_types)
-            assert len(self.lldp_beacon) == len(self.lldp_beacon_defaults_types), (
-                'all lldp_beacon config (%s) must be specified' % list(self.lldp_beacon_defaults_types.keys()))
+            assert 'send_interval' in self.lldp_beacon, (
+                'lldp_beacon send_interval not set')
+            assert 'max_per_interval' in self.lldp_beacon, (
+                'lldp_beacon max_per_interval not set')
+            self.lldp_beacon = self._set_unknown_conf(
+                self.lldp_beacon, self.lldp_beacon_defaults_types)
+            if self.lldp_beacon['system_name'] is None:
+                self.lldp_beacon['system_name'] = self.name
         if self.stack:
             self._check_conf_types(self.stack, self.stack_defaults_types)
 

--- a/faucet/port.py
+++ b/faucet/port.py
@@ -26,6 +26,7 @@ class Port(Conf):
     name = None
     number = None
     dp_id = None
+    description = None
     enabled = None
     permanent_learn = None
     unicast_flood = None
@@ -157,6 +158,9 @@ class Port(Conf):
                 self.lldp_beacon, self.lldp_beacon_defaults_types)
             if self.lldp_beacon_enabled():
                 assert self.native_vlan, 'native_vlan must be defined for LLDP beacon'
+                if self.lldp_beacon['port_descr'] is None:
+                    self.lldp_beacon['port_descr'] = self.description
+
                 org_tlvs = []
                 for org_tlv in self.lldp_beacon['org_tlvs']:
                     self._check_conf_types(org_tlv, self.lldp_org_tlv_defaults_types)

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -366,6 +366,11 @@ class Valve(object):
                     for org_tlv in lldp_beacon['org_tlvs']:
                         org_tlvs.append(
                             (org_tlv['oui'], org_tlv['subtype'], org_tlv['info']))
+                    # if the port doesn't have a system name set, default to
+                    # using the system name from the dp
+                    if lldp_beacon['system_name'] is None:
+                        lldp_beacon['system_name'] = self.dp.lldp_beacon['system_name']
+
                     lldp_beacon_pkt = valve_packet.lldp_beacon(
                         port.native_vlan.faucet_mac,
                         chassis_id, port.number, ttl,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1472,6 +1472,90 @@ dps:
 """
         self.check_config_success(config, cp.dp_parser)
 
+    def test_dp_lldp_minimal_invalid(self):
+        """Test minimal invalid DP config."""
+        config = """
+vlans:
+    office:
+        vid: 100
+dps:
+    sw1:
+        dp_id: 0x1
+        lldp_beacon:
+            system_name: test_system
+        interfaces:
+            testing:
+                number: 1
+                native_vlan: office
+"""
+        self.check_config_failure(config, cp.dp_parser)
+
+    def test_dp_lldp_minimal_valid(self):
+        """Test minimal valid DP config."""
+        config = """
+vlans:
+    office:
+        vid: 100
+dps:
+    sw1:
+        dp_id: 0x1
+        lldp_beacon:
+            send_interval: 10
+            max_per_interval: 10
+        interfaces:
+            testing:
+                number: 1
+                native_vlan: office
+"""
+        self.check_config_success(config, cp.dp_parser)
+
+    def test_port_lldp_minimal_valid(self):
+        """Test minimal valid LLDP config."""
+        config = """
+vlans:
+    office:
+        vid: 100
+dps:
+    sw1:
+        dp_id: 0x1
+        lldp_beacon:
+            send_interval: 10
+            max_per_interval: 10
+        interfaces:
+            testing:
+                number: 1
+                native_vlan: office
+                lldp_beacon:
+                    enable: true
+"""
+        self.check_config_success(config, cp.dp_parser)
+
+    def test_all_lldp_valid(self):
+        """Test a fully specified valid LLDP config."""
+        config = """
+vlans:
+    office:
+        vid: 100
+dps:
+    sw1:
+        dp_id: 0x1
+        lldp_beacon:
+            system_name: test_system
+            send_interval: 10
+            max_per_interval: 10
+        interfaces:
+            testing:
+                number: 1
+                native_vlan: office
+                lldp_beacon:
+                    enable: true
+                    system_name: port_system
+                    port_descr: port_description
+                    org_tlvs:
+                        - {oui: 0x12bb, subtype: 2, info: "01406500"}
+"""
+        self.check_config_success(config, cp.dp_parser)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Provide sensible defaults for system_name and port_descr as described in #1539. Includes some basic tests for the new behaviour and configuration.