### PR TITLE
Switch to using faucet startup script by default

### DIFF
--- a/docker/supervisord.gauge.conf
+++ b/docker/supervisord.gauge.conf
@@ -2,10 +2,10 @@
 nodaemon=true
 
 [program:faucet]
-command=ryu-manager --ofp-tcp-listen-port=6653 faucet.faucet
+command=faucet --ryu-ofp-tcp-listen-port=6653
 
 [program:guage]
-command=ryu-manager --ofp-tcp-listen-port=6654 faucet.gauge
+command=gauge --ryu-ofp-tcp-listen-port=6654
 
 [program:influx]
 command=/usr/bin/influxd -config /etc/influxdb/influxdb.conf

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -98,7 +98,7 @@ starts the faucet process)
 
 .. code:: console
 
-    ryu-manager --ctl-privkey /etc/ryu/ctrlr.key --ctl-cert /etc/ryu/ctrlr.cert  --ca-certs /etc/ryu/sw.cert faucet.faucet --verbose
+    faucet --ryu-ctl-privkey /etc/ryu/ctrlr.key --ryu-ctl-cert /etc/ryu/ctrlr.cert --ryu-ca-certs /etc/ryu/sw.cert --verbose
 
 Support multiple switches
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -193,7 +193,7 @@ You can then start FAUCET manually:
 
 .. code:: console
 
-  ryu-manager faucet.faucet --verbose
+  faucet --verbose
 
 Or, you can configure systemd to start the containers automatically:
 

--- a/docs/vendors/lagopus/README_Lagopus.rst
+++ b/docs/vendors/lagopus/README_Lagopus.rst
@@ -81,7 +81,7 @@ Run FAUCET
 
 .. code:: console
 
-    ryu-manager --config-file=/home/faucet/faucet/etc/ryu/ryu.conf /home/faucet/faucet/faucet/faucet.py --verbose --ofp-listen-host=127.0.0.1
+    faucet --verbose --ryu-ofp-listen-host=127.0.0.1
 
 
 Test connectivity

--- a/docs/vendors/noviflow/README_noviflow.rst
+++ b/docs/vendors/noviflow/README_noviflow.rst
@@ -80,7 +80,7 @@ Run FAUCET
 
 .. code:: console
 
-    ryu-manager faucet.faucet --verbose
+    faucet --verbose
 
 Test connectivity
 ^^^^^^^^^^^^^^^^^

--- a/docs/vendors/ovs/README_OVS-DPDK.rst
+++ b/docs/vendors/ovs/README_OVS-DPDK.rst
@@ -139,7 +139,7 @@ Run FAUCET
 
 .. code:: console
 
-    ryu-manager faucet.faucet --verbose --ofp-listen-host=127.0.0.1
+    faucet --verbose --ryu-ofp-listen-host=127.0.0.1
 
 
 Test connectivity

--- a/etc/systemd/system/faucet.service
+++ b/etc/systemd/system/faucet.service
@@ -7,7 +7,7 @@ Wants=network-online.target
 EnvironmentFile=/etc/default/faucet
 User=faucet
 Group=faucet
-ExecStart=/usr/local/bin/ryu-manager --config-file=${FAUCET_RYU_CONF} --ofp-tcp-listen-port=${FAUCET_LISTEN_PORT} faucet.faucet
+ExecStart=/usr/local/bin/faucet --ryu-config-file=${FAUCET_RYU_CONF} --ryu-ofp-tcp-listen-port=${FAUCET_LISTEN_PORT}
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=always
 

--- a/etc/systemd/system/gauge.service
+++ b/etc/systemd/system/gauge.service
@@ -7,7 +7,7 @@ Wants=network-online.target
 EnvironmentFile=/etc/default/gauge
 User=faucet
 Group=faucet
-ExecStart=/usr/local/bin/ryu-manager --config-file=${GAUGE_RYU_CONF} --ofp-tcp-listen-port=${GAUGE_LISTEN_PORT} --wsapi-host=${WSAPI_LISTEN_HOST} faucet.gauge ryu.app.ofctl_rest
+ExecStart=/usr/local/bin/gauge --ryu-config-file=${GAUGE_RYU_CONF} --ryu-ofp-tcp-listen-port=${GAUGE_LISTEN_PORT} --ryu-wsapi-host=${WSAPI_LISTEN_HOST} --ryu-app=ryu.app.ofctl_rest
 Restart=always
 
 [Install]

--- a/tests/faucet_mininet_test_topo.py
+++ b/tests/faucet_mininet_test_topo.py
@@ -397,7 +397,7 @@ socket_timeout=15
             cprofile_args = 'python3 -m cProfile -s time'
         with open(script_wrapper_name, 'w') as script_wrapper:
             script_wrapper.write(
-                'PYTHONPATH=.:..:../faucet %s exec timeout %u %s /usr/local/bin/ryu-manager %s $*\n' % (
+                'PYTHONPATH=.:..:../faucet %s exec timeout %u %s /usr/local/bin/faucet %s $*\n' % (
                     ' '.join(env_vars), self.MAX_CTL_TIME, cprofile_args, args))
         return '/bin/sh %s' % script_wrapper_name
 


### PR DESCRIPTION
This deprecates starting faucet with "ryu-manager" the faucet start script should now be used instead.