### PR TITLE
Add support for multiple ACLs

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -9,6 +9,11 @@ The following is example demonstrating a few common features:
   :caption: faucet.yaml
   :name: faucet.yaml
 
+.. literalinclude:: ../etc/ryu/faucet/acls.yaml
+  :language: yaml
+  :caption: acls.yaml
+  :name: acls.yaml
+
 The datapath ID may be specified as an integer or hex string (beginning with 0x).
 
 A port not explicitly defined in the YAML configuration file will be left down and will drop all packets.
@@ -300,8 +305,15 @@ OFP port number ranges (eg. 1-6).
     * - acl_in
       - integer or string
       - None
-      - The acl that should be applied to all packets arriving on this port.
+      - Deprecated, replaced by acls_in which accepts a list.
+        The acl that should be applied to all packets arriving on this port.
         referenced by name or list index
+    * - acls_in
+      - a list of ACLs, as integers or strings
+      - None
+      - A list of ACLs that should be applied to all packets arriving on this port.
+        referenced by name or list index. ACLs listed first take priority over
+        those later in the list.
     * - description
       - string
       - None
@@ -431,7 +443,13 @@ or a name. The following attributes can be configured:
     * - acl_in
       - string or integer
       - None
+      - Deprecated, replaced by acls_in which accepts a list.
+        The acl to be applied to all packets arriving on this vlan.
+    * - acls_in
+      - a list of ACLs, as integers or strings
+      - None
       - The acl to be applied to all packets arriving on this vlan.
+        ACLs listed first take priority over those later in the list.
     * - bgp_as
       - integer
       - 0

--- a/etc/ryu/faucet/faucet.yaml
+++ b/etc/ryu/faucet/faucet.yaml
@@ -5,7 +5,7 @@ vlans:
     office:
         vid: 100
         description: "office network"
-        acl_in: office-vlan-protect
+        acls_in: [office-vlan-protect]
         faucet_mac: "0e:00:00:00:10:01"
         faucet_vips: ['10.0.100.254/24', '2001:100::1/64', 'fe80::c00:00ff:fe00:1001/64']
         routes:
@@ -32,27 +32,27 @@ dps:
                 name: "h1"
                 description: "host1 container"
                 native_vlan: office
-                acl_in: access-port-protect
+                acls_in: [access-port-protect]
             2:
                 name: "h2"
                 description: "host2 container"
                 native_vlan: office
-                acl_in: access-port-protect
+                acls_in: [access-port-protect]
             3:
                 name: "g1"
                 description: "guest1 container"
                 native_vlan: guest
-                acl_in: access-port-protect
+                acls_in: [access-port-protect]
             4:
                 name: "s1"
                 description: "services1 container"
                 native_vlan: office
-                acl_in: service-port-protect
+                acls_in: [service-port-protect]
             5:
                 name: "trunk"
                 description: "VLAN trunk to sw2"
                 tagged_vlans: [office]
-                acl_in: access-port-protect
+                acls_in: [access-port-protect]
     sw2:
         dp_id: 0x2
         hardware: "Allied-Telesis"
@@ -61,12 +61,12 @@ dps:
                 name: "pi"
                 description: "Raspberry Pi"
                 native_vlan: office
-                acl_in: access-port-protect
+                acls_in: [access-port-protect]
             2:
                 name: "laptop"
                 description: "Guest Laptop"
                 native_vlan: guest
-                acl_in: access-port-protect
+                acls_in: [access-port-protect]
             24:
                 name: "trunk"
                 description: "VLAN trunk to sw1"

--- a/faucet/port.py
+++ b/faucet/port.py
@@ -34,6 +34,7 @@ class Port(Conf):
     native_vlan = None
     tagged_vlans = [] # type: list
     acl_in = None
+    acls_in = None
     stack = {} # type: dict
     max_hosts = None
     hairpin = None
@@ -65,6 +66,7 @@ class Port(Conf):
         'tagged_vlans': None,
         # Set tagged VLANs on this port.
         'acl_in': None,
+        'acls_in': None,
         # ACL for input on this port.
         'stack': None,
         # Configure a stack peer on this port.
@@ -95,6 +97,7 @@ class Port(Conf):
         'native_vlan': (str, int),
         'tagged_vlans': list,
         'acl_in': (str, int),
+        'acls_in': list,
         'stack': dict,
         'max_hosts': int,
         'hairpin': bool,
@@ -173,6 +176,14 @@ class Port(Conf):
                     org_tlv['oui'] = bytearray.fromhex('%6.6x' % org_tlv['oui'])
                     org_tlvs.append(org_tlv)
                 self.lldp_beacon['org_tlvs'] = org_tlvs
+        if self.acl_in and self.acls_in:
+            assert False, 'found both acl_in and acls_in, use only acls_in'
+        if self.acl_in and not isinstance(self.acl_in, list):
+            self.acls_in = [self.acl_in,]
+            self.acl_in = None
+        if self.acls_in:
+            for acl in self.acls_in:
+                assert isinstance(acl, (int, str)), 'acl names must be int or'
 
     def finalize(self):
         assert self.vlans() or self.stack or self.output_only, (

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -212,13 +212,13 @@ class Valve(object):
 
     def _vlan_add_acl(self, vlan):
         ofmsgs = []
-        if vlan.acl_in:
+        if vlan.acls_in:
             acl_table = self.dp.tables['vlan_acl']
             acl_allow_inst = valve_of.goto_table(self.dp.tables['eth_src'])
             ofmsgs = valve_acl.build_acl_ofmsgs(
-                [vlan.acl_in], acl_table, acl_allow_inst,
+                vlan.acls_in, acl_table, acl_allow_inst,
                 self.dp.highest_priority, self.dp.meters,
-                vlan.acl_in.exact_match, vlan_vid=vlan.vid)
+                vlan.acls_in[0].exact_match, vlan_vid=vlan.vid)
         return ofmsgs
 
     def _add_vlan_flood_flow(self):
@@ -424,11 +424,11 @@ class Valve(object):
         if cold_start:
             ofmsgs.extend(acl_table.flowdel(in_port_match))
         acl_allow_inst = valve_of.goto_table(self.dp.tables['vlan'])
-        if port.acl_in:
+        if port.acls_in:
             ofmsgs.extend(valve_acl.build_acl_ofmsgs(
-                [port.acl_in], acl_table, acl_allow_inst,
+                port.acls_in, acl_table, acl_allow_inst,
                 self.dp.highest_priority, self.dp.meters,
-                port.acl_in.exact_match, port_num=port.number))
+                port.acls_in[0].exact_match, port_num=port.number))
         else:
             ofmsgs.append(acl_table.flowmod(
                 in_port_match,
@@ -464,7 +464,7 @@ class Valve(object):
         return self._port_add_vlan_rules(port, vlan, vlan_inst)
 
     def _find_forwarding_table(self, vlan):
-        if vlan.acl_in:
+        if vlan.acls_in:
             return self.dp.tables['vlan_acl']
         return self.dp.tables['eth_src']
 

--- a/faucet/vlan.py
+++ b/faucet/vlan.py
@@ -63,6 +63,7 @@ class VLAN(Conf):
     max_hosts = None
     unicast_flood = None
     acl_in = None
+    acls_in = None
     targeted_gw_resolution = None
     proactive_arp_limit = None
     proactive_nd_limit = None
@@ -79,6 +80,7 @@ class VLAN(Conf):
         'name': None,
         'description': None,
         'acl_in': None,
+        'acls_in': None,
         'faucet_vips': None,
         'faucet_mac': FAUCET_MAC,
         # set MAC for FAUCET VIPs on this VLAN
@@ -110,6 +112,7 @@ class VLAN(Conf):
         'name': str,
         'description': str,
         'acl_in': (int, str),
+        'acls_in': list,
         'faucet_vips': list,
         'faucet_mac': str,
         'unicast_flood': bool,
@@ -194,6 +197,14 @@ class VLAN(Conf):
                 assert False, 'missing route config'
             except TypeError:
                 assert False, '%s is not a valid routes value' % self.routes
+        if self.acl_in and self.acls_in:
+            assert False, 'found both acl_in and acls_in, use only acls_in'
+        if self.acl_in and not isinstance(self.acl_in, list):
+            self.acls_in = [self.acl_in,]
+            self.acl_in = None
+        if self.acls_in:
+            for acl in self.acls_in:
+                assert isinstance(acl, (int, str)), 'acl names must be int or str'
 
     @staticmethod
     def vid_valid(vid):

--- a/tests/faucet_mininet_test_unit.py
+++ b/tests/faucet_mininet_test_unit.py
@@ -1555,6 +1555,29 @@ acls:
             cookie: 1234
             actions:
                 allow: 1
+    3:
+        - rule:
+            cookie: 1234
+            dl_type: 0x800
+            ip_proto: 6
+            tcp_dst: 5003
+            actions:
+                allow: 0
+    4:
+        - rule:
+            cookie: 1234
+            dl_type: 0x800
+            ip_proto: 6
+            tcp_dst: 5002
+            actions:
+                allow: 1
+        - rule:
+            cookie: 1234
+            dl_type: 0x800
+            ip_proto: 6
+            tcp_dst: 5001
+            actions:
+                allow: 0
     deny:
         - rule:
             cookie: 1234
@@ -1716,7 +1739,7 @@ class FaucetConfigReloadAclTest(FaucetConfigReloadTestBase):
             %(port_1)d:
                 native_vlan: 100
                 description: "b1"
-                acl_in: allow
+                acls_in: [allow]
             %(port_2)d:
                 native_vlan: 100
                 description: "b2"
@@ -1744,7 +1767,12 @@ class FaucetConfigReloadAclTest(FaucetConfigReloadTestBase):
         self._verify_hosts_learned((first_host, second_host))
         self.change_port_config(
             self.port_map['port_3'], 'acl_in', 'allow', restart=restart)
+        self.change_port_config(
+            self.port_map['port_1'], 'acls_in', [3,4,"allow"], restart=restart)
         self._verify_hosts_learned((first_host, second_host, third_host))
+        self.verify_tp_dst_blocked(5001, first_host, second_host)
+        self.verify_tp_dst_notblocked(5002, first_host, second_host)
+        self.verify_tp_dst_blocked(5003, first_host, second_host)
 
 
 class FaucetConfigStatReloadAclTest(FaucetConfigReloadAclTest):

--- a/tests/test_check_config.py
+++ b/tests/test_check_config.py
@@ -21,6 +21,7 @@ import shutil
 import subprocess
 import tempfile
 import unittest
+import re
 
 
 SRC_DIR = '../faucet'
@@ -55,9 +56,17 @@ class CheckConfigTestCase(unittest.TestCase):
 
     def check_config_success(self, config):
         self.assertTrue(self.run_check_config(config, True))
+        # Check acls_in work now acl_in is deprecated, TODO remove in future
+        if "acl_in" in config and not "acls_in" in config:
+            acls_cfg = re.sub("(acl_in: )(.*)", "acls_in: [\\2]", config)
+            self.assertTrue(self.run_check_config(acls_cfg, True))
 
     def check_config_failure(self, config):
         self.assertTrue(self.run_check_config(config, False))
+        # Check acls_in work now acl_in is deprecated, TODO remove in future
+        if "acl_in" in config and not "acls_in" in config:
+            acls_cfg = re.sub("(acl_in: )(.*)", "acls_in: [\\2]", config)
+            self.assertTrue(self.run_check_config(acls_cfg, False))
 
     def test_minimal(self):
         """Test minimal correct config."""


### PR DESCRIPTION
Fix for issue #972

* Adds acls_in option to vlans and ports which take a list of acls.
   - These are applied in the order listed
* This replaces and deprecates the acl_in option.
* Add missing acls.yaml file to the config documentation, which is included
  from faucet.yaml but not listed in the docs.