### PR TITLE
use delete_strict in Valve.lacp_up()

### DIFF
--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -652,7 +652,7 @@ class Valve(object):
         ofmsgs = []
         ofmsgs.extend(eth_src_table.flowdel(
             match=eth_src_table.match(in_port=port.number),
-            priority=self.dp.high_priority))
+            priority=self.dp.high_priority, strict=True))
         return ofmsgs
 
     def lacp_handler(self, pkt_meta):


### PR DESCRIPTION
When LCAP session goes Up the Valve.lacp_up() method sends a flow_mod DELETE which matches only on in_port, causing the deletion of the flows that intercept LACP messages and send them to controller.    
By using DELETE_STRICT we avoid the deletion of those flows