### PR TITLE
Gauge faucet config

### DIFF
--- a/faucet/config_parser.py
+++ b/faucet/config_parser.py
@@ -225,11 +225,28 @@ def _watcher_parser_v2(conf, logname, prom_client):
     result = []
 
     dps = {}
-    for faucet_file in conf['faucet_configs']:
-        _, dp_list = dp_parser(faucet_file, logname)
-        if dp_list:
-            for dp in dp_list:
-                dps[dp.name] = dp
+    if 'faucet_configs' in conf:
+        for faucet_file in conf['faucet_configs']:
+            _, dp_list = dp_parser(faucet_file, logname)
+            if dp_list:
+                for dp in dp_list:
+                    dps[dp.name] = dp
+
+    if 'faucet' in conf:
+        faucet_conf = conf['faucet']
+        print(faucet_conf)
+        acls = faucet_conf.get('acls', {})
+        fct_dps = faucet_conf.get('dps', {})
+        meters = faucet_conf.get('meters', {})
+        routers = faucet_conf.get('routers', {})
+        vlans = faucet_conf.get('vlans', {})
+        for dp in _dp_parser_v2(acls, fct_dps, meters, routers, vlans):
+            dps[dp.name] = dp
+
+    if not dps:
+        raise InvalidConfigError(
+            'Gauge configured without any faucet configuration'
+            )
 
     dbs = conf.pop('dbs')
 

--- a/faucet/config_parser.py
+++ b/faucet/config_parser.py
@@ -234,7 +234,6 @@ def _watcher_parser_v2(conf, logname, prom_client):
 
     if 'faucet' in conf:
         faucet_conf = conf['faucet']
-        print(faucet_conf)
         acls = faucet_conf.get('acls', {})
         fct_dps = faucet_conf.get('dps', {})
         meters = faucet_conf.get('meters', {})

--- a/tests/test_config_gauge.py
+++ b/tests/test_config_gauge.py
@@ -90,5 +90,34 @@ dbs:
             self.assertEqual(watcher_conf.interval, 10, msg)
             self.assertEqual(watcher_conf.db_type, 'prometheus', msg)
 
+    def test_no_faucet_config_file(self):
+        GAUGE_CONF = """
+faucet:
+    dps:
+        dp1:
+            dp_id: 1
+            interfaces:
+                1:
+                    native_vlan: v1
+    vlans:
+        v1:
+            vid: 1
+watchers:
+    port_stats_poller:
+        type: 'port_stats'
+        dps: ['dp1']
+        db: 'prometheus'
+dbs:
+    prometheus:
+        type: 'prometheus'
+"""
+        gauge_file, faucet_file = self.create_config_files(GAUGE_CONF, '')
+        watcher_conf = cp.watcher_parser(
+            gauge_file, 'gauge_config_test', None)[0]
+        msg = 'failed to create watcher correctly when dps configured in gauge.yaml'
+        self.assertEqual(watcher_conf.dps[0], 'dp1', msg)
+        self.assertEqual(watcher_conf.type, 'port_stats', msg)
+        self.assertEqual(watcher_conf.db_type, 'prometheus', msg)
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
    Instead of providing gauge with a list of faucet.yaml files to
    use to read the faucet config, you can now add the faucet
    config in the gauge.yaml file
	eg.
```
faucet:
	dps:
		dp1:
			dp_id: 1
			interfaces:
				1:
					native_vlan: v1
	vlans:
		v1:
			vid: 1
watchers:
	port_stats_poller:
		type: 'port_stats'
		dps: ['dp1']
		db: 'prometheus'
dbs:
	prometheus:
		type: 'prometheus'
```

	This will make it easier to configure gauge to operate from
	a separate server to faucet, or to allow gauge to monitor
	other non-faucet openflow deployments.