### PR TITLE
Sphinx 1.7 changes how main arguments are parsed.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -170,7 +170,7 @@ def run_apidoc(_):
     """Call sphinx-apidoc on faucet module"""
     from sphinx.apidoc import main as apidoc_main
     cur_dir = os.path.abspath(os.path.dirname(__file__))
-    apidoc_main([None, '-e', '-o', 'source/apidoc', '../faucet'])
+    apidoc_main(['-e', '-o', 'source/apidoc', '../faucet'])
 
 def setup(app):
     """Over-ride Sphinx setup to trigger sphinx-apidoc."""

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
 -r ../requirements.txt
-sphinx>=1.6
-sphinx_rtd_theme
+sphinx==1.7.0
+sphinx_rtd_theme==0.2.4


### PR DESCRIPTION
 * Fix how we call sphinx-apidoc to work in 1.7
 * Lock onto Sphinx 1.7.0 as they seem to have more breaking changes in the pipeline

Fixes #1661 