### PR TITLE
add a dockerfile for rabbitmq-adapter on raspberry pi

### DIFF
--- a/adapters/vendors/rabbitmq/Dockerfile.pi
+++ b/adapters/vendors/rabbitmq/Dockerfile.pi
@@ -1,0 +1,31 @@
+## Image name: faucet/faucet-event-adapter-rabbitmq-pi
+
+FROM faucet/faucet-base-pi
+LABEL maintainer="Charlie Lewis <clewis@iqt.org>"
+
+ENV PYTHONUNBUFFERED=0
+
+RUN apk add --update \
+    python3 \
+    python3-dev \
+    py3-pip \
+    gcc \
+    musl-dev \
+    && rm -rf /var/cache/apk/*
+
+WORKDIR /src
+
+COPY requirements.txt requirements.txt
+RUN pip3 install -r requirements.txt
+
+COPY rabbit.py rabbit.py
+COPY test_rabbit.py test_rabbit.py
+
+RUN apk add --update pytest && \
+    pip3 install pytest-cov && \
+    python3 -m pytest -l -v --cov=. --cov-report term-missing && \
+    apk del pytest && \
+    pip3 uninstall -y pytest-cov && \
+    find / -name \*pyc -delete
+
+CMD ["python3", "rabbit.py"]


### PR DESCRIPTION
I will need to test this actually runs correctly on pi network on Monday, but it does build. Think it did yesterday but not certain.