### PR TITLE
Test documentation builds with test suite

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
-docs
 faucet/*pyc
 tests/*pyc
 faucet/*/*pyc

--- a/docker/base/install-faucet.sh
+++ b/docker/base/install-faucet.sh
@@ -16,3 +16,6 @@ $APK add -U git $BUILDDEPS && \
   python3 -m pytest $FROOT/tests/test_valve.py && \
   for i in $BUILDDEPS ; do $APK del $i ; done && \
   find / -name \*pyc -delete
+
+# Clean up
+rm -r "$FROOT/docs"

--- a/docker/runtests.sh
+++ b/docker/runtests.sh
@@ -35,6 +35,12 @@ sysctl -w net.ipv4.tcp_tw_reuse=1
 # minimize TCP connection timeout so application layer timeouts are quicker to test.
 sysctl -w net.ipv4.tcp_syn_retries=4
 
+echo "========== Building documentation =========="
+cd /faucet-src/docs
+pip3 install -r requirements.txt
+make html || exit 1
+rm -rf _build
+
 cd /faucet-src/tests
 
 if [ "$DEPCHECK" == 1 ] ; then

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,7 @@ autodoc_default_flags = ["members", "undoc-members", "show-inheritance"]
 
 # If your documentation needs a minimal Sphinx version, state it here.
 #
-needs_sphinx = '1.6'
+needs_sphinx = '1.7'
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
@@ -169,7 +169,6 @@ texinfo_documents = [
 def run_apidoc(_):
     """Call sphinx-apidoc on faucet module"""
     from sphinx.apidoc import main as apidoc_main
-    cur_dir = os.path.abspath(os.path.dirname(__file__))
     apidoc_main(['-e', '-o', 'source/apidoc', '../faucet'])
 
 def setup(app):

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
 -r ../requirements.txt
-sphinx==1.7.1
+sphinx==1.7.0
 sphinx_rtd_theme==0.2.4

--- a/run-travis-test.sh
+++ b/run-travis-test.sh
@@ -8,7 +8,12 @@ docker images
 # If sanity shard, just the sanity test and lint/type/dependency checks.
 if [ "${MATRIX_SHARD}" == "sanity" ] ; then
   touch ~/.pylintrc
-  cd ./tests
+  cd ./docs
+  pip3 install -r requirements.txt
+  make html || exit 1
+  rm -rf _build
+
+  cd ../tests
   PYTHONPATH=~/faucet ./test_min_pylint.sh || exit 1
   PYTHONPATH=~/faucet python3 -m pytest ./test_*.py --cov faucet --doctest-modules -v --cov-report term-missing || exit 1
   codecov || true


### PR DESCRIPTION
#1703 from pyup broke documentation builds because of https://github.com/sphinx-doc/sphinx/issues/4615

Adding doc builds to test suite so this can't happen in future.

I am also reverting #1703 while I wrap my head around the changes to Sphinx.