### PR TITLE
Make combinatorial_port_flood configurable.

### DIFF
--- a/faucet/acl.py
+++ b/faucet/acl.py
@@ -37,8 +37,10 @@ matches and actions for the rule.
 The matches are key/values based on the ryu RESTFul API.
 The key 'actions' contains a dictionary with keys/values as follows:
 
- * allow (bool): if True allow the packet to continue through the Faucet \
-       pipeline, if False drop the packet.
+ * allow (int): if 1 allow the packet to continue through the Faucet \
+       pipeline, if 0 drop the packet.
+ * force_port_vlan (int): if 1, do not verify the VLAN/port association \
+       for this packet and override any VLAN ACL on the forced VLAN.
  * meter (str): meter to apply to the packet
  * output (dict): used to output a packet directly. details below.
  * cookie (int): set flow cookie to this value on this flow
@@ -76,6 +78,7 @@ The output action contains a dictionary with the following elements:
         'mirror': (str, int),
         'output': dict,
         'allow': int,
+        'force_port_vlan': int,
     }
     output_actions_types = {
         'port': (str, int),

--- a/faucet/dp.py
+++ b/faucet/dp.py
@@ -85,6 +85,7 @@ configuration.
     lldp_beacon = {} # type: dict
     metrics_rate_limit_sec = None
     faucet_dp_mac = None
+    combinatorial_port_flood = None
 
     dyn_last_coldstart_time = None
 
@@ -161,6 +162,8 @@ configuration.
         # Rate limit metric updates - don't update metrics if last update was less than this many seconds ago.
         'faucet_dp_mac': FAUCET_MAC,
         # MAC address of packets sent by FAUCET, not associated with any VLAN.
+        'combinatorial_port_flood': True,
+        # if True, use a seperate output flow for each input port on this VLAN.
         }
 
     defaults_types = {
@@ -200,6 +203,7 @@ configuration.
         'lldp_beacon': dict,
         'metrics_rate_limit_sec': int,
         'faucet_dp_mac': str,
+        'combinatorial_port_flood': bool,
     }
 
     stack_defaults_types = {

--- a/faucet/dp.py
+++ b/faucet/dp.py
@@ -545,14 +545,15 @@ configuration.
                     return resolved_action_conf
                 return None
 
-            def resolve_allow(_acl, action_conf):
+            def resolve_noop(_acl, action_conf):
                 return action_conf
 
             action_resolvers = {
                 'meter': resolve_meter,
                 'mirror': resolve_mirror,
                 'output': resolve_output,
-                'allow': resolve_allow,
+                'allow': resolve_noop,
+                'force_port_vlan': resolve_noop,
             }
 
             def build_acl(acl, vid=None):
@@ -563,6 +564,7 @@ configuration.
                     try:
                         ofmsgs = valve_acl.build_acl_ofmsgs(
                             [acl], self.wildcard_table,
+                            valve_of.goto_table(self.wildcard_table),
                             valve_of.goto_table(self.wildcard_table),
                             2**16-1, self.meters, acl.exact_match,
                             vlan_vid=vid)

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -235,7 +235,7 @@ class Valve(object):
             acl_allow_inst = valve_of.goto_table(self.dp.tables['eth_src'])
             ofmsgs = valve_acl.build_acl_ofmsgs(
                 vlan.acls_in, acl_table,
-                acl_allow_inst,
+                acl_allow_inst, acl_allow_inst,
                 self.dp.highest_priority, self.dp.meters,
                 vlan.acls_in[0].exact_match, vlan_vid=vlan.vid)
         return ofmsgs
@@ -474,9 +474,11 @@ class Valve(object):
         if cold_start:
             ofmsgs.extend(acl_table.flowdel(in_port_match))
         acl_allow_inst = valve_of.goto_table(self.dp.tables['vlan'])
+        acl_force_port_vlan_inst = valve_of.goto_table(self.dp.tables['eth_src'])
         if port.acls_in:
             ofmsgs.extend(valve_acl.build_acl_ofmsgs(
-                port.acls_in, acl_table, acl_allow_inst,
+                port.acls_in, acl_table,
+                acl_allow_inst, acl_force_port_vlan_inst,
                 self.dp.highest_priority, self.dp.meters,
                 port.acls_in[0].exact_match, port_num=port.number))
         else:

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -118,13 +118,15 @@ class Valve(object):
                 self.dp.tables['flood'], self.dp.tables['eth_src'],
                 self.dp.low_priority, self.dp.highest_priority,
                 self.dp.group_table, self.dp.groups,
+                self.dp.combinatorial_port_flood,
                 self.dp.stack, self.dp.stack_ports,
                 self.dp.shortest_path_to_root, self.dp.shortest_path_port)
         else:
             self.flood_manager = valve_flood.ValveFloodManager(
                 self.dp.tables['flood'], self.dp.tables['eth_src'],
                 self.dp.low_priority, self.dp.highest_priority,
-                self.dp.group_table, self.dp.groups)
+                self.dp.group_table, self.dp.groups,
+                self.dp.combinatorial_port_flood)
         if self.dp.use_idle_timeout:
             self.host_manager = valve_host.ValveHostFlowRemovedManager(
                 self.logger, self.dp.ports, self.dp.vlans,

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -234,7 +234,8 @@ class Valve(object):
             acl_table = self.dp.tables['vlan_acl']
             acl_allow_inst = valve_of.goto_table(self.dp.tables['eth_src'])
             ofmsgs = valve_acl.build_acl_ofmsgs(
-                vlan.acls_in, acl_table, acl_allow_inst,
+                vlan.acls_in, acl_table,
+                acl_allow_inst,
                 self.dp.highest_priority, self.dp.meters,
                 vlan.acls_in[0].exact_match, vlan_vid=vlan.vid)
         return ofmsgs

--- a/faucet/valve_acl.py
+++ b/faucet/valve_acl.py
@@ -91,7 +91,9 @@ def build_output_actions(output_dict):
 
 # TODO: change this, maybe this can be rewritten easily
 # possibly replace with a class for ACLs
-def build_acl_entry(rule_conf, acl_allow_inst, meters, port_num=None, vlan_vid=None):
+def build_acl_entry(rule_conf, meters,
+                    acl_allow_inst,
+                    port_num=None, vlan_vid=None):
     acl_inst = []
     acl_act = []
     acl_match_dict = {}
@@ -147,7 +149,8 @@ def build_acl_entry(rule_conf, acl_allow_inst, meters, port_num=None, vlan_vid=N
     return (acl_match, acl_inst, acl_cookie, acl_ofmsgs)
 
 
-def build_acl_ofmsgs(acls, acl_table, acl_allow_inst,
+def build_acl_ofmsgs(acls, acl_table,
+                     acl_allow_inst,
                      highest_priority, meters,
                      exact_match, port_num=None, vlan_vid=None):
     ofmsgs = []
@@ -155,7 +158,9 @@ def build_acl_ofmsgs(acls, acl_table, acl_allow_inst,
     for acl in acls:
         for rule_conf in acl.rules:
             acl_match, acl_inst, acl_cookie, acl_ofmsgs = build_acl_entry(
-                rule_conf, acl_allow_inst, meters, port_num, vlan_vid)
+                rule_conf, meters,
+                acl_allow_inst,
+                port_num, vlan_vid)
             ofmsgs.extend(acl_ofmsgs)
             if exact_match:
                 flowmod = acl_table.flowmod(

--- a/faucet/valve_of.py
+++ b/faucet/valve_of.py
@@ -664,7 +664,7 @@ def flood_untagged_port_outputs(ports, in_port=None, exclude_ports=None):
     if ports:
         flood_acts.append(pop_vlan())
         flood_acts.extend(flood_tagged_port_outputs(
-            ports, in_port=None, exclude_ports=exclude_ports))
+            ports, in_port=in_port, exclude_ports=exclude_ports))
     return flood_acts
 
 

--- a/faucet/valve_of.py
+++ b/faucet/valve_of.py
@@ -643,12 +643,12 @@ def group_flood_buckets(ports, untagged):
     return buckets
 
 
-def flood_tagged_port_outputs(ports, in_port, exclude_ports=None):
+def flood_tagged_port_outputs(ports, in_port=None, exclude_ports=None):
     """Return list of actions necessary to flood to list of tagged ports."""
     flood_acts = []
     if ports:
         for port in ports:
-            if port == in_port:
+            if in_port is not None and port == in_port:
                 if port.hairpin:
                     flood_acts.append(output_in_port())
                 continue
@@ -658,13 +658,13 @@ def flood_tagged_port_outputs(ports, in_port, exclude_ports=None):
     return flood_acts
 
 
-def flood_untagged_port_outputs(ports, in_port, exclude_ports=None):
+def flood_untagged_port_outputs(ports, in_port=None, exclude_ports=None):
     """Return list of actions necessary to flood to list of untagged ports."""
     flood_acts = []
     if ports:
         flood_acts.append(pop_vlan())
         flood_acts.extend(flood_tagged_port_outputs(
-            ports, in_port, exclude_ports=exclude_ports))
+            ports, in_port=None, exclude_ports=exclude_ports))
     return flood_acts
 
 

--- a/tests/faucet_mininet_test_unit.py
+++ b/tests/faucet_mininet_test_unit.py
@@ -135,11 +135,51 @@ vlans:
         self.assertEqual(prom_event_id, event_id)
 
 
+class FaucetUntaggedNoCombinatorialFlood(FaucetUntaggedTest):
+
+    CONFIG = """
+        combinatorial_port_flood: False
+        interfaces:
+            %(port_1)d:
+                native_vlan: 100
+                description: "b1"
+            %(port_2)d:
+                native_vlan: 100
+                description: "b2"
+            %(port_3)d:
+                native_vlan: 100
+                description: "b3"
+            %(port_4)d:
+                native_vlan: 100
+                description: "b4"
+"""
+
+
 class FaucetUntaggedBroadcastTest(FaucetUntaggedTest):
 
     def test_untagged(self):
        super(FaucetUntaggedBroadcastTest, self).test_untagged()
        self.verify_broadcast()
+
+
+class FaucetUntaggedNoCombinatorialBroadcastTest(FaucetUntaggedBroadcastTest):
+
+    CONFIG = """
+        combinatorial_port_flood: False
+        interfaces:
+            %(port_1)d:
+                native_vlan: 100
+                description: "b1"
+            %(port_2)d:
+                native_vlan: 100
+                description: "b2"
+            %(port_3)d:
+                native_vlan: 100
+                description: "b3"
+            %(port_4)d:
+                native_vlan: 100
+                description: "b4"
+"""
 
 
 class FaucetExperimentalAPITest(FaucetUntaggedTest):


### PR DESCRIPTION
dps:
    combinatorial_port_flood: True (default)

If False, we use only one flood rule for all ports on a VLAN
(using OpenFlow spec implied behavior, if a rule says in_port=n,output:n,x,y,
packet is sent to x and y only, because OFPP_IN_PORT was not specified).

False is more convenient and may become the default.
