### PR TITLE
Tidy debian packaging

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -1,12 +1,12 @@
 Source: faucet
 Section: python
 Priority: optional
-Maintainer: Jayden Hewer <jfh13@students.waikato.ac.nz>
+Maintainer: Faucet Maintainers <maintainers@faucet.nz>
 Build-Depends: debhelper (>=9),
                dh-systemd (>= 1.5),
                dh-python,
                git,
-               python3-pkg-resources, 
+               python3-pkg-resources,
                python3-all,
                python3-setuptools,
                python3-pbr (>=1.9),
@@ -54,9 +54,9 @@ Description: This is a compact open source OpenFlow controller (Python 3)
 
 Package: gauge
 Architecture: all
-Depends: adduser, 
+Depends: adduser,
          python3-faucet (>= 1.7.0),
-Suggests: python-faucet-doc, 
+Suggests: python-faucet-doc,
           faucet,
 Description: This is a component the Faucet OpenFlow controller (Python 3)
  This is a component of the Faucet OpenFlow controller,
@@ -70,8 +70,8 @@ Description: This is a component the Faucet OpenFlow controller (Python 3)
 package: faucet-all-in-one
 Architecture: all
 Depends: faucet (>= 1.7.0),
-         gauge (= 1.7.0),
-         python3-faucet (= 1.7.0),
+         gauge (>= 1.7.0),
+         python3-faucet (>= 1.7.0),
          prometheus (>= 2.0.0),
          grafana,
 Suggests: python-faucet-doc,

--- a/debian/faucet.postinst
+++ b/debian/faucet.postinst
@@ -12,8 +12,21 @@ case "$1" in
     USER="faucet"
     GROUP="faucet"
 
-    addgroup --system ${GROUP}
-    adduser --system ${USER} --ingroup ${GROUP}
+    if ! getent group ${GROUP} >/dev/null; then
+        addgroup --system ${GROUP}
+    fi
+
+    if ! getent passwd ${USER} >/dev/null; then
+        adduser \
+            --system \
+            --disabled-login \
+            --disabled-password \
+            --home /etc/faucet \
+            --no-create-home \
+            -gecos "Faucet Network Controller" \
+            --ingroup ${GROUP} \
+            ${USER}
+    fi
 
     mkdir -p /var/log/faucet
     mkdir -p /etc/faucet

--- a/debian/gauge.postinst
+++ b/debian/gauge.postinst
@@ -12,8 +12,21 @@ case "$1" in
     USER="faucet"
     GROUP="faucet"
 
-    addgroup --system ${GROUP}
-    adduser --system ${USER} --ingroup ${GROUP}
+    if ! getent group ${GROUP} >/dev/null; then
+        addgroup --system ${GROUP}
+    fi
+
+    if ! getent passwd ${USER} >/dev/null; then
+        adduser \
+            --system \
+            --disabled-login \
+            --disabled-password \
+            --home /etc/faucet \
+            --no-create-home \
+            -gecos "Faucet Network Controller" \
+            --ingroup ${GROUP} \
+            ${USER}
+    fi
 
     mkdir -p /var/log/gauge
     mkdir -p /etc/faucet

--- a/debian/rules
+++ b/debian/rules
@@ -1,9 +1,9 @@
 #!/usr/bin/make -f
 
 # output every command that modifies files on the build system.
-export DH_VERBOSE = 1
-export DEBINSTALL = 1
+export DEBINSTALL=1
 export PYBUILD_NAME=faucet
+export PYBUILD_AFTER_INSTALL=rm -rf '{destdir}/usr/etc'
 
 %:
 	dh $@  --with python3,systemd --buildsystem=pybuild


### PR DESCRIPTION
* Makes user/group creation more robust
* Allows users to install packages that are >= 1.7.0
* Remove unwanted /usr/etc directory from python3-faucet package