### PR TITLE
Adding test-base dependeny for doing docker-in-docker hosts/testing

### DIFF
--- a/docker/base/Dockerfile.base-tests
+++ b/docker/base/Dockerfile.base-tests
@@ -112,3 +112,9 @@ RUN \
   $PIP3 $PIPDEPS && \
   $PIP ryu && \
   $PIP3 ryu
+
+# Install docker in docker...
+RUN ./setupproxy.sh && \
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add - && \
+    add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" && \
+    $AG update && $AG install docker-ce


### PR DESCRIPTION
Staging this first since it'll need to propagate through docker hub/cloud before submitting any CL to faucet code proper.

