### PR TITLE
Lldp fix

### DIFF
--- a/faucet/port.py
+++ b/faucet/port.py
@@ -130,9 +130,9 @@ class Port(Conf):
     }
 
     lldp_org_tlv_defaults_types = {
-        'oui': int,
-        'subtype': int,
-        'info': str,
+        'oui': (int, bytearray),
+        'subtype': (int, bytearray),
+        'info': (str, bytearray)
     }
 
     def __init__(self, _id, dp_id, conf=None):
@@ -181,11 +181,15 @@ class Port(Conf):
                     self._check_conf_types(org_tlv, self.lldp_org_tlv_defaults_types)
                     assert len(org_tlv) == len(self.lldp_org_tlv_defaults_types), (
                         'missing org_tlv config')
-                    try:
-                        org_tlv['info'] = bytearray.fromhex(org_tlv['info']) # pytype: disable=missing-parameter
-                    except ValueError:
-                        org_tlv['info'] = org_tlv['info'].encode('utf-8')
-                    org_tlv['oui'] = bytearray.fromhex('%6.6x' % org_tlv['oui']) # pytype: disable=missing-parameter
+                    if not isinstance(org_tlv['info'], bytearray):
+                        try:
+                            org_tlv['info'] = bytearray.fromhex(
+                                org_tlv['info']) # pytype: disable=missing-parameter
+                        except ValueError:
+                            org_tlv['info'] = org_tlv['info'].encode('utf-8')
+                    if not isinstance(org_tlv['oui'], bytearray):
+                        org_tlv['oui'] = bytearray.fromhex(
+                            '%6.6x' % org_tlv['oui']) # pytype: disable=missing-parameter
                     org_tlvs.append(org_tlv)
                 self.lldp_beacon['org_tlvs'] = org_tlvs
         if self.acl_in and self.acls_in:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -45,7 +45,7 @@ class TestConfig(unittest.TestCase):
             before_function()
         try:
             function(conf_file, LOGNAME)
-        except cp.InvalidConfigError:
+        except cp.InvalidConfigError as err:
             return False
         return True
 
@@ -1735,6 +1735,35 @@ dps:
                     port_descr: port_description
                     org_tlvs:
                         - {oui: 0x12bb, subtype: 2, info: "01406500"}
+"""
+        self.check_config_success(config, cp.dp_parser)
+
+    def test_interface_ranges_lldp(self):
+        """Verify lldp config works when using interface ranges"""
+        config = """
+vlans:
+    office:
+        vid: 100
+    guest:
+        vid: 200
+dps:
+    sw1:
+        dp_id: 0x1
+        lldp_beacon:
+            send_interval: 10
+            max_per_interval: 10
+        interface_ranges:
+            '1-2':
+                lldp_beacon:
+                    enable: True
+                    system_name: port_system
+                    org_tlvs:
+                        - {oui: 0x12bb, subtype: 2, info: "01406500"}
+        interfaces:
+            1:
+                native_vlan: office
+            2:
+                native_vlan: office
 """
         self.check_config_success(config, cp.dp_parser)
 


### PR DESCRIPTION
lldp wasnt working when you used interface_ranges because it would recast values from their default types then re-check whether they were the correct type or not.

Fix by accepting both types.