### PR TITLE
with freeradius3 tls-sockets cannot be used when in 'single server' m…

### DIFF
--- a/docker/gasket/Dockerfile.freeradius
+++ b/docker/gasket/Dockerfile.freeradius
@@ -8,14 +8,11 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y freeradius
 
-
-
 USER freerad:freerad
-
 
 EXPOSE \
     1812/udp \
     1813/udp \
     18120
 
-CMD ["freeradius", "-X"]
+CMD ["freeradius", "-fxx", "-l", "stdout"]


### PR DESCRIPTION
…ode. otherwise this is the same as '-X'

This is required by a change in the configuration, which returns the correct user attribute.