### PR TITLE
Work-around for docker users missing from system.

### DIFF
--- a/docker-compose-pi.yaml
+++ b/docker-compose-pi.yaml
@@ -19,6 +19,7 @@ services:
             context: docker/prometheus
             dockerfile: Dockerfile
         image: 'faucet/prometheus-pi:2.2.1'
+        user: 'root'
         ports:
             - '9090:9090'
         volumes:
@@ -32,6 +33,7 @@ services:
     grafana:
         restart: always
         image: 'fg2it/grafana-armhf:v5.1.0'
+        user: 'root'
         ports:
             - '3000:3000'
         volumes:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -31,6 +31,7 @@ services:
     grafana:
         restart: always
         image: 'grafana/grafana:5.1.2'
+        user: 'root'
         ports:
             - '3000:3000'
         volumes:


### PR DESCRIPTION
A number of docker images will drop back to regular user UIDs when they
start so that they don't run as root which is good. However if this UID
doesn't exist on the system the container won't start.

We will run everything as root for now with the idea that the user
should change the UID to something that exists on their system before
they run docker-compose.