### PR TITLE
Fix VLAN.to_conf() for routes and faucet_vips

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -553,7 +553,7 @@ or a name. The following attributes can be configured:
         ACLs listed first take priority over those later in the list.
     * - bgp_as
       - integer
-      - 0
+      - None
       - The local AS number to used when speaking BGP
     * - bgp_connect_mode
       - string
@@ -569,7 +569,7 @@ or a name. The following attributes can be configured:
       - The list of BGP neighbours
     * - bgp_neighbour_as
       - integer
-      - 0
+      - None
       - The AS Number for the BGP neighbours
     * - bgp_port
       - integer
@@ -593,14 +593,14 @@ or a name. The following attributes can be configured:
       - A name that can be used to refer to this vlan.
     * - proactive_arp_limit
       - integer
-      - None
+      - 2052
       - Do not proactively ARP for hosts once this value has been reached
-        (unlimited by default)
+        (set to None for unlimited)
     * - proactive_nd_limit
       - integer
-      - None
+      - 2052
       - Don't proactively discover IPv6 hosts once this value has been reached
-        (unlimited by default)
+        (set to None for unlimited)
     * - routes
       - list of routes
       - None

--- a/faucet/vlan.py
+++ b/faucet/vlan.py
@@ -476,6 +476,8 @@ class VLAN(Conf):
         if result is not None:
             if self.routes:
                 result['routes'] = [{'route': route} for route in self.routes]
+            if self.faucet_vips:
+                result['faucet_vips'] = [str(vip) for vip in self.faucet_vips]
             if 'bgp_neighbor_as' in result:
                 del result['bgp_neighbor_as']
             if 'bgp_neighbor_addresses' in result:

--- a/faucet/vlan.py
+++ b/faucet/vlan.py
@@ -218,8 +218,8 @@ class VLAN(Conf):
                         raise InvalidConfigError('Invalid IP address in route: %s' % err)
                     test_config_condition(ip_gw.version != ip_dst.version, 'ip_gw version does not match the ip_dst version')
                     self.add_route(ip_dst, ip_gw)
-            except KeyError:
-                raise InvalidConfigError('missing route config')
+            except KeyError as e:
+                raise InvalidConfigError('missing route config %s' % e)
             except TypeError:
                 raise InvalidConfigError('%s is not a valid routes value' % self.routes)
         test_config_condition(self.acl_in and self.acls_in, 'found both acl_in and acls_in, use only acls_in')
@@ -470,3 +470,14 @@ class VLAN(Conf):
         if self.is_faucet_vip(dst_ip) and self.ip_in_vip_subnet(src_ip):
             return True
         return False
+
+    def to_conf(self):
+        result = super(VLAN, self).to_conf()
+        if result is not None:
+            if self.routes:
+                result['routes'] = [{'route': route} for route in self.routes]
+            if 'bgp_neighbor_as' in result:
+                del result['bgp_neighbor_as']
+            if 'bgp_neighbor_addresses' in result:
+                del result['bgp_neighbor_addresses']
+        return result

--- a/tests/test_vlan.py
+++ b/tests/test_vlan.py
@@ -1,0 +1,68 @@
+"""Unit tests for VLAN"""
+
+import unittest
+
+from faucet.vlan import VLAN
+
+class FaucetVLANConfigTest(unittest.TestCase):
+    """Test that VLAN serialises config as it receives it"""
+
+    def setUp(self):
+        """Defines the default config - this should match the documentation"""
+
+        self.default_config = {
+            'acl_in': None,
+            'acls_in': None,
+            'bgp_as': None,
+            'bgp_connect_mode': 'both',
+            'bgp_local_address': None,
+            'bgp_neighbour_addresses': [],
+            'bgp_neighbour_as': None,
+            'bgp_port': 9179,
+            'bgp_routerid': None,
+            'bgp_server_addresses': ['0.0.0.0', '::'],
+            'description': None,
+            'faucet_mac': '0e:00:00:00:00:01',
+            'faucet_vips': [],
+            'max_hosts': 255,
+            'minimum_ip_size_check': True,
+            'proactive_arp_limit': 2052,
+            'proactive_nd_limit': 2052,
+            'routes': None,
+            'targeted_gw_resolution': False,
+            'unicast_flood': True,
+        }
+
+    def test_basic_config(self):
+        """Tests the minimal config"""
+
+        input_config = {
+            'vid': 100
+        }
+
+        expected_config = self.default_config
+        expected_config.update(input_config)
+
+        vlan = VLAN(1, 1, input_config)
+        output_config = vlan.to_conf()
+
+        self.assertEqual(output_config, expected_config)
+
+    def test_with_routes(self):
+        """Tests a config with routes"""
+
+        input_config = {
+            'routes': [
+                {'route' : {'ip_dst': '10.99.99.0/24', 'ip_gw': '10.0.0.1'}},
+                {'route' : {'ip_dst': '10.99.98.0/24', 'ip_gw': '10.0.0.99'}}
+            ],
+            'vid': 100
+        }
+
+        expected_config = self.default_config
+        expected_config.update(input_config)
+
+        vlan = VLAN(1, 1, input_config)
+        output_config = vlan.to_conf()
+
+        self.assertEqual(output_config, expected_config)

--- a/tests/test_vlan.py
+++ b/tests/test_vlan.py
@@ -66,3 +66,20 @@ class FaucetVLANConfigTest(unittest.TestCase):
         output_config = vlan.to_conf()
 
         self.assertEqual(output_config, expected_config)
+
+    def test_with_vips(self):
+        """Tests a config with virtual IPs"""
+
+        input_config = {
+            'faucet_vips': ['10.0.0.254/24'],
+            'vid': 100
+        }
+
+        expected_config = self.default_config
+        expected_config.update(input_config)
+
+        vlan = VLAN(1, 1, input_config)
+        output_config = vlan.to_conf()
+
+        self.maxDiff = None
+        self.assertEqual(output_config, expected_config)


### PR DESCRIPTION
    - VLAN.faucet_vips now serialises as a string, fixes #1928
    - VLAN route config is now correct (fixes #1927)
    - Unit tests added for VLAN config
    - Documentation updated to match defaults
    - VLAN.to_conf() no longer passes Americanised "neighbor" params
    - VLAN.check_config() passes through name of missing key

Travis build: https://travis-ci.org/samrussell/faucet/builds/377192081