### PR TITLE
Add Port unit tests

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -355,7 +355,7 @@ OFP port number ranges (eg. 1-6).
         those later in the list.
     * - description
       - string
-      - None
+      - name (which defaults to the configuration key)
       - Description, purely informational
     * - enabled
       - boolean
@@ -363,7 +363,7 @@ OFP port number ranges (eg. 1-6).
       - Allow packets to be forwarded through this port.
     * - hairpin
       - boolean
-      - True
+      - False
       - If True it allows packets arriving on this port to be output to this
         port. This is necessary to allow routing between two vlans on this
         port, or for use with a WIFI radio port.
@@ -371,6 +371,10 @@ OFP port number ranges (eg. 1-6).
       - dict
       - {}
       - Configuration block for lldp configuration
+    * - loop_protect
+      - boolean
+      - False
+      - If True, do simple loop protection on this port.
     * - max_hosts
       - integer
       - 255
@@ -393,6 +397,18 @@ OFP port number ranges (eg. 1-6).
       - integer
       - The configuration key.
       - The OFP port number for this port.
+    * - opstatus_reconf
+      - boolean
+      - True
+      - If True, FAUCET will reconfigure the pipeline based on operational status of the port.
+    * - output_only
+      - boolean
+      - False
+      - If True, no packets will be accepted from this port.
+    * - override_output_port
+      - integer
+      - None
+      - If set, packets are sent to this other port.
     * - permanent_learn
       - boolean
       - False
@@ -412,14 +428,6 @@ OFP port number ranges (eg. 1-6).
       - boolean
       - True
       - If False unicast packets will not be flooded to this port.
-    * - output_only
-      - boolean
-      - False
-      - If True, no packets will be accepted from this port.
-    * - opstatus_reconf
-      - boolean
-      - True
-      - If True, FAUCET will reconfigure the pipeline based on operational status of the port.
 
 
 Stacking (Interfaces)

--- a/tests/test_port.py
+++ b/tests/test_port.py
@@ -1,0 +1,141 @@
+"""Unit tests for Port"""
+
+import unittest
+
+from faucet.port import Port
+
+class MockVLAN(object): # pylint: disable=too-few-public-methods
+    """Mock class for VLAN so we can inject into Port"""
+
+    def __init__(self, name):
+        self.name = name
+
+class FaucetPortConfigTest(unittest.TestCase):
+    """Test that Port serialises config as it receives it"""
+
+    def setUp(self):
+        """Defines the default config - this should match the documentation"""
+
+        self.default_config = {
+            'acl_in': None,
+            'acls_in': None,
+            'description': None,
+            'enabled': True,
+            'hairpin': False,
+            'lacp': 0,
+            'lldp_beacon': {},
+            'loop_protect': False,
+            'max_hosts': 255,
+            'mirror': None,
+            # .to_conf() doesn't export name
+            'native_vlan': None,
+            'number': None,
+            'opstatus_reconf': True,
+            'output_only': False,
+            'override_output_port': None,
+            'permanent_learn': False,
+            'receive_lldp': False,
+            'stack': None,
+            'tagged_vlans': [],
+            'unicast_flood': True
+        }
+
+    def test_basic_config(self):
+        """Tests the minimal config"""
+
+        port_number = 1
+        port_key = 1
+
+        input_config = {}
+        output_config = {
+            'description': str(port_key),
+            'number': port_number
+        }
+
+        expected_config = self.default_config
+        expected_config.update(input_config)
+        expected_config.update(output_config)
+
+        port = Port(port_key, 1, input_config)
+        output_config = port.to_conf()
+
+        self.assertEqual(output_config, expected_config)
+
+    def test_config_with_port_number(self):
+        """Tests the minimal config"""
+
+        port_number = 1
+        port_key = 'port_1'
+
+        input_config = {
+            'number': port_number
+        }
+        output_config = {
+            'description': str(port_key),
+            'number': port_number
+        }
+
+        expected_config = self.default_config
+        expected_config.update(input_config)
+        expected_config.update(output_config)
+
+        port = Port(port_key, 1, input_config)
+        output_config = port.to_conf()
+
+        self.assertEqual(output_config, expected_config)
+
+    def test_config_with_vlans(self):
+        """Tests the config with tagged and native vlans"""
+
+        vlan100 = MockVLAN('v100')
+        vlan200 = MockVLAN('v200')
+        vlan300 = MockVLAN('v300')
+
+        tagged_vlans = [vlan200, vlan300]
+        native_vlan = vlan100
+
+        port_number = 1
+        port_key = 'port_1'
+
+        input_config = {
+            'number': port_number
+        }
+        output_config = {
+            'description': str(port_key),
+            'number': port_number,
+            'native_vlan': vlan100.name,
+            'tagged_vlans': [vlan200.name, vlan300.name]
+        }
+
+        expected_config = self.default_config
+        expected_config.update(input_config)
+        expected_config.update(output_config)
+
+        port = Port(port_key, 1, input_config)
+        port.native_vlan = native_vlan
+        port.tagged_vlans = tagged_vlans
+
+        output_config = port.to_conf()
+
+        self.assertEqual(output_config, expected_config)
+
+class FaucetPortMethodTest(unittest.TestCase):
+    """Test a range of methods on Port"""
+
+    def test_vlans(self):
+        """Test that the vlans() method behaves correctly"""
+
+        vlan100 = MockVLAN('v100')
+        vlan200 = MockVLAN('v200')
+        vlan300 = MockVLAN('v300')
+
+        tagged_vlans = [vlan200, vlan300]
+        native_vlan = vlan100
+
+        port = Port(1, 1, {})
+        port.native_vlan = native_vlan
+        self.assertEqual(port.vlans(), [native_vlan])
+        port.tagged_vlans = tagged_vlans
+        self.assertEqual(set(port.vlans()), set([native_vlan] + tagged_vlans))
+        port.native_vlan = None
+        self.assertEqual(set(port.vlans()), set(tagged_vlans))


### PR DESCRIPTION
Travis green - https://travis-ci.org/samrussell/faucet/builds/377565165

No functional changes, adds tests for:
- Port.to_conf()
- Port.vlans()

Docs updated with new fields and updated defaults