### PR TITLE
Grafana doesn't call this "proxy" anymore.

### DIFF
--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -107,7 +107,6 @@ source and add our first dashboard:
            Name:   Prometheus
            Type:   Prometheus
            URL:    http://localhost:9090
-           Access: proxy
 
     4. Next we want to add some dashboards so that we can later view the metrics
        from faucet.


### PR DESCRIPTION
The defaults are correct anyway so let's just remove it to avoid
confusion.