### PR TITLE
Making docker tests actually run

### DIFF
--- a/clib/mininet_test.py
+++ b/clib/mininet_test.py
@@ -357,7 +357,8 @@ def pipeline_superset_report(decoded_pcap_logs):
 
 
 def filter_test_hardware(test_obj, hw_config):
-    test_links = (test_obj.N_TAGGED + test_obj.N_UNTAGGED) * test_obj.LINKS_PER_HOST
+    test_hosts = test_obj.N_TAGGED + test_obj.N_UNTAGGED + test_obj.N_EXTENDED
+    test_links = test_hosts * test_obj.LINKS_PER_HOST
     if hw_config is not None:
         test_hardware = hw_config['hardware']
         if test_obj.NUM_DPS != 1:

--- a/docker/runtests.sh
+++ b/docker/runtests.sh
@@ -56,6 +56,9 @@ if [ "$UNITTESTS" == 1 ] ; then
     PYTHONPATH=.. ./test_coverage.sh || exit 1
 fi
 
+echo "========== Starting docker container =========="
+service docker start
+
 echo "========== Running faucet system tests =========="
 test_failures=
 export PYTHONPATH=/faucet-src


### PR DESCRIPTION
Somehow this got missed when I did the original docker PR, and so the tests weren't actually being run!  Core problem was that the "hardware" filtering logic wasn't updated, so it was filtering out the tests.
