### PR TITLE
Implementation of probe protocol for failures on stack

### DIFF
--- a/faucet/dp.py
+++ b/faucet/dp.py
@@ -358,7 +358,7 @@ configuration.
         for dp in dps:
             if dp.stack is not None:
                 stack_dps.append(dp)
-                if 'priority' in dp.stack: 
+                if 'priority' in dp.stack:
                     test_config_condition(dp.stack['priority'] <= 0, (
                         'stack priority must be > 0'))
                     test_config_condition(root_dp is not None, 'cannot have multiple stack roots')

--- a/faucet/faucet.py
+++ b/faucet/faucet.py
@@ -71,6 +71,11 @@ class EventFaucetLLDPAdvertise(event.EventBase):
     pass
 
 
+class EventFaucetStackProbe(event.EventBase):
+    """Event used to trigger periodic stack probes."""
+    pass
+
+
 class Faucet(RyuAppBase):
     """A RyuApp that implements an L2/L3 learning VLAN switch.
 
@@ -88,6 +93,7 @@ class Faucet(RyuAppBase):
         EventFaucetStateExpire: ('state_expire', 5),
         EventFaucetAdvertise: ('advertise', 5),
         EventFaucetLLDPAdvertise: ('send_lldp_beacons', 5),
+        EventFaucetStackProbe: ('probe_stack_links', 2),
     }
     logname = 'faucet'
     exc_logname = logname + '.exception'
@@ -191,6 +197,7 @@ class Faucet(RyuAppBase):
     @set_ev_cls(EventFaucetStateExpire, MAIN_DISPATCHER)
     @set_ev_cls(EventFaucetAdvertise, MAIN_DISPATCHER)
     @set_ev_cls(EventFaucetLLDPAdvertise, MAIN_DISPATCHER)
+    @set_ev_cls(EventFaucetStackProbe, MAIN_DISPATCHER)
     @kill_on_exception(exc_logname)
     def _valve_flow_services(self, ryu_event):
         """Call a method on all Valves and send any resulting flows."""

--- a/faucet/port.py
+++ b/faucet/port.py
@@ -57,6 +57,7 @@ class Port(Conf):
     dyn_last_ban_time = None
     dyn_last_lldp_beacon_time = None
     dyn_stack_current_state = STACK_STATE_DOWN
+    dyn_stack_probe_info = None
 
     defaults = {
         'number': None,
@@ -143,6 +144,7 @@ class Port(Conf):
     def __init__(self, _id, dp_id, conf=None):
         super(Port, self).__init__(_id, dp_id, conf)
         self.dyn_phys_up = False
+        self.dyn_stack_probe_info = {}
 
         # If the port is mirrored convert single attributes to a array
         if self.mirror and not isinstance(self.mirror, list):

--- a/faucet/port.py
+++ b/faucet/port.py
@@ -48,6 +48,7 @@ class Port(Conf):
     op_status_reconf = None
     receive_lldp = None
     override_output_port = None
+    max_lldp_lost = None
 
     dyn_learn_ban_count = 0
     dyn_phys_up = False
@@ -97,6 +98,8 @@ class Port(Conf):
         # If True, receive LLDP on this port.
         'override_output_port': None,
         # If set, packets are sent to this other port.
+        'max_lldp_lost': 3,
+        # threshold before marking a stack port as down
     }
 
     defaults_types = {

--- a/faucet/port.py
+++ b/faucet/port.py
@@ -274,3 +274,35 @@ class Port(Conf):
         if self.mirror is not None:
             return [valve_of.output_port(mirror_port) for mirror_port in self.mirror]
         return []
+
+    def is_stack_up(self):
+        """Return True if port is in UP state."""
+        return self.dyn_stack_current_state == STACK_STATE_UP
+
+    def is_stack_down(self):
+        """Return True if port is in DOWN state."""
+        return self.dyn_stack_current_state == STACK_STATE_DOWN
+
+    def is_stack_admin_down(self):
+        """Return True if port is in ADMIN_DOWN state."""
+        return self.dyn_stack_current_state == STACK_STATE_ADMIN_DOWN
+
+    def is_stack_init(self):
+        """Return True if port is in INIT state."""
+        return self.dyn_stack_current_state == STACK_STATE_DOWN
+
+    def stack_up(self):
+        """Change the current stack state to UP."""
+        self.dyn_stack_current_state = STACK_STATE_UP
+
+    def stack_down(self):
+        """Change the current stack state to DOWN."""
+        self.dyn_stack_current_state = STACK_STATE_DOWN
+
+    def stack_admin_down(self):
+        """Change the current stack state to ADMIN_DOWN."""
+        self.dyn_stack_current_state = STACK_STATE_ADMIN_DOWN
+
+    def stack_init(self):
+        """Change the current stack state to INIT_DOWN."""
+        self.dyn_stack_current_state = STACK_STATE_INIT

--- a/faucet/port.py
+++ b/faucet/port.py
@@ -289,7 +289,7 @@ class Port(Conf):
 
     def is_stack_init(self):
         """Return True if port is in INIT state."""
-        return self.dyn_stack_current_state == STACK_STATE_DOWN
+        return self.dyn_stack_current_state == STACK_STATE_INIT
 
     def stack_up(self):
         """Change the current stack state to UP."""

--- a/faucet/port.py
+++ b/faucet/port.py
@@ -56,6 +56,7 @@ class Port(Conf):
     dyn_lacp_updated_time = None
     dyn_last_ban_time = None
     dyn_last_lldp_beacon_time = None
+    dyn_stack_current_state = STACK_STATE_DOWN
 
     defaults = {
         'number': None,

--- a/faucet/port.py
+++ b/faucet/port.py
@@ -19,6 +19,10 @@
 from faucet.conf import Conf, InvalidConfigError, test_config_condition
 from faucet import valve_of
 
+STACK_STATE_ADMIN_DOWN = 0
+STACK_STATE_INIT = 1
+STACK_STATE_DOWN = 2
+STACK_STATE_UP = 3
 
 class Port(Conf):
     """Stores state for ports, including the configuration."""

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -510,6 +510,11 @@ class Valve(object):
         ofmsgs = [self._send_lldp_beacon_on_port(port, now) for port in send_ports]
         return ofmsgs
 
+    def probe_stack_links(self, now):
+        """Called periodically to verify the state of stack ports."""
+        # TODO: implement the verification logic
+        pass
+
     def datapath_connect(self, now, discovered_ports):
         """Handle Ryu datapath connection event and provision pipeline.
 

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -467,6 +467,7 @@ class Valve(object):
             (tlv['oui'], tlv['subtype'], tlv['info'])
             for tlv in lldp_beacon['org_tlvs']]
         org_tlvs.extend(valve_packet.faucet_lldp_tlvs(self.dp))
+        org_tlvs.extend(valve_packet.faucet_lldp_stack_state_tlvs(self.dp, port))
         # if the port doesn't have a system name set, default to
         # using the system name from the dp
         if lldp_beacon['system_name'] is None:

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -827,7 +827,7 @@ class Valve(object):
                 ofmsgs.append(valve_of.packetout(pkt_meta.port.number, pkt.data))
         return ofmsgs
 
-    def lldp_handler(self, pkt_meta):
+    def lldp_handler(self, now, pkt_meta):
         """Handle an LLDP packet.
 
         Args:
@@ -1089,7 +1089,7 @@ class Valve(object):
                 lacp_ofmsgs = self.lacp_handler(now, pkt_meta)
                 if lacp_ofmsgs:
                     return lacp_ofmsgs
-            self.lldp_handler(pkt_meta)
+            self.lldp_handler(now, pkt_meta)
             # TODO: verify stacking connectivity using LLDP (DPID, port)
             # TODO: verify LLDP message (e.g. org-specific authenticator TLV)
             return ofmsgs

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -31,7 +31,7 @@ from faucet import valve_packet
 from faucet import valve_route
 from faucet import valve_util
 
-from faucet.port import STACK_STATE_INIT, STACK_STATE_UP
+from faucet.port import STACK_STATE_INIT, STACK_STATE_UP, STACK_STATE_DOWN
 
 
 class ValveLogger(object):
@@ -546,6 +546,9 @@ class Valve(object):
                         remote_port_state in [STACK_STATE_UP, STACK_STATE_INIT]):
                     port.stack_up()
                     self.logger.info('Stack port %u UP' % port.number)
+                elif port.is_stack_up() and remote_port_state == STACK_STATE_DOWN:
+                    port.stack_down()
+                    self.logger.info('Stack port %u DOWN. Remote port is down' % port.number)
 
     def datapath_connect(self, now, discovered_ports):
         """Handle Ryu datapath connection event and provision pipeline.

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -517,7 +517,7 @@ class Valve(object):
         if not self.dp.stack:
             return
         for port in self.dp.stack_ports:
-            if not port.running() or port.is_stack_admin_down():
+            if port.is_stack_admin_down():
                 continue
             stack_probe_info = port.dyn_stack_probe_info
             last_seen_lldp_time = stack_probe_info.get('last_seen_lldp_time', None)

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -839,6 +839,10 @@ class Valve(object):
             if lldp_pkt:
                 self.logger.info('LLDP from port %u: %s' % (
                     pkt_meta.port.number, lldp_pkt))
+                remote_dp_id = None
+                remote_dp_name = None
+                remote_port_id = None
+                remote_port_state = None
                 port_id_tlvs = [
                     tlv for tlv in lldp_pkt.tlvs
                     if tlv.tlv_type == valve_packet.lldp.LLDP_TLV_PORT_ID]
@@ -853,6 +857,25 @@ class Valve(object):
                     remote_port_id = int(port_id_tlvs[0].port_id)
                     self.logger.info('FAUCET LLDP from %s, port %u' % (
                         valve_util.dpid_log(remote_dp_id), remote_port_id))
+                # update stack port info
+                port_state_tlvs = [
+                    tlv for tlv in faucet_tlvs
+                    if tlv.subtype == valve_packet.LLDP_FAUCET_STACK_STATE]
+                if port_state_tlvs:
+                    remote_port_state = int(port_state_tlvs[0].info)
+                dp_name_tlvs = [
+                    tlv for tlv in lldp_pkt.tlvs
+                    if tlv.tlv_type == valve_packet.lldp.LLDP_TLV_SYSTEM_NAME]
+                if dp_name_tlvs:
+                    remote_dp_name = dp_name_tlvs[0].system_name.decode('utf-8')
+                port = pkt_meta.port
+                if port.stack:
+                    port.dyn_stack_probe_info['last_seen_lldp_time'] = now
+                    port.dyn_stack_probe_info['remote_dp_id'] = remote_dp_id
+                    port.dyn_stack_probe_info['remote_dp_name'] = remote_dp_name
+                    port.dyn_stack_probe_info['remote_port_id'] = remote_port_id
+                    port.dyn_stack_probe_info['remote_port_state'] = remote_port_state
+
     @staticmethod
     def _control_plane_handler(now, pkt_meta, route_manager):
         """Handle a packet probably destined to FAUCET's route managers.

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -485,7 +485,7 @@ class Valve(object):
 
     def _lldp_beacon_ports(self, now):
         """Return list of ports to send LLDP packets; stacked ports always send LLDP."""
-        priority_ports = set([port for port in self.dp.stack_ports if port.running])
+        priority_ports = set([port for port in self.dp.stack_ports if port.running()])
         cutoff_beacon_time = now - self.dp.lldp_beacon['send_interval']
         nonpriority_ports = set([
             port for port in self.dp.lldp_beacon_ports
@@ -517,7 +517,7 @@ class Valve(object):
         if not self.dp.stack:
             return
         for port in self.dp.stack_ports:
-            if not port.running or port.is_stack_admin_down():
+            if not port.running() or port.is_stack_admin_down():
                 continue
             stack_probe_info = port.dyn_stack_probe_info
             last_seen_lldp_time = stack_probe_info.get('last_seen_lldp_time', None)

--- a/faucet/valve_packet.py
+++ b/faucet/valve_packet.py
@@ -51,6 +51,7 @@ IPV6_ALL_NODES = ipaddress.IPv6Address(btos('ff02::1'))
 IPV6_MAX_HOP_LIM = 255
 
 LLDP_FAUCET_DP_ID = 1
+LLDP_FAUCET_STACK_STATE = 2
 
 
 def ipv4_parseable(ip_header_data):
@@ -258,6 +259,19 @@ def faucet_lldp_tlvs(dp):
     tlvs = []
     tlvs.append(
         (faucet_oui(dp.faucet_dp_mac), LLDP_FAUCET_DP_ID, str(dp.dp_id).encode('utf-8')))
+    return tlvs
+
+
+def faucet_lldp_stack_state_tlvs(dp, port):
+    """Return a LLDP TLV for state of a stack port."""
+    tlvs = []
+    if not port.stack:
+        return []
+    tlvs.append(
+        (
+            faucet_oui(dp.faucet_dp_mac),
+            LLDP_FAUCET_STACK_STATE,
+            str(port.dyn_stack_current_state).encode('utf-8')))
     return tlvs
 
 

--- a/tests/test_valve.py
+++ b/tests/test_valve.py
@@ -287,7 +287,9 @@ def build_pkt(pkt):
     elif 'chassis_id' in pkt and 'port_id' in pkt:
         ethertype = ether.ETH_TYPE_LLDP
         return valve_packet.lldp_beacon(
-            pkt['eth_src'], pkt['chassis_id'], str(pkt['port_id']), 1)
+            pkt['eth_src'], pkt['chassis_id'], str(pkt['port_id']), 1,
+            org_tlvs=pkt.get('org_tlvs', None),
+            system_name=pkt.get('system_name', None))
     assert ethertype is not None, pkt
     if 'vid' in pkt:
         tpid = ether.ETH_TYPE_8021Q
@@ -1461,6 +1463,70 @@ class ValveEdgeStackTestCase(ValveTestBases.ValveTestSmall):
                 'eth_src': self.P1_V300_MAC
             }]
         self.verify_flooding(matches)
+
+
+class ValveStackProbeTestCase(ValveTestBases.ValveTestSmall):
+    """Test stack link probing."""
+
+    CONFIG = """
+dps:
+    s1:
+%s
+        stack:
+            priority: 1
+        interfaces:
+            1:
+                stack:
+                    dp: s2
+                    port: 1
+            2:
+                native_vlan: v100
+    s2:
+        hardware: 'Open vSwitch'
+        dp_id: 0x2
+        lldp_beacon:
+            send_interval: 5
+            max_per_interval: 1
+        interfaces:
+            1:
+                stack:
+                    dp: s1
+                    port: 1
+            2:
+                native_vlan: v100
+vlans:
+    v100:
+        vid: 100
+    """ % DP1_CONFIG
+
+    def setUp(self):
+        self.setup_valve(self.CONFIG)
+
+    def rcv_lldp(self, other_dp, other_port):
+        tlvs = []
+        tlvs.extend(valve_packet.faucet_lldp_tlvs(other_dp))
+        tlvs.extend(valve_packet.faucet_lldp_stack_state_tlvs(other_dp, other_port))
+        self.rcv_packet(1, 0, {
+            'eth_src': FAUCET_MAC,
+            'eth_dst': lldp.LLDP_MAC_NEAREST_BRIDGE,
+            'port_id': other_port.number,
+            'chassis_id': FAUCET_MAC,
+            'system_name': other_dp.name,
+            'org_tlvs': tlvs})
+        self.valve.probe_stack_links(time.time())
+
+    def test_stack_probe(self):
+        """Test probing works correctly."""
+        stack_port = self.valve.dp.ports[1]
+        other_dp = self.valves_manager.valves[2].dp
+        other_port = other_dp.ports[1]
+        for change_func, check_func in [
+                ('stack_init', 'is_stack_init'),
+                ('stack_up', 'is_stack_up'),
+                ('stack_down', 'is_stack_down')]:
+            getattr(other_port, change_func)()
+            self.rcv_lldp(other_dp, other_port)
+            self.assertTrue(getattr(stack_port, check_func)())
 
 
 class ValveGroupRoutingTestCase(ValveTestBases.ValveTestSmall):


### PR DESCRIPTION
The protocol will be able to detect wrong cabling, unidirection, and link broken. 
No handling of failures for the moment. 
It takes 2 intervals to detect if a link is working, 3 intervals (configurable) to confirm a link has broken.
The interval can be configured by lldp_beacon send_interval. However, the smallest value can be 5 seconds (the hardcoded interval for send_lldp_beacon service).
Next step to handle failures, including root bridge failure.