### PR TITLE
Prep methods for handling stack events

### DIFF
--- a/faucet/faucet.py
+++ b/faucet/faucet.py
@@ -266,13 +266,15 @@ class Faucet(RyuAppBase):
         Args:
             ryu_event (ryu.controller.ofp_event.Event)
         """
+        now = time.time()
         valve, ryu_dp, _ = self._get_valve(ryu_event)
         if valve is None:
             return
         discovered_up_ports = [
             port.port_no for port in list(ryu_dp.ports.values())
             if valve_of.port_status_from_state(port.state) and not valve_of.ignore_port(port.port_no)]
-        self._send_flow_msgs(valve, valve.datapath_connect(time.time(), discovered_up_ports))
+        self._send_flow_msgs(valve, valve.datapath_connect(now, discovered_up_ports))
+        self.valves_manager.stack_topo_change(now, valve)
 
     @kill_on_exception(exc_logname)
     def _datapath_disconnect(self, ryu_event):
@@ -285,6 +287,7 @@ class Faucet(RyuAppBase):
         if valve is None:
             return
         valve.datapath_disconnect()
+        self.valves_manager.stack_topo_change(time.time(), valve)
 
     @set_ev_cls(ofp_event.EventOFPDescStatsReply, MAIN_DISPATCHER) # pylint: disable=no-member
     @kill_on_exception(exc_logname)

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -565,6 +565,10 @@ class Valve(object):
                     elif port.is_stack_up() and remote_port_state == STACK_STATE_DOWN:
                         self.logger.error('Stack %s DOWN. Remote port is down' % port)
             next_state()
+            if port.is_stack_up():
+                self.flood_manager.update_stack_topo(True, self.dp, port)
+            else:
+                self.flood_manager.update_stack_topo(False, self.dp, port)
 
     def datapath_connect(self, now, discovered_up_ports):
         """Handle Ryu datapath connection event and provision pipeline.

--- a/faucet/valve_flood.py
+++ b/faucet/valve_flood.py
@@ -201,6 +201,10 @@ class ValveFloodManager(object):
             return self._build_group_flood_rules(vlan, modify, command)
         return self._build_multiout_flood_rules(vlan, command)
 
+    def update_stack_topo(self, event, dp, port=None): # pylint: disable=unused-argument
+        """Update the stack topology. It has nothing to do for non-stacking DPs."""
+        return
+
     @staticmethod
     def edge_learn_port(_other_valves, pkt_meta):
         """Possibly learn a host on a port.
@@ -425,6 +429,32 @@ class ValveFloodStackManager(ValveFloodManager):
                     if entry.port.stack is None:
                         return other_valve.dp
         return None
+
+    def update_stack_topo(self, event, dp, port=None):
+        """Update the stack topo according to the event."""
+
+        def _stack_topo_up_dp(dp): # pylint: disable=unused-argument
+            pass
+
+        def _stack_topo_down_dp(dp): # pylint: disable=unused-argument
+            pass
+
+        def _stack_topo_up_port(dp, port): # pylint: disable=unused-argument
+            pass
+
+        def _stack_topo_down_port(dp, port): # pylint: disable=unused-argument
+            pass
+
+        if port:
+            if event:
+                _stack_topo_up_port(dp, port)
+            else:
+                _stack_topo_down_port(dp, port)
+        else:
+            if event:
+                _stack_topo_up_dp(dp)
+            else:
+                _stack_topo_down_dp(dp)
 
     def edge_learn_port(self, other_valves, pkt_meta):
         """Possibly learn a host on a port.

--- a/faucet/valves_manager.py
+++ b/faucet/valves_manager.py
@@ -162,3 +162,11 @@ class ValvesManager(object):
         if ofmsgs:
             self.send_flows_to_dp_by_id(valve, ofmsgs)
             valve.update_metrics(now, pkt_meta.port, rate_limited=True)
+
+    def stack_topo_change(self, now, valve):
+        """Update stack topo of all other Valves affected by the event on this Valve."""
+        for other_valve in list(self.valves.values()):
+            if valve == other_valve or not valve.dp.running:
+                continue
+            other_valve.flood_manager.update_stack_topo(valve.dp.running, valve)
+            # TODO: rebuild flood rules


### PR DESCRIPTION
The purpose is to have Valves to update its stack topo upon network events (dp connect, disconect, stack port up/down). No update codes are implemented in this PR.
This prep is for making flood rule calculation dynamic to support root and other failures.