### PR TITLE
Reset the hardware type to 'Open vSwitch' for the virtual switch

### DIFF
--- a/tests/faucet_mininet_test_unit.py
+++ b/tests/faucet_mininet_test_unit.py
@@ -5347,6 +5347,9 @@ class FaucetStringOfDPTest(FaucetTest):
             }
             interfaces_config = dp_config['interfaces']
 
+            if dpid != hw_dpid:
+                dp_config['hardware'] = 'Open vSwitch'
+
             port = 1
             for _ in range(n_tagged):
                 interfaces_config[port] = {


### PR DESCRIPTION
If we are running the test FaucetStackStringOfDPUntaggedTest with a hardware type that is sending
a table feature request (TFM) to start, the test will fail with an error because a table feature request 
will be sent as well to the virtual switch which could not handle this request.
The issue is coming from the fact that all the switches in the faucet yaml file will use the same hardware type instead of only the real switch should use the hardware type and the virtual switch should use the 
'Open vSwitch' type.