### PR TITLE
Add experimental API test app back to unit tests.

### DIFF
--- a/tests/run_unit_tests.sh
+++ b/tests/run_unit_tests.sh
@@ -3,5 +3,6 @@
 MINCOVERAGE=93
 
 coverage erase || exit 1
-for i in unit/test_*py ; do PYTHONPATH=.. coverage run -a --source ../faucet $i || exit 1 ; done
+
+for i in  unit/test_*py integration/experimental_api_test_app.py; do PYTHONPATH=.. coverage run -a --source ../faucet $i || exit 1 ; done
 coverage report -m --fail-under=$MINCOVERAGE || exit 1


### PR DESCRIPTION
Also restores fail-under=$MINCOVERAGE
    
integration/experimental_api_test_app.py is used in the integration
tests, but previously it was being run as a unit test as well.
    
Moving it into integration/ removed it from the unit tests and
reduced coverage slightly.
    
The test appears to be mostly a no-op at this point, but invoking
it from run_unit_tests.sh should reduce the coverage drop (though
there still seems to be a drop on test_vlan.py?)

With luck this will fix the coverage issue.