### PR TITLE
updates versions of influxdb and grafana

### DIFF
--- a/docker-compose-pi.yaml
+++ b/docker-compose-pi.yaml
@@ -2,7 +2,7 @@ version: '2'
 services:
     influxdb:
         restart: always
-        image: 'arm32v7influxdb:1.6'
+        image: 'arm32v7/influxdb:1.6'
         ports:
             - '8086'
             - '8083'

--- a/docker-compose-pi.yaml
+++ b/docker-compose-pi.yaml
@@ -2,7 +2,7 @@ version: '2'
 services:
     influxdb:
         restart: always
-        image: 'hypriot/rpi-influxdb:latest'
+        image: 'arm32v7influxdb:1.6'
         ports:
             - '8086'
             - '8083'

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -30,7 +30,7 @@ services:
 
     grafana:
         restart: always
-        image: 'grafana/grafana:5.2.0'
+        image: 'grafana/grafana:5.2.1'
         user: 'root'
         ports:
             - '3000:3000'

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '2'
 services:
     influxdb:
         restart: always
-        image: 'influxdb:1.3-alpine'
+        image: 'influxdb:1.6-alpine'
         ports:
             - '8086'
             - '8083'


### PR DESCRIPTION
brings influxdb up to 1.6 for both amd64 and arm compose files.  opted away from hypriot's image as it's now archived and hasn't been updated in a year (https://github.com/hypriot/rpi-influxdb).

brings grafana up to the latest for amd64, no newer version for arm yet.