### PR TITLE
Missed call to self.dp.reset_refs() causes VLAN associations to be lo…

### DIFF
--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -132,6 +132,7 @@ class Valve(object):
         self._route_manager_by_eth_type = {}
         self._port_highwater = {}
 
+        self.dp.reset_refs()
         for vlan_vid in list(self.dp.vlans.keys()):
             self._port_highwater[vlan_vid] = {}
             for port_number in list(self.dp.ports.keys()):
@@ -1326,7 +1327,6 @@ class Valve(object):
             ofmsgs.extend(self.ports_delete(changed_ports))
 
         self.dp = new_dp
-        self.dp.reset_refs()
         self.dp_init()
 
         if changed_vlans:

--- a/tests/integration/mininet_tests.py
+++ b/tests/integration/mininet_tests.py
@@ -3801,32 +3801,30 @@ vlans:
 
     CONFIG = """
         interfaces:
-            b1:
-                number: %(port_1)d
+            %(port_1)d:
+                name: b1
                 native_vlan: 100
                 description: "b1"
-            b2:
-                number: %(port_2)d
+            %(port_2)d:
+                name: b2
                 native_vlan: 100
                 description: "b2"
             %(port_3)d:
                 description: "b3"
-                native_vlan: 100
-            %(port_4)d:
-                description: "b4"
                 output_only: True
 """
 
     def test_untagged(self):
-        first_host, second_host, _third_host, mirror_host = self.net.hosts
+        first_host, second_host, mirror_host = self.net.hosts[:3]
         ping_pairs = (
             (first_host, second_host),
             (second_host, first_host))
         self.flap_all_switch_ports()
         self.change_port_config(
-            self.port_map['port_4'], 'mirror', ['b1', 'b2'],
-            restart=True, cold_start=False, hup=True)
-        self.verify_ping_mirrored_multi(ping_pairs, mirror_host, both_mirrored=True)
+            self.port_map['port_3'], 'mirror', ['b1', 'b2'],
+            restart=True, cold_start=True, hup=True)
+        self.verify_ping_mirrored_multi(
+            ping_pairs, mirror_host, both_mirrored=True)
 
 
 class FaucetUntaggedMultiMirrorSepTest(FaucetUntaggedTest):


### PR DESCRIPTION
…st if all ports change.