### PR TITLE
configuration inconsistency fix #1836

### DIFF
--- a/faucet/vlan.py
+++ b/faucet/vlan.py
@@ -253,16 +253,19 @@ class VLAN(Conf):
                 'Must be as many BGP neighbor addresses as BGP server addresses'))
 
         if self.routes:
+            test_config_condition(not isinstance(self.routes, list), 'invalid VLAN routes format')
             try:
                 self.routes = [route['route'] for route in self.routes]
             except TypeError:
                 raise InvalidConfigError('%s is not a valid routes value' % self.routes)
+            except KeyError:
+                pass
             for route in self.routes:
-                try:
-                    ip_gw = self._check_ip_str(route['ip_gw'])
-                    ip_dst = self._check_ip_str(route['ip_dst'], ip_method=ipaddress.ip_network)
-                except KeyError as err:
-                    raise InvalidConfigError('missing route config %s' % err)
+                test_config_condition(not isinstance(route, dict), 'invalid VLAN route format')
+                test_config_condition('ip_gw' not in route, 'missing ip_gw in VLAN route')
+                test_config_condition('ip_dst' not in route, 'missing ip_dst in VLAN route')
+                ip_gw = self._check_ip_str(route['ip_gw'])
+                ip_dst = self._check_ip_str(route['ip_dst'], ip_method=ipaddress.ip_network)
                 test_config_condition(
                     ip_gw.version != ip_dst.version,
                     'ip_gw version does not match the ip_dst version')

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -2101,6 +2101,57 @@ acls:
 """
         self.check_config_success(config, cp.dp_parser)
 
+    def test_vlan_route_dictionary_valid(self):
+        """Test new vlan route format as dictionary is valid"""
+        config = """
+vlans:
+    office:
+        vid: 100
+        routes:
+            - {ip_gw: '10.0.0.1', ip_dst: '10.99.99.0/24'}
+dps:
+    sw1:
+        dp_id: 0x1
+        interfaces:
+            1:
+                native_vlan: office
+"""
+        self.check_config_success(config, cp.dp_parser)
+
+    def test_vlan_route_missing_value_invalid(self):
+        """Test new vlan route format fails when missing value"""
+        config = """
+vlans:
+    office:
+        vid: 100
+        routes:
+            - {}
+dps:
+    sw1:
+        dp_id: 0x1
+        interfaces:
+            1:
+                native_vlan: office
+"""
+        self.check_config_failure(config, cp.dp_parser)
+
+    def test_vlan_route_values_invalid(self):
+        """Test new vlan route format fails when values are invalid"""
+        config = """
+vlans:
+    office:
+        vid: 100
+        routes:
+            - {ip_gw: [],ip_gw: 5.5}
+dps:
+    sw1:
+        dp_id: 0x1
+        interfaces:
+            1:
+                native_vlan: office
+"""
+        self.check_config_failure(config, cp.dp_parser)
+
 
 if __name__ == "__main__":
     unittest.main() # pytype: disable=module-attr


### PR DESCRIPTION
allows vlan routes to be configured like org_tlvs as suggested in #1836:
```
        routes:
            - {ip_gw: '10.0.0.1', ip_dst: '10.99.99.0/24'}
```

