### PR TITLE
Update stack-graph according to linkstate events

### DIFF
--- a/faucet/dp.py
+++ b/faucet/dp.py
@@ -388,8 +388,8 @@ configuration.
             graph.add_edge(
                 edge_a_dp.name, edge_z_dp.name,
                 key=edge_name, port_map=edge_attr)
-        else:
-            graph.remove_edge(edge_a_dp.name, edge_z_dp.name)
+        elif (edge_a_dp.name, edge_z_dp.name, edge_name) in graph.edges:
+            graph.remove_edge(edge_a_dp.name, edge_z_dp.name, edge_name)
 
         return edge_name
 

--- a/faucet/dp.py
+++ b/faucet/dp.py
@@ -349,8 +349,9 @@ configuration.
         if port.lldp_beacon_enabled():
             self.lldp_beacon_ports.append(port)
 
-    def resolve_stack_topology(self, dps):
-        """Resolve inter-DP config for stacking."""
+    @staticmethod
+    def modify_stack_topology(graph, dp, port, add=True):
+        """Add/remove an edge to the stack graph which originates from this dp and port."""
 
         def canonical_edge(dp, port):
             peer_dp = port.stack['dp']
@@ -377,6 +378,33 @@ configuration.
                 'dp_a': edge_a_dp, 'port_a': edge_a_port,
                 'dp_z': edge_z_dp, 'port_z': edge_z_port}
 
+        edge = canonical_edge(dp, port)
+        edge_a, edge_z = edge
+        edge_name = make_edge_name(edge_a, edge_z)
+        edge_attr = make_edge_attr(edge_a, edge_z)
+        edge_a_dp, _ = edge_a
+        edge_z_dp, _ = edge_z
+        if add:
+            graph.add_edge(
+                edge_a_dp.name, edge_z_dp.name,
+                key=edge_name, port_map=edge_attr)
+        else:
+            graph.remove_edge(edge_a_dp.name, edge_z_dp.name)
+
+        return edge_name
+
+    @classmethod
+    def add_stack_link(cls, graph, dp, port):
+        """Add a stack link to the stack graph."""
+        return cls.modify_stack_topology(graph, dp, port)
+
+    @classmethod
+    def remove_stack_link(cls, graph, dp, port):
+        """Remove a stack link to the stack graph."""
+        return cls.modify_stack_topology(graph, dp, port, False)
+
+    def resolve_stack_topology(self, dps):
+        """Resolve inter-DP config for stacking."""
         root_dp = None
         stack_dps = []
         for dp in dps:
@@ -402,18 +430,10 @@ configuration.
             if dp.stack_ports:
                 graph.add_node(dp.name)
                 for port in dp.stack_ports:
-                    edge = canonical_edge(dp, port)
-                    edge_a, edge_z = edge
-                    edge_name = make_edge_name(edge_a, edge_z)
-                    edge_attr = make_edge_attr(edge_a, edge_z)
-                    edge_a_dp, _ = edge_a
-                    edge_z_dp, _ = edge_z
+                    edge_name = self.add_stack_link(graph, dp, port)
                     if edge_name not in edge_count:
                         edge_count[edge_name] = 0
                     edge_count[edge_name] += 1
-                    graph.add_edge(
-                        edge_a_dp.name, edge_z_dp.name,
-                        key=edge_name, port_map=edge_attr)
         if graph.size():
             for edge_name, count in list(edge_count.items()):
                 test_config_condition(count != 2, '%s defined only in one direction' % edge_name)

--- a/faucet/faucet.py
+++ b/faucet/faucet.py
@@ -273,7 +273,6 @@ class Faucet(RyuAppBase):
             port.port_no for port in list(ryu_dp.ports.values())
             if valve_of.port_status_from_state(port.state) and not valve_of.ignore_port(port.port_no)]
         self._send_flow_msgs(valve, valve.datapath_connect(now, discovered_up_ports))
-        self.valves_manager.stack_topo_change(now, valve)
 
     @kill_on_exception(exc_logname)
     def _datapath_disconnect(self, ryu_event):
@@ -286,7 +285,6 @@ class Faucet(RyuAppBase):
         if valve is None:
             return
         valve.datapath_disconnect()
-        self.valves_manager.stack_topo_change(time.time(), valve)
 
     @set_ev_cls(ofp_event.EventOFPDescStatsReply, MAIN_DISPATCHER) # pylint: disable=no-member
     @kill_on_exception(exc_logname)

--- a/faucet/faucet.py
+++ b/faucet/faucet.py
@@ -207,7 +207,8 @@ class Faucet(RyuAppBase):
         """Call a method on all Valves and send any resulting flows."""
         self.valves_manager.valve_flow_services(
             time.time(),
-            self._VALVE_SERVICES[type(ryu_event)][0])
+            self._VALVE_SERVICES[type(ryu_event)][0],
+            isinstance(ryu_event, EventFaucetStackLinkStates))
 
     def get_config(self):
         """FAUCET experimental API: return config for all Valves."""

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -573,8 +573,11 @@ class Valve:
         port_labels = dict(self.base_prom_labels, port=port.number)
         self.metrics.port_stack_state.labels( # pylint: disable=no-member
             **port_labels).set(port.dyn_stack_current_state)
-        port_stack_up = port.is_stack_up()
-        self.flood_manager.update_stack_topo(port_stack_up, self.dp, port)
+        if port.is_stack_up() or port.is_stack_down():
+            port_stack_up = port.is_stack_up()
+            self.flood_manager.update_stack_topo(port_stack_up, self.dp, port)
+            # mark the stack status to inform other DPs
+            self.dp.stack['has_changed'] = True
 
     def update_stack_link_states(self, now):
         """Called periodically to verify the state of stack ports."""

--- a/faucet/valve_flood.py
+++ b/faucet/valve_flood.py
@@ -464,16 +464,21 @@ class ValveFloodStackManager(ValveFloodManager):
         """Update the stack topo according to the event."""
 
         def _stack_topo_up_dp(_dp): # pylint: disable=invalid-name
-            pass
+            for port in [port for port in _dp.stack_ports]:
+                if port.is_stack_up():
+                    _stack_topo_up_port(_dp, port)
+                else:
+                    _stack_topo_down_port(_dp, port)
 
         def _stack_topo_down_dp(_dp): # pylint: disable=invalid-name
-            pass
+            for port in [port for port in _dp.stack_ports]:
+                _stack_topo_down_port(_dp, port)
 
         def _stack_topo_up_port(_dp, _port): # pylint: disable=invalid-name
-            pass
+            _dp.add_stack_link(self.stack['graph'], _dp, _port)
 
         def _stack_topo_down_port(_dp, _port): # pylint: disable=invalid-name
-            pass
+            _dp.remove_stack_link(self.stack['graph'], _dp, _port)
 
         if port:
             if event:
@@ -485,6 +490,7 @@ class ValveFloodStackManager(ValveFloodManager):
                 _stack_topo_up_dp(dp)
             else:
                 _stack_topo_down_dp(dp)
+        return True
 
     def edge_learn_port(self, other_valves, pkt_meta):
         """Possibly learn a host on a port.

--- a/faucet/valves_manager.py
+++ b/faucet/valves_manager.py
@@ -152,6 +152,9 @@ class ValvesManager:
             ofmsgs = getattr(valve, valve_service)(now)
             if ofmsgs:
                 self.send_flows_to_dp_by_id(valve, ofmsgs)
+            if valve.dp.stack and valve.dp.stack.get('has_changed'):
+                self.stack_topo_change(now, valve)
+                valve.dp.stack['has_changed'] = False
 
     def _other_running_valves(self, valve):
         return [other_valve for other_valve in list(self.valves.values())
@@ -172,9 +175,3 @@ class ValvesManager:
         if ofmsgs:
             self.send_flows_to_dp_by_id(valve, ofmsgs)
             valve.update_metrics(now, pkt_meta.port, rate_limited=True)
-
-    def stack_topo_change(self, _now, valve):
-        """Update stack topo of all other Valves affected by the event on this Valve."""
-        for other_valve in self._other_running_valves(valve):
-            other_valve.flood_manager.update_stack_topo(valve.dp.dyn_running, valve)
-            # TODO: rebuild flood rules

--- a/tests/integration/mininet_tests.py
+++ b/tests/integration/mininet_tests.py
@@ -5315,7 +5315,7 @@ class FaucetStringOfDPTest(FaucetTest):
                         'priority': 1
                     }
                 for peer_dp in peer_dps:
-                    if ((first_dp and peer_dp != dpid_count - 1) or second_dp
+                    if (dpid_count <=2 or (first_dp and peer_dp != dpid_count - 1) or second_dp
                             or (not end_dp and peer_dp > i)):
                         peer_stack_port_base = first_stack_port
                     else:
@@ -5568,6 +5568,79 @@ class FaucetStackStringOfDPUntaggedTest(FaucetStringOfDPTest):
         """All untagged hosts in stack topology can reach each other."""
         self.verify_stack_hosts()
         self.verify_no_cable_errors()
+
+
+class FaucetStackRingOfDPTest(FaucetStringOfDPTest):
+
+    NUM_DPS = 3
+    NUM_HOSTS = 2
+
+    def setUp(self): # pylint: disable=invalid-name
+        super(FaucetStackRingOfDPTest, self).setUp()
+        self.build_net(
+            stack=True,
+            n_dps=self.NUM_DPS,
+            n_untagged=self.NUM_HOSTS,
+            untagged_vid=self.VID,
+            switch_to_switch_links=2,
+            stack_ring=True)
+        self.start_net()
+        self.first_host = self.net.hosts[0]
+        self.second_host = self.net.hosts[1]
+        self.fifth_host = self.net.hosts[self.NUM_HOSTS + self.NUM_DPS - 1]
+        self.last_host = self.net.hosts[self.NUM_HOSTS + self.NUM_DPS]
+
+    def wait_for_stack_port_status(self, dpid, port_no, status, timeout=25):
+        controller = self._get_controller()
+        count = 0
+        for _ in range(timeout):
+            count = int(controller.cmd('grep -c "%s. Stack Port %s.%s" %s' % (
+                        dpid, port_no, status, self.env['faucet']['FAUCET_LOG'])))
+            if count:
+                break
+            time.sleep(1)
+        self.assertGreaterEqual(
+            1, count, 'status log "%s" for Port %s on dp %s not found' % (
+                status, port_no, dpid))
+
+    def verify_all_stack_up(self):
+        port_base = self.NUM_HOSTS + 1
+        for dpid in self.dpids:
+            for port_no in range(self.topo.switch_to_switch_links):
+                self.wait_for_stack_port_status(dpid, port_base + port_no, 'UP')
+
+    def verify_stack_has_no_loop(self):
+        tcpdump_filter = 'ether src %s' % self.first_host.MAC()
+        tcpdump_txt = self.tcpdump_helper(
+            self.first_host, tcpdump_filter, [
+                lambda: self.last_host.cmd('ping -c1 %s' % self.first_host.IP())],
+            packets=self.topo.switch_to_switch_links * 5)
+        num_arp_expected = self.topo.switch_to_switch_links * 2
+        num_arp_received = len(re.findall(
+            'who-has %s tell %s' % (self.first_host.IP(), self.last_host.IP()), tcpdump_txt))
+        self.assertLessEqual(num_arp_received, num_arp_expected)
+
+    def one_stack_port_down(self):
+        port = self.NUM_HOSTS + self.topo.switch_to_switch_links + 1 # root port
+        self.set_port_down(port, self.dpid)
+        self.wait_for_stack_port_status(self.dpid, port, 'DOWN')
+
+    def test_untagged(self):
+        """Stack loop prevention works and hosts can ping each others."""
+        self.verify_all_stack_up()
+        self.verify_stack_has_no_loop()
+        self.retry_net_ping()
+
+    def test_stack_down(self):
+        """Verify if a link down is reflected on stack-topology."""
+        self.verify_all_stack_up()
+        # ping first pair
+        self.retry_net_ping([self.first_host, self.last_host])
+        self.one_stack_port_down()
+        # ping fails for now because failures are not handled yet
+        self.retry_net_ping([self.first_host, self.last_host], required_loss=100, retries=1)
+        # newly learned hosts should work
+        self.retry_net_ping([self.second_host, self.fifth_host])
 
 
 class FaucetSingleStackAclControlTest(FaucetStringOfDPTest):

--- a/tests/unit/test_valve.py
+++ b/tests/unit/test_valve.py
@@ -1623,7 +1623,7 @@ class ValveStackGraphUpdateTestCase(ValveStackProbeTestCase):
     def test_update_stack_graph(self):
         def all_stack_up():
             for valve in self.valves_manager.valves.values():
-                valve.dp.running = True
+                valve.dp.dyn_running = True
                 for port in valve.dp.stack_ports:
                     port.stack_up()
 

--- a/tests/unit/test_valve.py
+++ b/tests/unit/test_valve.py
@@ -1580,7 +1580,8 @@ vlans:
         stack_port = self.valve.dp.ports[1]
         other_dp = self.valves_manager.valves[2].dp
         other_port = other_dp.ports[1]
-        self.valve.update_stack_link_states(time.time())
+        other_valves = self.valves_manager._other_running_valves(self.valve)
+        self.valve.update_stack_link_states(time.time(), other_valves)
         self.assertTrue(stack_port.is_stack_down())
         for change_func, check_func in [
                 ('stack_init', 'is_stack_init'),
@@ -1612,7 +1613,8 @@ vlans:
         other_port = other_dp.ports[1]
         self.rcv_lldp(stack_port, other_dp, other_port)
         self.assertTrue(stack_port.is_stack_init())
-        self.valve.update_stack_link_states(time.time() + 300) # simulate packet loss
+        other_valves = self.valves_manager._other_running_valves(self.valve)
+        self.valve.update_stack_link_states(time.time() + 300, other_valves) # simulate packet loss
         self.assertTrue(stack_port.is_stack_down())
 
 
@@ -1638,7 +1640,10 @@ class ValveStackGraphUpdateTestCase(ValveStackProbeTestCase):
             peer_dp = port.stack['dp']
             peer_port = port.stack['port']
             peer_port.stack_down()
-            self.valves_manager.valve_flow_services(time.time() + 600, 'update_stack_link_states')
+            self.valves_manager.valve_flow_services(
+                time.time() + 600,
+                'update_stack_link_states',
+                True)
             self.assertTrue(port.is_stack_down())
 
         def verify_stack_learn_edges(num_edges, edge=None, test_func=None):


### PR DESCRIPTION
This is to reflect link-state up/down events on a stack into each DP's stack graph. It works when all DPs are controlled by the same Faucet or events are local (no mechanism to distribute events across Faucet yet).
The updated graph is then used to re-calculate flood/unicast rules.