### PR TITLE
use clib_mininet_tests.py after rename

### DIFF
--- a/run-travis-test.sh
+++ b/run-travis-test.sh
@@ -11,7 +11,7 @@ if [ "${MATRIX_SHARD}" = "sanity" ] ; then
   ./tests/run_unit_tests.sh || exit 1
   codecov || true
 else
-  ALLTESTFILES="tests/integration/mininet_tests.py clib/clib_mininet_test_unit.py"
+  ALLTESTFILES="tests/integration/mininet_tests.py clib/clib_mininet_tests.py"
   ALLTESTS=`grep -E -o "^class (Faucet[a-zA-Z0-9]+Test)" ${ALLTESTFILES}|cut -f2 -d" "|sort`
   declare -A sharded
 


### PR DESCRIPTION
I ran into this and it's also showing up in mainline (https://travis-ci.com/faucetsdn/faucet/jobs/139023998)

    grep: clib/clib_mininet_test_unit.py: No such file or directory
