### PR TITLE
pylint fixes to work on new test base image

### DIFF
--- a/clib/mininet_test_topo.py
+++ b/clib/mininet_test_topo.py
@@ -13,6 +13,8 @@ import netifaces
 
 # pylint: disable=import-error
 # pylint: disable=no-name-in-module
+# pylint: disable=too-many-arguments
+
 from mininet.log import error, output
 from mininet.topo import Topo
 from mininet.node import Controller

--- a/tests/integration/mininet_tests.py
+++ b/tests/integration/mininet_tests.py
@@ -4,6 +4,7 @@
 
 # pylint: disable=missing-docstring
 # pylint: disable=too-many-arguments
+# pylint: disable=unbalanced-tuple-unpacking
 
 import binascii
 import itertools


### PR DESCRIPTION
**Summary**

In preparation for the Python 3 Mininet merge, these small changes should enable mainline FAUCET to work against my `docker-test-base` changes in https://github.com/lantz/docker-faucet-test-base

An alternative approach would be to move Mininet higher up the docker image stack. We might want to do that anyway? Either way works for me.

Unfortunately the new base image may cause the `sanity` shard to run ~9m slower - see below. :(

**Background**

The root cause is that `pytype` seems to fail with a `not a directory` error when running against python 3 `mininet_tests.py` unless mininet's `.egg`  is unzipped, but doing so in the base image seems to cause `pylint` to explode with a flurry of spurious errors, notably `unbalanced-tuple-unpacking`, which cause `min_pylint.sh` to fail. These changes allow the `pylint` test to pass against a base image with an unzipped `mininet`, which is my current solution for allowing `pytype.sh` to pass.

**Merge Plan**

Once this is merged, I will submit a pull request for the base image changes, which will enable both current mainline *and* my development version to run against the new standard Faucet test base image.

After the new base image is built and validated in mainline, then I can submit a pull request for the Python 3 Mininet changes.

Then once those merge and pass, I will create a base image change that pulls out the Python 2 stuff, validate it against mainline, and submit a pull request for it.

Assuming everything goes smoothly, this will enable a nice transition that won't break anything.

In the (likely) case that things don't go as smoothly as anticipated, then they should be relatively easy to revert and fix!

**Annoying Issues**

Unzipping mininet's `.egg` in my new test base image seems to slow down `pytype.sh` annoyingly (`sanity` shard seems to take 9 minutes longer, 32 minutes vs. 23 minutes, though I haven't confirmed that it is only because of `pytype`.) Probably `pytype` is processing mininet, which it really doesn't need to do on Faucet's behalf?

 Is there a better way to get `pytype` to behave?

We should probably time `pytype.sh` to determine whether it is in fact eating up all that time.

**Alternative Approaches**

An alternative approach would be to move Mininet higher up the docker image stack. We might want to do this anyway?

An interesting future direction could be to move Mininet into PyPi. This might be possible if we can boil down Mininet's dependencies into something that exists in nearly every Linux distribution, or if we could make a "pure python" mininet.

Another alternative approach would be to "live dangerously" and just try to merge everything in all at once. I think the conservative approach is less likely to break things in hard-to-fix ways.

It may also be possible to get `pytype` to cooperate in another way - having to unzip a package is pretty annoying and also seems to slow down `pytype` significantly - up to 9 minutes in my tests? :(

**References**

My docker test base changes:
https://github.com/lantz/docker-faucet-test-base
https://hub.docker.com/r/lantz/docker-faucet-test-base/

Python 3 Mininet changes: 
https://github.com/lantz/faucet/tree/py3-mn-nofuzz
https://travis-ci.org/lantz/faucet/builds (check `py3-mn-nofuzz` branch)