### PR TITLE
Update mininet-based integration tests to python 3

### DIFF
--- a/clib/clib_mininet_test.py
+++ b/clib/clib_mininet_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """Mininet tests for clib client library functionality.
 

--- a/clib/clib_mininet_test_main.py
+++ b/clib/clib_mininet_test_main.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """Mininet test runner
 
@@ -28,7 +28,7 @@ import subprocess
 import tempfile
 import threading
 import time
-import unittest2
+import unittest
 
 import yaml
 
@@ -117,7 +117,7 @@ def import_hw_config():
         required_config = {
             'dp_ports': (dict,),
             'cpn_intf': (str,),
-            'dpid': (long, int), # pytype: disable=name-error
+            'dpid': (int),
             'of_port': (int,),
             'gauge_of_port': (int,),
         }
@@ -163,9 +163,9 @@ def check_dependencies():
                 stderr=subprocess.STDOUT,
                 close_fds=True)
             proc_out, proc_err = proc.communicate()
-            binary_output = proc_out
+            binary_output = proc_out.decode()
             if proc_err is not None:
-                binary_output += proc_err
+                binary_output += proc_err.decode()
         except subprocess.CalledProcessError:
             # Might have run successfully, need to parse output
             pass
@@ -198,9 +198,9 @@ def check_dependencies():
 
 def make_suite(tc_class, hw_config, root_tmpdir, ports_sock, max_test_load):
     """Compose test suite based on test class names."""
-    testloader = unittest2.TestLoader()
+    testloader = unittest.TestLoader()
     testnames = testloader.getTestCaseNames(tc_class)
-    suite = unittest2.TestSuite()
+    suite = unittest.TestSuite()
     for name in testnames:
         suite.addTest(tc_class(name, hw_config, root_tmpdir, ports_sock, max_test_load))
     return suite
@@ -380,9 +380,9 @@ def expand_tests(module, requested_test_classes, excluded_test_classes,
                 else:
                     parallel_test_suites.append(test_suite)
 
-    sanity_tests = unittest2.TestSuite()
-    single_tests = unittest2.TestSuite()
-    parallel_tests = unittest2.TestSuite()
+    sanity_tests = unittest.TestSuite()
+    single_tests = unittest.TestSuite()
+    parallel_tests = unittest.TestSuite()
 
     if len(parallel_test_suites) == 1:
         single_test_suites.extend(parallel_test_suites)
@@ -402,7 +402,7 @@ def expand_tests(module, requested_test_classes, excluded_test_classes,
     return (sanity_tests, single_tests, parallel_tests)
 
 
-class FaucetResult(unittest2.runner.TextTestResult):
+class FaucetResult(unittest.runner.TextTestResult): # pytype: disable=module-attr
 
     root_tmpdir = None
 
@@ -424,7 +424,7 @@ class FaucetCleanupResult(FaucetResult):
 
 def test_runner(root_tmpdir, resultclass, failfast=False):
     resultclass.root_tmpdir = root_tmpdir
-    return unittest2.TextTestRunner(verbosity=255, resultclass=resultclass, failfast=failfast)
+    return unittest.TextTestRunner(verbosity=255, resultclass=resultclass, failfast=failfast)
 
 
 def run_parallel_test_suites(root_tmpdir, resultclass, parallel_tests):
@@ -513,7 +513,7 @@ def start_port_server(root_tmpdir, start_free_ports, min_free_ports):
         args=(ports_sock, start_free_ports, min_free_ports))
     ports_server.setDaemon(True)
     ports_server.start()
-    for _ in range(min_free_ports / 2): # pytype: disable=wrong-arg-types
+    for _ in range(min_free_ports // 2):
         if os.path.exists(ports_sock):
             break
         time.sleep(1)

--- a/clib/mininet_test_topo.py
+++ b/clib/mininet_test_topo.py
@@ -9,8 +9,6 @@ import shutil
 import subprocess
 import time
 
-import netifaces
-
 # pylint: disable=import-error
 # pylint: disable=no-name-in-module
 # pylint: disable=too-many-arguments
@@ -22,6 +20,8 @@ from mininet.node import CPULimitedHost
 from mininet.node import OVSSwitch
 
 import mininet_test_util
+
+import netifaces
 
 # TODO: mininet 2.2.2 leaks ptys (master slave assigned in startShell)
 # override as necessary close them. Transclude overridden methods
@@ -60,7 +60,7 @@ class FaucetHostCleanup(object):
         self.shell = self._popen( # pylint: disable=no-member; # pytype: disable=attribute-error
             cmd, stdin=self.slave, stdout=self.slave, stderr=self.slave,
             close_fds=False)
-        self.stdin = os.fdopen(self.master, 'rw')
+        self.stdin = os.fdopen(self.master, 'r')
         self.stdout = self.stdin
         self.pid = self.shell.pid
         self.pollOut = select.poll() # pylint: disable=invalid-name
@@ -195,7 +195,7 @@ class FaucetSwitchTopo(Topo):
         """Return a unique switch/host prefix for a test."""
         # Linux tools require short interface names.
         # pylint: disable=no-member
-        id_chars = string.letters + string.digits # pytype: disable=module-attr
+        id_chars = string.ascii_letters + string.digits # pytype: disable=module-attr
         id_a = int(ports_served / len(id_chars))
         id_b = ports_served - (id_a * len(id_chars))
         return '%s%s' % (
@@ -539,7 +539,7 @@ class FAUCET(BaseFAUCET):
         self.ofctl_port = mininet_test_util.find_free_port(
             ports_sock, test_name)
         cargs = ' '.join((
-            '--ryu-wsapi-host=%s' % str(mininet_test_util.LOCALHOSTV6),
+            '--ryu-wsapi-host=%s' % mininet_test_util.LOCALHOSTV6,
             '--ryu-wsapi-port=%u' % self.ofctl_port,
             self._tls_cargs(port, ctl_privkey, ctl_cert, ca_certs)))
         super(FAUCET, self).__init__(

--- a/clib/mininet_test_util.py
+++ b/clib/mininet_test_util.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """Standalone utility functions for Mininet tests."""
 
@@ -17,8 +17,8 @@ GETPORT = 'GETPORT'
 PUTPORTS = 'PUTPORTS'
 GETSERIAL = 'GETSERIAL'
 LISTPORTS = 'LISTPORTS'
-LOCALHOST = u'127.0.0.1'
-LOCALHOSTV6 = u'::1'
+LOCALHOST = '127.0.0.1'
+LOCALHOSTV6 = '::1'
 FAUCET_DIR = os.getenv('FAUCET_DIR', '../faucet')
 RESERVED_FOR_TESTS_PORTS = (179, 5001, 5002, 6633, 6653)
 MIN_PORT_AGE = max(int(open(
@@ -61,7 +61,7 @@ def receive_sock_line(sock):
     """Receive a \n terminated line from a socket."""
     buf = ''
     while buf.find('\n') <= -1:
-        buf += str(sock.recv(2**10))
+        buf += sock.recv(2**10).decode()
     return buf.strip()
 
 
@@ -79,7 +79,7 @@ def test_server_request(ports_socket, name, command):
     assert name is not None
     sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
     sock.connect(ports_socket)
-    sock.sendall(b'%s,%s\n' % (command, name))
+    sock.sendall(('%s,%s\n' % (command, name)).encode())
     output('%s %s\n' % (name, command))
     buf = receive_sock_line(sock)
     responses = [int(i) for i in buf.split('\n')]
@@ -180,8 +180,8 @@ def serve_ports(ports_socket, start_free_ports, min_free_ports):
             response_str = ''
             if isinstance(response, int):
                 response = [response]
-            response_str = bytes(''.join(['%u\n' % i for i in response]))
-            connection.sendall(response_str) # pylint: disable=no-member
+            response_str = ''.join(['%u\n' % i for i in response])
+            connection.sendall(response_str.encode()) # pylint: disable=no-member
         connection.close()
 
 

--- a/clib/tcpdump_helper.py
+++ b/clib/tcpdump_helper.py
@@ -110,7 +110,7 @@ class TcpdumpHelper(object):
         fileno = self.pipe.stdout.fileno()
         while '\n' not in self.readbuf:
             try:
-                read = str(os.read(fileno, 2**10))
+                read = os.read(fileno, 2**10)
             except OSError as err:
                 if err.errno != errno.EAGAIN or not self.blocking:
                     raise
@@ -119,7 +119,7 @@ class TcpdumpHelper(object):
                 line = self.readbuf
                 self.readbuf = ''
                 return line
-            self.readbuf += read
+            self.readbuf += read.decode()
         pos = self.readbuf.find('\n') + 1
         line = self.readbuf[0:pos]
         self.readbuf = self.readbuf[pos:]
@@ -132,7 +132,7 @@ class TcpdumpHelper(object):
                 line = self.readline()
             except OSError as err:
                 if err.errno == errno.EWOULDBLOCK or err.errno == errno.EAGAIN:
-                    return None
+                    return ''
                 raise
             assert line or self.started, 'tcpdump did not start: %s' % self.last_line.strip()
             if self.started:

--- a/docker/localtest.sh
+++ b/docker/localtest.sh
@@ -26,7 +26,7 @@ echo "try:"
 echo "  docker/runtests.sh"
 echo "or:"
 echo '  cd tests && ./run_integration_tests.sh $FAUCET_TESTS'
-echo '  cd clib && python2 ./clib_mininet_test.py $FAUCET_TESTS'
+echo '  cd clib && ./clib_mininet_test.py $FAUCET_TESTS'
 echo
 
 sudo docker run -ti -v $PWD:/faucet-src -e FAUCET_TESTS="$FAUCET_TESTS" \

--- a/docker/pip_deps.sh
+++ b/docker/pip_deps.sh
@@ -4,8 +4,6 @@ FAUCETHOME=`dirname $0`/..
 FAUCETHOME=`readlink -f $FAUCETHOME`
 PIPARGS="install -q --upgrade $*"
 
-$FAUCETHOME/docker/retrycmd.sh "pip $PIPARGS -r $FAUCETHOME/py2-test-requirements.txt" || exit 1
-
 for r in test-requirements.txt requirements.txt docs/requirements.txt fuzz-requirements.txt ; do
   $FAUCETHOME/docker/retrycmd.sh "pip3 $PIPARGS -r $FAUCETHOME/$r" || exit 1
 done

--- a/docker/runtests.sh
+++ b/docker/runtests.sh
@@ -33,6 +33,7 @@ if [ -d /var/tmp/pip-cache ] ; then
   cp -r /var/tmp/pip-cache /var/tmp/pip-cache-local || exit 1
 fi
 ./docker/pip_deps.sh "--cache-dir=/var/tmp/pip-cache-local" || exit 1
+./docker/workarounds.sh || exit 1
 
 echo "========== checking IPv4/v6 localhost is up ====="
 ping6 -c 1 ::1 || exit 1
@@ -78,14 +79,14 @@ service docker start
 echo "========== Running faucet system tests =========="
 test_failures=
 export FAUCET_DIR=/faucet-src/faucet
-export PYTHONPATH=/faucet-src
+export PYTHONPATH=/faucet-src:/faucet-src/faucet:/faucet-src/clib
 
 cd /faucet-src/tests/integration
-python2 ./mininet_main.py -c
-http_proxy="" python2 ./mininet_main.py $FAUCET_TESTS || test_failures+=" mininet_main"
+./mininet_main.py -c
+http_proxy="" ./mininet_main.py $FAUCET_TESTS || test_failures+=" mininet_main"
 
 cd /faucet-src/clib
-http_proxy="" python2 ./clib_mininet_test.py $FAUCET_TESTS || test_failures+=" clib_mininet_test"
+http_proxy="" ./clib_mininet_test.py $FAUCET_TESTS || test_failures+=" clib_mininet_test"
 
 if [ -n "$test_failures" ]; then
     echo Test failures: $test_failures

--- a/docker/workarounds.sh
+++ b/docker/workarounds.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Hack/workaround for testtools breaking pytype
+# https://github.com/google/pytype/issues/133
+COMPAT=`python3 -c 'from testtools import compat; print(compat.__file__)'`
+FIX='s/_compat2x as _compat/_compat3x as _compat  # pytype workaround, was: _compat2x/'
+sed -i -e "$FIX" $COMPAT

--- a/py2-test-requirements.txt
+++ b/py2-test-requirements.txt
@@ -1,6 +1,0 @@
-concurrencytest
-ipaddress
-netifaces
-packaging
-pyyaml
-requests

--- a/tests/codecheck/pytype.sh
+++ b/tests/codecheck/pytype.sh
@@ -1,23 +1,12 @@
 #!/bin/bash
 
 FAUCETHOME=`dirname $0`"/../.."
+PYTHONPATH=$FAUCETHOME:$FAUCETHOME/faucet:$FAUCETHOME/clib
 PARARGS="parallel --delay 1 --bar"
-PYTYPEARGS="pytype -d pyi-error,import-error"
+PYTYPEARGS="pytype --pythonpath $PYTHONPATH -d pyi-error,import-error -V3.5"
 PYTYPE=`which pytype`
 PYHEADER=`head -1 $PYTYPE`
-
+SRCFILES="$FAUCETHOME/tests/codecheck/src_files.sh"
 echo "Using $PYTYPE (header $PYHEADER)"
 
-PY2=""
-PY3=""
-for i in `$FAUCETHOME/tests/codecheck/src_files.sh|shuf` ; do
-  # mininet requires python2
-  if grep -qn -E "^(from|import) mininet" $i ; then
-    PY2+="$i\n"
-  else
-    PY3+="$i\n"
-  fi
-done
-
-echo -ne $PY2 | $PARARGS $PYTYPEARGS -V2.7 || exit 1
-echo -ne $PY3 | $PARARGS $PYTYPEARGS -V3.5 || exit 1
+$SRCFILES | shuf | $PARARGS $PYTYPEARGS || exit 1

--- a/tests/integration/mininet_main.py
+++ b/tests/integration/mininet_main.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """Mininet tests for FAUCET.
 

--- a/tests/run_integration_tests.sh
+++ b/tests/run_integration_tests.sh
@@ -4,7 +4,7 @@
 
 export OVS_LOGDIR=/usr/local/var/log
 export FAUCET_DIR=$PWD/../faucet
-export PYTHONPATH=$PWD/..
+export PYTHONPATH=$PWD/..:$PWD/../clib
 
 cd integration
-rm -rf /tmp/faucet*log /tmp/gauge*log /tmp/faucet-tests* /var/tmp/faucet-tests* $OVS_LOGDIR/* ; killall ryu-manager ; python2 ./mininet_main.py -c ; /usr/local/share/openvswitch/scripts/ovs-ctl stop ; /usr/local/share/openvswitch/scripts/ovs-ctl start ; python2 ./mininet_main.py $*
+rm -rf /tmp/faucet*log /tmp/gauge*log /tmp/faucet-tests* /var/tmp/faucet-tests* $OVS_LOGDIR/* ; killall ryu-manager ; ./mininet_main.py -c ; /usr/local/share/openvswitch/scripts/ovs-ctl stop ; /usr/local/share/openvswitch/scripts/ovs-ctl start ; ./mininet_main.py $*


### PR DESCRIPTION
There are a lot of changes here so you will probably want to review them - I can definitely help with any clarification or additional requested changes.

### Notes

These changes migrate FAUCET's Mininet-based integration tests to Python 3, removing the requirement for Python 2.

They depend on the test base docker image changes in faucetsdn/docker-test-base#4.

**Overview**

- We install a Python 3-compatible version of Mininet in the base test image (also see below)
- We remove the Python 2 pip dependencies and install the Python 3 versions
- The Mininet-based integration tests are migrated to Python 3
- We invoke the integration tests using Python 2 rather than Python 3
- We run `pytype` invoking it with `-V3.5` on all code
- We invoke a workaround in `docker/workarounds.sh` to compensate for an upstream `ptype` issue (see below)

**Potential Issues**

- `FaucetTcpdumpHelperTest-test_tcpdump_nextline: not all controllers healthy` on shard 3 (see below)
- This patch currently skips the IPv6 `test_fuzz_controller()` test which seems to hang consistently on travis but not locally; it would be nice to find and fix the root cause of this behavior
- Python 3 `pytype` chokes on `testtools` with a fatal error that we cannot catch, so this patch breaks `pytype.sh` unless the fix in `workarounds.sh` is applied. See google/pytype#133
- This may slow down some CI tests somewhat (`sanity` shard seems to be several minutes slower in my testing); we may wish to investigate this to examine the root cause and see whether it can be improved

**Subsequent Work**

- After this is merged into mainline, we can remove Python 2 support from the base test image
- We might want to install Mininet in `run_tests.sh` instead of the base image
- I still would like to remove the Mininet hacks/workarounds in `mininet_topo.py` at some point, as they should no longer be necessary (and should also be fixed in Mininet mainline if they aren't already!)
