### PR TITLE
Don't check test_packaging:

### DIFF
--- a/tests/codecheck/src_files.sh
+++ b/tests/codecheck/src_files.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 
 FAUCETHOME=`dirname $0`"/../.."
-for i in clib faucet tests ; do find $FAUCETHOME/$i/ -type f -name [a-z]*.py ; done | xargs realpath | sort
+# TODO: test_packaging.py causes pytype to die.
+for i in clib faucet tests ; do find $FAUCETHOME/$i/ -type f -name [a-z]*.py ; done | xargs realpath | sort |grep -v test_packaging.py


### PR DESCRIPTION
CRITICAL Cannot parse input files:
[Errno 20] Not a directory: '/usr/share/python-wheels/packaging-17.1-py2.py3-none-any.whl/packaging/specifiers.py'