### PR TITLE
NoviFlow Valve must use barriers

### DIFF
--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -1561,7 +1561,7 @@ class AlliedTelesis(OVSValve):
     DEC_TTL = False
 
 
-class NoviFlowValve(OVSValve):
+class NoviFlowValve(Valve):
     """Valve implementation for NoviFlow with static pipeline."""
 
     STATIC_TABLE_IDS = True


### PR DESCRIPTION
Inheriting from OVSValve cause USE_BARRIERS to be False, but NoviFlow switches require barriers to be used. Inheriting directly from Valve instead