### PR TITLE
Acl config tidy rebase

### DIFF
--- a/faucet/acl.py
+++ b/faucet/acl.py
@@ -21,10 +21,8 @@ import netaddr
 from faucet import valve_of
 from faucet import valve_acl
 from faucet.valve_of import MATCH_FIELDS, OLD_MATCH_FIELDS
-from faucet.faucet_pipeline import ValveTableConfig
-from faucet.valve_table import ValveTable, ValveGroupTable
 from faucet.conf import Conf, test_config_condition, InvalidConfigError
-
+from faucet.valve_table import wildcard_table
 
 class ACL(Conf):
     """Contains the state for an ACL, including the configuration.
@@ -96,9 +94,6 @@ The output action contains a dictionary with the following elements:
         'vlan_vids': list,
     }
 
-    wildcard_table = ValveTable(
-        valve_of.ofp.OFPTT_ALL, 'all', ValveTableConfig('all'), flow_cookie=0)
-
     def __init__(self, _id, dp_id, conf):
         self.rules = []
         self.exact_match = None
@@ -160,9 +155,9 @@ The output action contains a dictionary with the following elements:
         if self.rules:
             try:
                 ofmsgs = valve_acl.build_acl_ofmsgs(
-                    [self], self.wildcard_table,
-                    valve_of.goto_table(self.wildcard_table),
-                    valve_of.goto_table(self.wildcard_table),
+                    [self], wildcard_table,
+                    valve_of.goto_table(wildcard_table),
+                    valve_of.goto_table(wildcard_table),
                     2**16-1, meters, self.exact_match,
                     vlan_vid=vid)
             except (netaddr.core.AddrFormatError, KeyError, ValueError) as err:

--- a/faucet/dp.py
+++ b/faucet/dp.py
@@ -32,13 +32,6 @@ from faucet.faucet_pipeline import ValveTableConfig
 from faucet.valve_table import ValveTable, ValveGroupTable
 from faucet import valve_packet
 
-
-class NullRyuDatapath:
-    """Placeholder Ryu Datapath."""
-
-    ofproto = valve_of.ofp
-
-
 # Documentation generated using documentation_generator.py
 # For attributues to be included in documentation they must
 # have a default value, and their descriptor must come
@@ -205,9 +198,6 @@ configuration.
     dot1x_defaults_types = {
         'nfv_intf': str,
     }
-
-    wildcard_table = ValveTable(
-        valve_of.ofp.OFPTT_ALL, 'all', ValveTableConfig('all'), flow_cookie=0)
 
 
     def __init__(self, _id, dp_id, conf):

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -29,6 +29,7 @@ from faucet import valve_host
 from faucet import valve_of
 from faucet import valve_packet
 from faucet import valve_route
+from faucet import valve_table
 from faucet import valve_util
 
 from faucet.port import STACK_STATE_INIT, STACK_STATE_UP, STACK_STATE_DOWN
@@ -256,7 +257,7 @@ class Valve:
     def _delete_all_valve_flows(self):
         """Delete all flows from all FAUCET tables."""
         ofmsgs = []
-        ofmsgs.extend(self.dp.wildcard_table.flowdel())
+        ofmsgs.extend(valve_table.wildcard_table.flowdel())
         if self.dp.meters:
             ofmsgs.append(valve_of.meterdel())
         if self.dp.group_table:
@@ -266,7 +267,7 @@ class Valve:
     def _delete_all_port_match_flows(self, port):
         """Delete all flows that match an input port from all FAUCET tables."""
         ofmsgs = []
-        tables = [self.dp.wildcard_table]
+        tables = [valve_table.wildcard_table]
         if self.dp.dp_acls:
             # DP ACL flows live forever.
             port_acl_table = self.dp.tables['port_acl']
@@ -397,7 +398,7 @@ class Valve:
 
     def _del_vlan(self, vlan):
         """Delete a configured VLAN."""
-        table = self.dp.wildcard_table
+        table = valve_table.wildcard_table
         ofmsgs = table.flowdel(match=table.match(vlan=vlan))
         self.logger.info('Delete VLAN %s' % vlan)
         return ofmsgs

--- a/faucet/valve_table.py
+++ b/faucet/valve_table.py
@@ -20,6 +20,7 @@ import hashlib
 import struct
 
 from faucet import valve_of
+from faucet.faucet_pipeline import ValveTableConfig
 
 
 class ValveTable: # pylint: disable=too-many-arguments,too-many-instance-attributes
@@ -201,3 +202,6 @@ class ValveGroupTable:
         """Delete all groups."""
         self.entries = {}
         return valve_of.groupdel()
+
+wildcard_table = ValveTable(
+    valve_of.ofp.OFPTT_ALL, 'all', ValveTableConfig('all'), flow_cookie=0)


### PR DESCRIPTION
Move wildcard_table into valve_table.py as it is needed by multiple classes

Also get rid of the NullRyuDatapath object from dp.py, its only needed in acl.py. It probably should be moved elsewhere if there are more uses for it. Possibly conf.py might make sense.