### PR TITLE
python3 Import cleanup

### DIFF
--- a/clib/clib_mininet_test_main.py
+++ b/clib/clib_mininet_test_main.py
@@ -39,7 +39,7 @@ from concurrencytest import ConcurrentTestSuite, fork_for_tests
 from mininet.log import setLogLevel
 from mininet.clean import Cleanup
 
-import mininet_test_util
+from clib import mininet_test_util
 
 # Only these hardware types will be tested with meters.
 SUPPORTS_METERS = (

--- a/clib/clib_mininet_tests.py
+++ b/clib/clib_mininet_tests.py
@@ -7,10 +7,10 @@ import re
 # Required to prevent circular import cycle.  pylint: disable=unused-import
 from mininet.net import Mininet
 
-import mininet_test_base
+from clib import mininet_test_base
 
-from tcpdump_helper import TcpdumpHelper
-from docker_host import make_docker_host
+from clib.tcpdump_helper import TcpdumpHelper
+from clib.docker_host import make_docker_host
 
 
 class FaucetSimpleTest(mininet_test_base.FaucetTestBase):

--- a/clib/docker_host.py
+++ b/clib/docker_host.py
@@ -14,7 +14,7 @@ from mininet.log import error, debug
 from mininet.node import Host
 from mininet.util import quietRun, errRun
 
-from mininet_test_util import DEVNULL
+from clib.mininet_test_util import DEVNULL
 
 DEFAULT_NETWORK = 'none'
 DEFAULT_PREFIX = 'mininet'

--- a/clib/mininet_test_base.py
+++ b/clib/mininet_test_base.py
@@ -31,9 +31,9 @@ from mininet.util import dumpNodeConnections, pmonitor # pylint: disable=import-
 
 import netifaces
 
-import mininet_test_util
-import mininet_test_topo
-from tcpdump_helper import TcpdumpHelper
+from clib import mininet_test_util
+from clib import mininet_test_topo
+from clib.tcpdump_helper import TcpdumpHelper
 
 OFPPC_PORT_DOWN = 1 << 0 # TODO: avoid dependency on Python2 Ryu.
 PEER_BGP_AS = 2**16 + 1

--- a/clib/mininet_test_topo.py
+++ b/clib/mininet_test_topo.py
@@ -19,7 +19,7 @@ from mininet.node import Controller
 from mininet.node import CPULimitedHost
 from mininet.node import OVSSwitch
 
-import mininet_test_util
+from clib import mininet_test_util
 
 import netifaces
 

--- a/clib/tcpdump_helper.py
+++ b/clib/tcpdump_helper.py
@@ -6,7 +6,7 @@ import subprocess
 import os
 import re
 
-import mininet_test_util
+from clib import mininet_test_util
 
 # pylint: disable=import-error
 # pylint: disable=no-name-in-module


### PR DESCRIPTION
changes necessary to allow clib to be imported from an external client under python3.
