### PR TITLE
Chewie prometheus metrics

### DIFF
--- a/faucet/faucet_dot1x.py
+++ b/faucet/faucet_dot1x.py
@@ -56,6 +56,7 @@ class FaucetDot1x:
         self.logger.info(
             'Successful auth from MAC %s on %s' % (
                 str(address), self.dot1x_port))
+        self._valve._inc_var('dot1x_success')
         flowmods = self._valve.add_authed_mac(
             self.dot1x_port.number, str(address))
         if flowmods:

--- a/faucet/faucet_metrics.py
+++ b/faucet/faucet_metrics.py
@@ -137,6 +137,10 @@ class FaucetMetrics(PromClient):
         self.stack_probes_received = self._dpid_counter(
             'stack_probes_received',
             'number of stacking messages received')
+        self.dot1x_success = self._dpid_counter('dot1x_success',
+                                           'number of successful authentications')
+        self.dot1x_failure = self._dpid_counter('dot1x_failure',
+                                           'number of authentications attempts failed')
 
 
     def _counter(self, var, var_help, labels):

--- a/tests/integration/mininet_tests.py
+++ b/tests/integration/mininet_tests.py
@@ -261,12 +261,10 @@ network={
                     self.eapol_host, self.wpasupplicant_conf, timeout=30))],
             timeout=30, vflags='-v', packets=6)
 
-        faucet_log = self.env['faucet']['FAUCET_LOG']
-        with open(faucet_log, 'r') as log:
-            print('Faucet log')
-            faucet_log_txt = log.read()
-            print(faucet_log_txt)
-        self.assertIn("Successful auth", faucet_log_txt)
+        dot1x_success = self.scrape_prometheus_var('dot1x_success', any_labels=True)
+        self.assertEqual(dot1x_success, 1)
+        dot1x_failure = self.scrape_prometheus_var('dot1x_failure', any_labels=True)
+        self.assertEqual(dot1x_failure, 0)
         self.assertIn('Success', tcpdump_txt)
 
 
@@ -297,6 +295,8 @@ class FaucetUntagged8021XFailureTest(FaucetUntagged8021XSuccessTest):
             faucet_log_txt = log.read()
             print(faucet_log_txt)
         self.assertNotIn("Successful auth", faucet_log_txt)
+        dot1x_success = self.scrape_prometheus_var('dot1x_success', any_labels=True)
+        self.assertEqual(dot1x_success, 0)
         self.assertIn('Failure', tcpdump_txt)
 
 


### PR DESCRIPTION
Adds a prometheus success/failure counter.
failure isn't currently used, will require a change to chewie - perhaps a failure_handler