### PR TITLE
Static eth src

### DIFF
--- a/faucet/faucet_pipeline.py
+++ b/faucet/faucet_pipeline.py
@@ -87,12 +87,12 @@ VLAN_DEFAULT_CONFIG = ValveTableConfig(
                  ('in_port', False), ('vlan_vid', False)),
     set_fields=('vlan_vid',),
     vlan_port_scale=1.5,
-    next_tables=('vlan_acl', 'eth_src')
+    next_tables=('vlan_acl', 'classification')
     )
 VLAN_ACL_DEFAULT_CONFIG = ValveTableConfig(
     'vlan_acl',
     VLAN_DEFAULT_CONFIG.table_id + 1,
-    next_tables=(('eth_src',) + _NEXT_ETH))
+    next_tables=(('classification',) + _NEXT_ETH))
 CLASSIFICATION_DEFAULT_CONFIG = ValveTableConfig(
     'classification',
     VLAN_ACL_DEFAULT_CONFIG.table_id + 1,

--- a/faucet/faucet_pipeline.py
+++ b/faucet/faucet_pipeline.py
@@ -82,7 +82,7 @@ PORT_ACL_DEFAULT_CONFIG = ValveTableConfig(
     )
 VLAN_DEFAULT_CONFIG = ValveTableConfig(
     'vlan',
-    1,
+    PORT_ACL_DEFAULT_CONFIG.table_id + 1,
     match_types=(('eth_dst', True), ('eth_type', False),
                  ('in_port', False), ('vlan_vid', False)),
     set_fields=('vlan_vid',),
@@ -91,11 +91,11 @@ VLAN_DEFAULT_CONFIG = ValveTableConfig(
     )
 VLAN_ACL_DEFAULT_CONFIG = ValveTableConfig(
     'vlan_acl',
-    2,
+    VLAN_DEFAULT_CONFIG.table_id + 1,
     next_tables=(('eth_src',) + _NEXT_ETH))
 ETH_SRC_DEFAULT_CONFIG = ValveTableConfig(
     'eth_src',
-    3,
+    VLAN_ACL_DEFAULT_CONFIG.table_id + 1,
     miss_goto='eth_dst',
     match_types=(('eth_dst', True), ('eth_src', False), ('eth_type', False),
                  ('in_port', False), ('vlan_vid', False)),
@@ -103,18 +103,18 @@ ETH_SRC_DEFAULT_CONFIG = ValveTableConfig(
     vlan_port_scale=4.1,
     next_tables=(('ipv4_fib', 'ipv6_fib') + _NEXT_VIP)
     )
-IPV4_FIB_DEFAULT_CONFIG = _fib_table(4, 4)
-IPV6_FIB_DEFAULT_CONFIG = _fib_table(6, 5)
+IPV4_FIB_DEFAULT_CONFIG = _fib_table(4, ETH_SRC_DEFAULT_CONFIG.table_id + 1)
+IPV6_FIB_DEFAULT_CONFIG = _fib_table(6, IPV4_FIB_DEFAULT_CONFIG.table_id + 1)
 VIP_DEFAULT_CONFIG = ValveTableConfig(
     'vip',
-    6,
+    IPV6_FIB_DEFAULT_CONFIG.table_id + 1,
     match_types=(('arp_tpa', False), ('eth_dst', False), ('eth_type', False),
                  ('icmpv6_type', False), ('ip_proto', False)),
     next_tables=_NEXT_ETH,
     )
 ETH_DST_HAIRPIN_DEFAULT_CONFIG = ValveTableConfig(
     'eth_dst_hairpin',
-    7,
+    VIP_DEFAULT_CONFIG.table_id + 1,
     match_types=(('in_port', False), ('eth_dst', False), ('vlan_vid', False)),
     miss_goto='eth_dst',
     exact_match=True,
@@ -122,7 +122,7 @@ ETH_DST_HAIRPIN_DEFAULT_CONFIG = ValveTableConfig(
     )
 ETH_DST_DEFAULT_CONFIG = ValveTableConfig(
     'eth_dst',
-    8,
+    ETH_DST_HAIRPIN_DEFAULT_CONFIG.table_id + 1,
     exact_match=True,
     miss_goto='flood',
     match_types=(('eth_dst', False), ('vlan_vid', False)),
@@ -130,7 +130,7 @@ ETH_DST_DEFAULT_CONFIG = ValveTableConfig(
     )
 FLOOD_DEFAULT_CONFIG = ValveTableConfig(
     'flood',
-    9,
+    ETH_DST_DEFAULT_CONFIG.table_id + 1,
     match_types=(('eth_dst', True), ('in_port', False), ('vlan_vid', False)),
     vlan_port_scale=2.1,
     )

--- a/faucet/faucet_pipeline.py
+++ b/faucet/faucet_pipeline.py
@@ -107,7 +107,7 @@ ETH_SRC_DEFAULT_CONFIG = ValveTableConfig(
                  ('in_port', False), ('vlan_vid', False)),
     set_fields=('vlan_vid', 'eth_dst'),
     vlan_port_scale=4.1,
-    next_tables=(('ipv4_fib', 'ipv6_fib') + _NEXT_VIP)
+    next_tables=_NEXT_ETH
     )
 IPV4_FIB_DEFAULT_CONFIG = _fib_table(4, ETH_SRC_DEFAULT_CONFIG.table_id + 1)
 IPV6_FIB_DEFAULT_CONFIG = _fib_table(6, IPV4_FIB_DEFAULT_CONFIG.table_id + 1)

--- a/faucet/faucet_pipeline.py
+++ b/faucet/faucet_pipeline.py
@@ -93,9 +93,15 @@ VLAN_ACL_DEFAULT_CONFIG = ValveTableConfig(
     'vlan_acl',
     VLAN_DEFAULT_CONFIG.table_id + 1,
     next_tables=(('eth_src',) + _NEXT_ETH))
+CLASSIFICATION_DEFAULT_CONFIG = ValveTableConfig(
+    'classification',
+    miss_goto='eth_dst'
+    VLAN_ACL_DEFAULT_CONFIG.table_id + 1,
+    next_tables=('ipv4_fib', 'vip')
+    )
 ETH_SRC_DEFAULT_CONFIG = ValveTableConfig(
     'eth_src',
-    VLAN_ACL_DEFAULT_CONFIG.table_id + 1,
+    CLASSIFICATION_DEFAULT_CONFIG.table_id + 1,
     miss_goto='eth_dst',
     match_types=(('eth_dst', True), ('eth_src', False), ('eth_type', False),
                  ('in_port', False), ('vlan_vid', False)),
@@ -120,6 +126,7 @@ ETH_DST_HAIRPIN_DEFAULT_CONFIG = ValveTableConfig(
     exact_match=True,
     vlan_port_scale=4.1,
     )
+
 ETH_DST_DEFAULT_CONFIG = ValveTableConfig(
     'eth_dst',
     ETH_DST_HAIRPIN_DEFAULT_CONFIG.table_id + 1,
@@ -128,6 +135,7 @@ ETH_DST_DEFAULT_CONFIG = ValveTableConfig(
     match_types=(('eth_dst', False), ('vlan_vid', False)),
     vlan_port_scale=4.1,
     )
+
 FLOOD_DEFAULT_CONFIG = ValveTableConfig(
     'flood',
     ETH_DST_DEFAULT_CONFIG.table_id + 1,
@@ -145,6 +153,7 @@ FAUCET_PIPELINE = (
     PORT_ACL_DEFAULT_CONFIG,
     VLAN_DEFAULT_CONFIG,
     VLAN_ACL_DEFAULT_CONFIG,
+    CLASSIFICATION_DEFAULT_CONFIG,
     ETH_SRC_DEFAULT_CONFIG,
     IPV4_FIB_DEFAULT_CONFIG,
     IPV6_FIB_DEFAULT_CONFIG,

--- a/faucet/faucet_pipeline.py
+++ b/faucet/faucet_pipeline.py
@@ -97,7 +97,7 @@ CLASSIFICATION_DEFAULT_CONFIG = ValveTableConfig(
     'classification',
     VLAN_ACL_DEFAULT_CONFIG.table_id + 1,
     miss_goto='eth_src',
-    next_tables=(('ipv4_fib', 'ipv6_fib') + _NEXT_VIP)
+    next_tables=(('eth_src', 'ipv4_fib', 'ipv6_fib') + _NEXT_VIP)
     )
 ETH_SRC_DEFAULT_CONFIG = ValveTableConfig(
     'eth_src',

--- a/faucet/faucet_pipeline.py
+++ b/faucet/faucet_pipeline.py
@@ -95,9 +95,9 @@ VLAN_ACL_DEFAULT_CONFIG = ValveTableConfig(
     next_tables=(('eth_src',) + _NEXT_ETH))
 CLASSIFICATION_DEFAULT_CONFIG = ValveTableConfig(
     'classification',
-    miss_goto='eth_dst'
     VLAN_ACL_DEFAULT_CONFIG.table_id + 1,
-    next_tables=('ipv4_fib', 'vip')
+    miss_goto='eth_src',
+    next_tables=(('ipv4_fib', 'ipv6_fib') + _NEXT_VIP)
     )
 ETH_SRC_DEFAULT_CONFIG = ValveTableConfig(
     'eth_src',
@@ -144,7 +144,7 @@ FLOOD_DEFAULT_CONFIG = ValveTableConfig(
     )
 
 MINIMUM_FAUCET_PIPELINE_TABLES = {
-    'vlan', 'eth_src', 'eth_dst', 'flood'}
+    'vlan', 'classification', 'eth_src', 'eth_dst', 'flood'}
 
 # TODO: implement an eth_type table before VLAN. This would enable interception
 # of control protocols and simplify matches in vlan/eth_src, enabling use of

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -203,12 +203,12 @@ class Valve:
         host_manager_cl = valve_host.ValveHostManager
         if self.dp.use_idle_timeout:
             host_manager_cl = valve_host.ValveHostFlowRemovedManager
-        self.host_manager = host_manager_cl(
-            self.logger, self.dp.ports, self.dp.vlans,
-            self.dp.tables['eth_src'], self.dp.tables['eth_dst'], eth_dst_hairpin_table,
-            self.dp.timeout, self.dp.learn_jitter, self.dp.learn_ban_timeout,
-            self.dp.low_priority, self.dp.highest_priority,
-            self.dp.cache_update_guard_time)
+        self.host_manager = host_manager_cl( self.logger, self.dp.ports,
+            self.dp.vlans, self.dp.tables['classification'],
+            self.dp.tables['eth_src'], self.dp.tables['eth_dst'],
+            eth_dst_hairpin_table, self.dp.timeout, self.dp.learn_jitter,
+            self.dp.learn_ban_timeout, self.dp.low_priority,
+            self.dp.highest_priority, self.dp.cache_update_guard_time)
         table_configs = sorted([
             (table.table_id, str(table.table_config)) for table in self.dp.tables.values()])
         for table_id, table_config in table_configs:
@@ -724,10 +724,10 @@ class Valve:
         for table in self.dp.output_tables():
             ofmsgs.extend(table.flowdel(out_port=port.number))
         if port.permanent_learn:
-            eth_src_table = self.dp.tables['eth_src']
+            classification_table = self.dp.tables['classification']
             for entry in port.hosts():
-                ofmsgs.extend(eth_src_table.flowdel(
-                    match=eth_src_table.match(eth_src=entry.eth_src)))
+                ofmsgs.extend(classification_table.flowdel(
+                    match=classification_table.match(eth_src=entry.eth_src)))
         for vlan in port.vlans():
             vlan.clear_cache_hosts_on_port(port)
         return ofmsgs

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -328,7 +328,7 @@ class Valve:
         ofmsgs = []
         if vlan.acls_in:
             acl_table = self.dp.tables['vlan_acl']
-            acl_allow_inst = acl_table.goto(self.dp.tables['eth_src'])
+            acl_allow_inst = acl_table.goto(self.dp.tables['classification'])
             acl_force_port_vlan_inst = acl_table.goto(self.dp.output_table())
             ofmsgs = valve_acl.build_acl_ofmsgs(
                 vlan.acls_in, acl_table,
@@ -703,7 +703,7 @@ class Valve:
     def _find_forwarding_table(self, vlan):
         if vlan.acls_in:
             return self.dp.tables['vlan_acl']
-        return self.dp.tables['eth_src']
+        return self.dp.tables['classification']
 
     def _port_add_vlans(self, port, mirror_act):
         ofmsgs = []

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -171,10 +171,12 @@ class Valve:
             proactive_learn = getattr(self.dp, 'proactive_learn_v%u' % ipv)
             route_manager = route_manager_class(
                 self.logger, self.dp.global_vlan, neighbor_timeout,
-                self.dp.max_hosts_per_resolve_cycle, self.dp.max_host_fib_retry_count,
-                self.dp.max_resolve_backoff_time, proactive_learn, self.DEC_TTL,
-                fib_table, self.dp.tables['vip'], self.dp.tables['eth_src'],
-                self.dp.output_table(), self.dp.highest_priority, self.dp.routers)
+                self.dp.max_hosts_per_resolve_cycle,
+                self.dp.max_host_fib_retry_count,
+                self.dp.max_resolve_backoff_time, proactive_learn,
+                self.DEC_TTL, fib_table, self.dp.tables['vip'],
+                self.dp.tables['classification'], self.dp.output_table(),
+                self.dp.highest_priority, self.dp.routers)
             self._route_manager_by_ipv[route_manager.IPV] = route_manager
             for vlan in list(self.dp.vlans.values()):
                 if vlan.faucet_vips_by_ipv(route_manager.IPV):
@@ -742,6 +744,7 @@ class Valve:
         ofmsgs = []
         vlans_with_ports_added = set()
         eth_src_table = self.dp.tables['eth_src']
+        classification_table = self.dp.tables['classification']
         vlan_table = self.dp.tables['vlan']
 
         for port_num in port_nums:
@@ -802,7 +805,7 @@ class Valve:
                 ofmsgs.append(vlan_table.flowmod(
                     match=vlan_table.match(in_port=port_num),
                     priority=self.dp.low_priority,
-                    inst=[vlan_table.goto(eth_src_table)]))
+                    inst=[vlan_table.goto(classification_table)]))
                 port_vlans = list(self.dp.vlans.values())
             else:
                 mirror_act = port.mirror_actions()

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -281,7 +281,7 @@ class Valve:
 
     def _add_default_drop_flows(self):
         """Add default drop rules on all FAUCET tables."""
-        eth_src_table = self.dp.tables['eth_src']
+        classification_table = self.dp.tables['classification']
         flood_table = self.dp.tables['flood']
 
         ofmsgs = []
@@ -298,20 +298,20 @@ class Valve:
 
         # drop broadcast sources
         if self.dp.drop_broadcast_source_address:
-            ofmsgs.append(eth_src_table.flowdrop(
-                eth_src_table.match(eth_src=valve_of.mac.BROADCAST_STR),
+            ofmsgs.append(classification_table.flowdrop(
+                classification_table.match(eth_src=valve_of.mac.BROADCAST_STR),
                 priority=self.dp.highest_priority))
 
-        ofmsgs.append(eth_src_table.flowdrop(
-            eth_src_table.match(eth_type=valve_of.ECTP_ETH_TYPE),
+        ofmsgs.append(classification_table.flowdrop(
+            classification_table.match(eth_type=valve_of.ECTP_ETH_TYPE),
             priority=self.dp.highest_priority))
 
         # antispoof for FAUCET's MAC address
         # TODO: antispoof for controller IPs on this VLAN, too.
         if self.dp.drop_spoofed_faucet_mac:
             for vlan in list(self.dp.vlans.values()):
-                ofmsgs.append(eth_src_table.flowdrop(
-                    eth_src_table.match(eth_src=vlan.faucet_mac),
+                ofmsgs.append(classification_table.flowdrop(
+                    classification_table.match(eth_src=vlan.faucet_mac),
                     priority=self.dp.high_priority))
 
         ofmsgs.append(flood_table.flowdrop(

--- a/tests/unit/faucet/test_config.py
+++ b/tests/unit/faucet/test_config.py
@@ -873,13 +873,15 @@ dps:
         dp = self._get_dps_as_dict(config)[0x1]
         tables = {
             'vlan': 0,
-            'eth_src': 1,
-            'eth_dst': 2,
-            'flood': 3
+            'classification': 1,
+            'eth_src': 2,
+            'eth_dst': 3,
+            'flood': 4
             }
         self._check_table_names_numbers(dp, tables)
-        self._check_next_tables(dp.tables['vlan'], [1])
-        self._check_next_tables(dp.tables['eth_src'], [2, 3])
+        self._check_next_tables(dp.tables['vlan'], [2])
+        self._check_next_tables(dp.tables['classification'], [3, 4])
+        self._check_next_tables(dp.tables['eth_src'], [3, 4])
         self._check_next_tables(dp.tables['eth_dst'], [])
         self._check_next_tables(dp.tables['flood'], [])
 
@@ -902,6 +904,7 @@ dps:
         tables = {
             'port_acl': 0,
             'vlan': 1,
+            'classification': 3,
             'eth_src': 4,
             'eth_dst': 9,
             'flood': 10
@@ -926,11 +929,12 @@ dps:
         dp = self._get_dps_as_dict(config)[0x1]
         tables = {
             'vlan': 0,
-            'eth_src': 1,
-            'ipv4_fib': 2,
-            'vip': 3,
-            'eth_dst': 4,
-            'flood': 5
+            'classification': 1,
+            'eth_src': 2,
+            'ipv4_fib': 3,
+            'vip': 4,
+            'eth_dst': 5,
+            'flood': 6
             }
         self._check_table_names_numbers(dp, tables)
 
@@ -952,12 +956,13 @@ dps:
         dp = self._get_dps_as_dict(config)[0x1]
         tables = {
             'vlan': 0,
-            'eth_src': 1,
-            'ipv4_fib': 2,
-            'ipv6_fib': 3,
-            'vip': 4,
-            'eth_dst': 5,
-            'flood': 6
+            'classification': 1,
+            'eth_src': 2,
+            'ipv4_fib': 3,
+            'ipv6_fib': 4,
+            'vip': 5,
+            'eth_dst': 6,
+            'flood': 7
             }
         self._check_table_names_numbers(dp, tables)
 
@@ -987,12 +992,13 @@ dps:
         tables = {
             'vlan': 0,
             'vlan_acl': 1,
-            'eth_src': 2,
-            'ipv4_fib': 3,
-            'ipv6_fib': 4,
-            'vip': 5,
-            'eth_dst': 6,
-            'flood': 7
+            'classification': 2,
+            'eth_src': 3,
+            'ipv4_fib': 4,
+            'ipv6_fib': 5,
+            'vip': 6,
+            'eth_dst': 7,
+            'flood': 8
             }
         self._check_table_names_numbers(dp, tables)
 
@@ -1024,21 +1030,23 @@ dps:
             'port_acl': 0,
             'vlan': 1,
             'vlan_acl': 2,
-            'eth_src': 3,
-            'ipv4_fib': 4,
-            'ipv6_fib': 5,
-            'vip': 6,
-            'eth_dst': 7,
-            'flood': 8
+            'classification': 3,
+            'eth_src': 4,
+            'ipv4_fib': 5,
+            'ipv6_fib': 6,
+            'vip': 7,
+            'eth_dst': 8,
+            'flood': 9
             }
         self._check_table_names_numbers(dp, tables)
-        self._check_next_tables(dp.tables['port_acl'], [1, 6, 7, 8])
-        self._check_next_tables(dp.tables['vlan'], [2, 3])
-        self._check_next_tables(dp.tables['vlan_acl'], [3, 7, 8])
-        self._check_next_tables(dp.tables['eth_src'], [4, 5, 6, 7, 8])
-        self._check_next_tables(dp.tables['ipv4_fib'], [6, 7, 8])
-        self._check_next_tables(dp.tables['ipv6_fib'], [6, 7, 8])
-        self._check_next_tables(dp.tables['vip'], [7, 8])
+        self._check_next_tables(dp.tables['port_acl'], [1, 7, 8, 9])
+        self._check_next_tables(dp.tables['vlan'], [2, 4])
+        self._check_next_tables(dp.tables['vlan_acl'], [4, 8, 9])
+        self._check_next_tables(dp.tables['classification'], [5, 6, 7, 8, 9])
+        self._check_next_tables(dp.tables['eth_src'], [5, 6, 7, 8, 9])
+        self._check_next_tables(dp.tables['ipv4_fib'], [7, 8, 9])
+        self._check_next_tables(dp.tables['ipv6_fib'], [7, 8, 9])
+        self._check_next_tables(dp.tables['vip'], [8, 9])
         self._check_next_tables(dp.tables['eth_dst'], [])
         self._check_next_tables(dp.tables['flood'], [])
 

--- a/tests/unit/faucet/test_config.py
+++ b/tests/unit/faucet/test_config.py
@@ -902,9 +902,9 @@ dps:
         tables = {
             'port_acl': 0,
             'vlan': 1,
-            'eth_src': 3,
-            'eth_dst': 8,
-            'flood': 9
+            'eth_src': 4,
+            'eth_dst': 9,
+            'flood': 10
             }
         self._check_table_names_numbers(dp, tables)
 

--- a/tests/unit/faucet/test_config.py
+++ b/tests/unit/faucet/test_config.py
@@ -880,7 +880,7 @@ dps:
             }
         self._check_table_names_numbers(dp, tables)
         self._check_next_tables(dp.tables['vlan'], [1])
-        self._check_next_tables(dp.tables['classification'], [3, 4])
+        self._check_next_tables(dp.tables['classification'], [2, 3, 4])
         self._check_next_tables(dp.tables['eth_src'], [3, 4])
         self._check_next_tables(dp.tables['eth_dst'], [])
         self._check_next_tables(dp.tables['flood'], [])
@@ -1042,7 +1042,7 @@ dps:
         self._check_next_tables(dp.tables['port_acl'], [1, 7, 8, 9])
         self._check_next_tables(dp.tables['vlan'], [2, 3])
         self._check_next_tables(dp.tables['vlan_acl'], [3, 8, 9])
-        self._check_next_tables(dp.tables['classification'], [5, 6, 7, 8, 9])
+        self._check_next_tables(dp.tables['classification'], [4, 5, 6, 7, 8, 9])
         self._check_next_tables(dp.tables['eth_src'], [8, 9])
         self._check_next_tables(dp.tables['ipv4_fib'], [7, 8, 9])
         self._check_next_tables(dp.tables['ipv6_fib'], [7, 8, 9])

--- a/tests/unit/faucet/test_config.py
+++ b/tests/unit/faucet/test_config.py
@@ -879,7 +879,7 @@ dps:
             'flood': 4
             }
         self._check_table_names_numbers(dp, tables)
-        self._check_next_tables(dp.tables['vlan'], [2])
+        self._check_next_tables(dp.tables['vlan'], [1])
         self._check_next_tables(dp.tables['classification'], [3, 4])
         self._check_next_tables(dp.tables['eth_src'], [3, 4])
         self._check_next_tables(dp.tables['eth_dst'], [])
@@ -1040,8 +1040,8 @@ dps:
             }
         self._check_table_names_numbers(dp, tables)
         self._check_next_tables(dp.tables['port_acl'], [1, 7, 8, 9])
-        self._check_next_tables(dp.tables['vlan'], [2, 4])
-        self._check_next_tables(dp.tables['vlan_acl'], [4, 8, 9])
+        self._check_next_tables(dp.tables['vlan'], [2, 3])
+        self._check_next_tables(dp.tables['vlan_acl'], [3, 8, 9])
         self._check_next_tables(dp.tables['classification'], [5, 6, 7, 8, 9])
         self._check_next_tables(dp.tables['eth_src'], [5, 6, 7, 8, 9])
         self._check_next_tables(dp.tables['ipv4_fib'], [7, 8, 9])

--- a/tests/unit/faucet/test_config.py
+++ b/tests/unit/faucet/test_config.py
@@ -1043,7 +1043,7 @@ dps:
         self._check_next_tables(dp.tables['vlan'], [2, 3])
         self._check_next_tables(dp.tables['vlan_acl'], [3, 8, 9])
         self._check_next_tables(dp.tables['classification'], [5, 6, 7, 8, 9])
-        self._check_next_tables(dp.tables['eth_src'], [5, 6, 7, 8, 9])
+        self._check_next_tables(dp.tables['eth_src'], [8, 9])
         self._check_next_tables(dp.tables['ipv4_fib'], [7, 8, 9])
         self._check_next_tables(dp.tables['ipv6_fib'], [7, 8, 9])
         self._check_next_tables(dp.tables['vip'], [8, 9])


### PR DESCRIPTION
Progress towards making the eth_src table static

creates a classification table before eth_src for directing packets to FIBs, filtering bogons and blocking mac spoofing.

The eth_src table still handles flows for override_output_port (see https://github.com/faucetsdn/faucet/issues/2448) and has vlan matches for the controller flows.