### PR TITLE
Egress table

### DIFF
--- a/faucet/dp.py
+++ b/faucet/dp.py
@@ -132,7 +132,9 @@ configuration.
         'cache_update_guard_time': 0,
         # Don't update L2 cache if port didn't change within this many seconds (default timeout/2).
         'use_classification': False,
-        # use a classification table to reduce the flow types in the eth_src table
+        # Don't update L2 cache if port didn't change within this many seconds.
+        'egress_pipeline': False
+        # Experimental inclusion of an egress pipeline
         }
 
     defaults_types = {
@@ -181,6 +183,7 @@ configuration.
         'global_vlan': int,
         'cache_update_guard_time': int,
         'use_classification': bool,
+        'egress_pipeline': bool
     }
 
     default_table_sizes_types = {
@@ -237,6 +240,7 @@ configuration.
         self.dyn_last_coldstart_time = None
         self.dyn_running = False
         self.dyn_up_ports = None
+        self.egress_pipeline = None
         self.faucet_dp_mac = None
         self.global_vlan = None
         self.groups = None

--- a/faucet/dp.py
+++ b/faucet/dp.py
@@ -397,6 +397,8 @@ configuration.
             included_tables.add('eth_dst_hairpin')
         if self.use_classification:
             included_tables.add('classification')
+        if self.egress_pipeline:
+            included_tables.add('egress')
         relative_table_id = 0
         table_configs = {}
         for canonical_table_config in faucet_pipeline.FAUCET_PIPELINE:

--- a/faucet/faucet_metadata.py
+++ b/faucet/faucet_metadata.py
@@ -1,7 +1,12 @@
+"""This module contains code relating to the use of OpenFlow Metadata within
+Faucet.
+"""
 PORT_METADATA_MASK = 0xFFF
 VLAN_METADATA_MASK = 0xFFF000
 EGRESS_METADATA_MASK = PORT_METADATA_MASK | VLAN_METADATA_MASK
 
 def get_egress_metadata(port_num, vid):
+    """Return the metadata value to output a packet to port port_num on vlan
+    vid"""
     metadata = vid << 12 | (port_num & PORT_METADATA_MASK)
     return metadata, EGRESS_METADATA_MASK

--- a/faucet/faucet_metadata.py
+++ b/faucet/faucet_metadata.py
@@ -1,0 +1,7 @@
+PORT_METADATA_MASK = 0xFFF
+VLAN_METADATA_MASK = 0xFFF000
+EGRESS_METADATA_MASK = PORT_METADATA_MASK | VLAN_METADATA_MASK
+
+def get_egress_metadata(port_num, vid):
+    metadata = vid << 12 | (port_num & PORT_METADATA_MASK)
+    return metadata, EGRESS_METADATA_MASK

--- a/faucet/faucet_pipeline.py
+++ b/faucet/faucet_pipeline.py
@@ -149,7 +149,7 @@ FLOOD_DEFAULT_CONFIG = ValveTableConfig(
 EGRESS_DEFAULT_CONFIG = ValveTableConfig(
     'egress',
     FLOOD_DEFAULT_CONFIG.table_id + 1,
-    match_types=(('metadata', True),),
+    match_types=(('metadata', True),('vlan_vid', False)),
     vlan_port_scale=1.5,
     metadata_match=EGRESS_METADATA_MASK
     )

--- a/faucet/faucet_pipeline.py
+++ b/faucet/faucet_pipeline.py
@@ -23,7 +23,8 @@ class ValveTableConfig: # pylint: disable=too-few-public-methods,too-many-instan
     def __init__(self, name, table_id, # pylint: disable=too-many-arguments
                  exact_match=None, meter=None, output=True, miss_goto=None,
                  size=None, match_types=None, set_fields=None, dec_ttl=None,
-                 vlan_port_scale=None, next_tables=None):
+                 vlan_port_scale=None, next_tables=None, metadata_match=0,
+                 metadata_write=0):
         self.name = name
         self.table_id = table_id
         self.exact_match = exact_match
@@ -35,6 +36,8 @@ class ValveTableConfig: # pylint: disable=too-few-public-methods,too-many-instan
         self.set_fields = set_fields
         self.dec_ttl = dec_ttl
         self.vlan_port_scale = vlan_port_scale
+        self.metadata_match = metadata_match
+        self.metadata_write = metadata_write
         if next_tables:
             assert isinstance(next_tables, (list, tuple))
             self.next_tables = next_tables

--- a/faucet/faucet_pipeline.py
+++ b/faucet/faucet_pipeline.py
@@ -16,8 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-PORT_METADATA_MASK = 0xFFF
-VLAN_METADATA_MASK = 0xFFF000
+from faucet.faucet_metadata import EGRESS_METADATA_MASK
 
 class ValveTableConfig: # pylint: disable=too-few-public-methods,too-many-instance-attributes
     """Configuration for a single table."""
@@ -139,7 +138,7 @@ ETH_DST_DEFAULT_CONFIG = ValveTableConfig(
     match_types=(('eth_dst', False), ('vlan_vid', False)),
     next_tables=('egress',),
     vlan_port_scale=4.1,
-    metadata_write=VLAN_METADATA_MASK & PORT_METADATA_MASK
+    metadata_write=EGRESS_METADATA_MASK
     )
 FLOOD_DEFAULT_CONFIG = ValveTableConfig(
     'flood',
@@ -152,7 +151,7 @@ EGRESS_DEFAULT_CONFIG = ValveTableConfig(
     FLOOD_DEFAULT_CONFIG.table_id + 1,
     match_types=(('metadata', True),),
     vlan_port_scale=1.5,
-    metadata_match=VLAN_METADATA_MASK & PORT_METADATA_MASK
+    metadata_match=EGRESS_METADATA_MASK
     )
 
 MINIMUM_FAUCET_PIPELINE_TABLES = {

--- a/faucet/faucet_pipeline.py
+++ b/faucet/faucet_pipeline.py
@@ -147,6 +147,13 @@ FLOOD_DEFAULT_CONFIG = ValveTableConfig(
     match_types=(('eth_dst', True), ('in_port', False), ('vlan_vid', False)),
     vlan_port_scale=2.1,
     )
+EGRESS_DEFAULT_CONFIG = ValveTableConfig(
+    'egress',
+    FLOOD_DEFAULT_CONFIG.table_id + 1,
+    match_types=(('metadata', True),),
+    vlan_port_scale=1.5,
+    metadata_match=VLAN_METADATA_MASK & PORT_METADATA_MASK
+    )
 
 MINIMUM_FAUCET_PIPELINE_TABLES = {
     'vlan', 'eth_src', 'eth_dst', 'flood'}

--- a/faucet/faucet_pipeline.py
+++ b/faucet/faucet_pipeline.py
@@ -16,6 +16,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+PORT_METADATA_MASK = 0xFFF
+VLAN_METADATA_MASK = 0xFFF000
 
 class ValveTableConfig: # pylint: disable=too-few-public-methods,too-many-instance-attributes
     """Configuration for a single table."""

--- a/faucet/faucet_pipeline.py
+++ b/faucet/faucet_pipeline.py
@@ -131,16 +131,16 @@ ETH_DST_HAIRPIN_DEFAULT_CONFIG = ValveTableConfig(
     exact_match=True,
     vlan_port_scale=4.1,
     )
-
 ETH_DST_DEFAULT_CONFIG = ValveTableConfig(
     'eth_dst',
     ETH_DST_HAIRPIN_DEFAULT_CONFIG.table_id + 1,
     exact_match=True,
     miss_goto='flood',
     match_types=(('eth_dst', False), ('vlan_vid', False)),
+    next_tables=('egress',),
     vlan_port_scale=4.1,
+    metadata_write=VLAN_METADATA_MASK & PORT_METADATA_MASK
     )
-
 FLOOD_DEFAULT_CONFIG = ValveTableConfig(
     'flood',
     ETH_DST_DEFAULT_CONFIG.table_id + 1,
@@ -173,6 +173,7 @@ FAUCET_PIPELINE = (
     ETH_DST_HAIRPIN_DEFAULT_CONFIG,
     ETH_DST_DEFAULT_CONFIG,
     FLOOD_DEFAULT_CONFIG,
+    EGRESS_DEFAULT_CONFIG
 )
 
 DEFAULT_CONFIGS = {
@@ -186,4 +187,5 @@ DEFAULT_CONFIGS = {
     'eth_dst_hairpin': ETH_DST_HAIRPIN_DEFAULT_CONFIG,
     'eth_dst': ETH_DST_DEFAULT_CONFIG,
     'flood': FLOOD_DEFAULT_CONFIG,
+    'egress': EGRESS_DEFAULT_CONFIG,
 }

--- a/faucet/tfm_pipeline.py
+++ b/faucet/tfm_pipeline.py
@@ -12,8 +12,8 @@ def load_tables(dp, valve_cl): # pylint: disable=invalid-name
         table_attr = {
             'config': 3,
             'max_entries': valve_table.table_config.size,
-            'metadata_match': 0,
-            'metadata_write': 0,
+            'metadata_match': valve_table.metadata_match,
+            'metadata_write': valve_table.metadata_write,
             'name': valve_table.name.encode('utf-8'),
             'properties': [],
             'table_id': table_id,

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -201,15 +201,17 @@ class Valve:
                 self.dp.group_table, self.dp.groups,
                 self.dp.combinatorial_port_flood)
         eth_dst_hairpin_table = self.dp.tables.get('eth_dst_hairpin', None)
+        egress_table = self.dp.tables.get('egress', None)
         host_manager_cl = valve_host.ValveHostManager
         if self.dp.use_idle_timeout:
             host_manager_cl = valve_host.ValveHostFlowRemovedManager
         self.host_manager = host_manager_cl( self.logger, self.dp.ports,
             self.dp.vlans, classification_table,
             self.dp.tables['eth_src'], self.dp.tables['eth_dst'],
-            eth_dst_hairpin_table, self.dp.timeout, self.dp.learn_jitter,
-            self.dp.learn_ban_timeout, self.dp.low_priority,
-            self.dp.highest_priority, self.dp.cache_update_guard_time)
+            eth_dst_hairpin_table, egress_table, self.dp.timeout,
+            self.dp.learn_jitter, self.dp.learn_ban_timeout,
+            self.dp.low_priority, self.dp.highest_priority,
+            self.dp.cache_update_guard_time)
         table_configs = sorted([
             (table.table_id, str(table.table_config)) for table in self.dp.tables.values()])
         for table_id, table_config in table_configs:

--- a/faucet/valve_host.py
+++ b/faucet/valve_host.py
@@ -66,7 +66,8 @@ class ValveHostManager:
         if entry is None:
             if port.max_hosts:
                 if port.hosts_count() == port.max_hosts:
-                    ofmsgs.append(self._temp_ban_host_learning(self.eth_src_table.match(in_port=port.number)))
+                    ofmsgs.append(self._temp_ban_host_learning(
+                        self.eth_src_table.match(in_port=port.number)))
                     port.dyn_learn_ban_count += 1
                     self.logger.info(
                         'max hosts %u reached on %s, '
@@ -143,7 +144,9 @@ class ValveHostManager:
 
     def learn_host_on_vlan_port_flows(self, port, vlan, eth_src,
                                       delete_existing, refresh_rules,
-                                      src_rule_idle_timeout, src_rule_hard_timeout, dst_rule_idle_timeout):
+                                      src_rule_idle_timeout,
+                                      src_rule_hard_timeout,
+                                      dst_rule_idle_timeout):
         """Return flows that implement learning a host on a port."""
         ofmsgs = []
 
@@ -268,7 +271,8 @@ class ValveHostManager:
             # already, or newly in protect mode, apply the ban rules.
             if learn_ban:
                 port.dyn_last_ban_time = now
-                ofmsgs.append(self._temp_ban_host_learning(self.eth_src_table.match(in_port=port.number)))
+                ofmsgs.append(self._temp_ban_host_learning(
+                    self.eth_src_table.match(in_port=port.number)))
                 return (ofmsgs, cache_port)
 
         (src_rule_idle_timeout,

--- a/faucet/valve_host.py
+++ b/faucet/valve_host.py
@@ -20,6 +20,7 @@
 import random
 
 from faucet import valve_of
+from faucet.faucet_metadata import get_egress_metadata
 
 
 class ValveHostManager:
@@ -27,9 +28,8 @@ class ValveHostManager:
 
     def __init__(self, logger, ports, vlans, classification_table,
                  eth_src_table, eth_dst_table, eth_dst_hairpin_table,
-                 learn_timeout, learn_jitter, learn_ban_timeout,
-                 low_priority, host_priority,
-                 cache_update_guard_time):
+                 egress_table, learn_timeout, learn_jitter, learn_ban_timeout,
+                 low_priority, host_priority, cache_update_guard_time):
         self.logger = logger
         self.ports = ports
         self.vlans = vlans
@@ -37,6 +37,7 @@ class ValveHostManager:
         self.eth_src_table = eth_src_table
         self.eth_dst_table = eth_dst_table
         self.eth_dst_hairpin_table = eth_dst_hairpin_table
+        self.egress_table = egress_table
         self.learn_timeout = learn_timeout
         self.learn_jitter = learn_jitter
         self.learn_ban_timeout = learn_ban_timeout
@@ -185,11 +186,20 @@ class ValveHostManager:
             return ofmsgs
 
         # Output packets for this MAC to specified port.
-        ofmsgs.append(self.eth_dst_table.flowmod(
-            self.eth_dst_table.match(vlan=vlan, eth_dst=eth_src),
-            priority=self.host_priority,
-            inst=[valve_of.apply_actions(vlan.output_port(port))],
-            idle_timeout=dst_rule_idle_timeout))
+        if self.egress_table is not None:
+            metadata, metadata_mask = get_egress_metadata(port.number, vlan.vid)
+            ofmsgs.append(self.eth_dst_table.flowmod(
+                self.eth_dst_table.match(vlan=vlan, eth_dst=eth_src),
+                priority=self.host_priority,
+                inst=valve_of.metadata_goto_table(
+                    metadata, metadata_mask, self.egress_table),
+                idle_timeout=dst_rule_idle_timeout))
+        else:
+            ofmsgs.append(self.eth_dst_table.flowmod(
+                self.eth_dst_table.match(vlan=vlan, eth_dst=eth_src),
+                priority=self.host_priority,
+                inst=[valve_of.apply_actions(vlan.output_port(port))],
+                idle_timeout=dst_rule_idle_timeout))
 
         # If port is in hairpin mode, install a special rule
         # that outputs packets destined to this MAC back out the same

--- a/faucet/valve_of.py
+++ b/faucet/valve_of.py
@@ -479,11 +479,10 @@ def _match_ip_masked(ipa):
     return (str(ipa.ip), str(ipa.netmask))
 
 
-def build_match_dict(in_port=None, vlan=None,
-                     eth_type=None, eth_src=None,
-                     eth_dst=None, eth_dst_mask=None,
-                     icmpv6_type=None,
-                     nw_proto=None, nw_dst=None):
+def build_match_dict(in_port=None, vlan=None, eth_type=None, eth_src=None,
+                     eth_dst=None, eth_dst_mask=None, icmpv6_type=None,
+                     nw_proto=None, nw_dst=None, metadata=None,
+                     metadata_mask=None):
     match_dict = {}
     if in_port is not None:
         match_dict['in_port'] = in_port
@@ -515,6 +514,11 @@ def build_match_dict(in_port=None, vlan=None,
             match_dict['ipv6_dst'] = nw_dst_masked
     if eth_type is not None:
         match_dict['eth_type'] = eth_type
+    if metadata is not None:
+        if metadata_mask is not None:
+            match_dict['metadata'] = (metadata, metadata_mask)
+        else:
+            match_dict['metadata'] = metadata
     return match_dict
 
 

--- a/faucet/valve_of.py
+++ b/faucet/valve_of.py
@@ -241,6 +241,19 @@ def goto_table(table):
     """
     return parser.OFPInstructionGotoTable(table.table_id)
 
+def metadata_goto_table(metadata, mask, table):
+    """Return instructions to write metadata and goto table.
+
+    Args:
+        metadata (int): metadata to write to packet
+        maks (int): mask to apply to metadata
+        table (ValveTable): table to goto.
+    Returns:
+        list of OFPInstructions"""
+    return [
+        parser.OFPInstructionWriteMetadata(metadata, mask),
+        parser.OFPInstructionGotoTable(table.table_id)
+        ]
 
 def set_field(**kwds):
     """Return action to set any field.
@@ -349,7 +362,6 @@ def output_controller(max_len=MAX_PACKET_IN_BYTES):
         ryu.ofproto.ofproto_v1_3_parser.OFPActionOutput: packet in action.
     """
     return output_port(ofp.OFPP_CONTROLLER, max_len)
-
 
 def packetouts(port_nums, data):
     """Return OpenFlow action to mulltiply packet out to dataplane from controller.

--- a/faucet/valve_table.py
+++ b/faucet/valve_table.py
@@ -82,15 +82,14 @@ class ValveTable: # pylint: disable=too-many-arguments,too-many-instance-attribu
     # TODO: verify actions
     @staticmethod
     def match(in_port=None, vlan=None, # pylint: disable=too-many-arguments
-              eth_type=None, eth_src=None,
-              eth_dst=None, eth_dst_mask=None,
-              icmpv6_type=None,
-              nw_proto=None, nw_dst=None):
+              eth_type=None, eth_src=None, eth_dst=None, eth_dst_mask=None,
+              icmpv6_type=None, nw_proto=None, nw_dst=None, metadata=None,
+              metadata_mask=None):
         """Compose an OpenFlow match rule."""
         match_dict = valve_of.build_match_dict(
             in_port, vlan, eth_type, eth_src,
             eth_dst, eth_dst_mask, icmpv6_type,
-            nw_proto, nw_dst)
+            nw_proto, nw_dst, metadata, metadata_mask)
         return valve_of.match(match_dict)
 
     def _verify_flowmod(self, flowmod):

--- a/faucet/valve_table.py
+++ b/faucet/valve_table.py
@@ -34,6 +34,8 @@ class ValveTable: # pylint: disable=too-many-arguments,too-many-instance-attribu
         self.set_fields = self.table_config.set_fields
         self.exact_match = self.table_config.exact_match
         self.match_types = None
+        self.metadata_match = self.table_config.metadata_match
+        self.metadata_write = self.table_config.metadata_write
         if next_tables:
             self.next_tables = next_tables
         else:

--- a/tests/integration/mininet_tests.py
+++ b/tests/integration/mininet_tests.py
@@ -156,7 +156,6 @@ vlans:
                 'nc -U %s' % sock, 10))
         self.verify_events_log(event_log)
 
-
 class Faucet8021XSuccessTest(FaucetUntaggedTest):
 
     SOFTWARE_ONLY = True
@@ -1716,6 +1715,23 @@ vlans:
         self.verify_broadcast()
         self.verify_no_bcast_to_self()
 
+class FaucetTaggedAndUntaggedSameVlanEgressTest(FaucetTaggedAndUntaggedSameVlanTest):
+    CONFIG = """
+        egress_pipeline: True
+        interfaces:
+            %(port_1)d:
+                tagged_vlans: [100]
+                description: "b1"
+            %(port_2)d:
+                native_vlan: 100
+                description: "b2"
+            %(port_3)d:
+                native_vlan: 100
+                description: "b3"
+            %(port_4)d:
+                native_vlan: 100
+                description: "b4"
+"""
 
 class FaucetTaggedAndUntaggedSameVlanGroupTest(FaucetTaggedAndUntaggedSameVlanTest):
 

--- a/tests/unit/faucet/fakeoftable.py
+++ b/tests/unit/faucet/fakeoftable.py
@@ -205,6 +205,11 @@ class FakeOFTable:
                         for action in instruction.actions:
                             if action.type == ofp.OFPAT_SET_FIELD:
                                 packet_dict[action.key] = action.value
+                    elif instruction.type == ofp.OFPIT_WRITE_METADATA:
+                        metadata = packet_dict.get('metadata', 0)
+                        packet_dict['metadata'] = metadata | (
+                            instruction.metadata & instruction.metadata_mask
+                            )
         return instructions
 
     def is_output(self, match, port=None, vid=None):

--- a/tests/unit/faucet/test_config.py
+++ b/tests/unit/faucet/test_config.py
@@ -1014,6 +1014,7 @@ dps:
     sw1:
         dp_id: 0x1
         use_classification: True
+        egress_pipeline: True
         interfaces:
             1:
                 native_vlan: office
@@ -1031,7 +1032,8 @@ dps:
             'ipv6_fib': 6,
             'vip': 7,
             'eth_dst': 8,
-            'flood': 9
+            'flood': 9,
+            'egress': 10
             }
         self._check_table_names_numbers(dp, tables)
         self._check_next_tables(dp.tables['port_acl'], [1, 7, 8, 9])
@@ -1042,8 +1044,9 @@ dps:
         self._check_next_tables(dp.tables['ipv4_fib'], [7, 8, 9])
         self._check_next_tables(dp.tables['ipv6_fib'], [7, 8, 9])
         self._check_next_tables(dp.tables['vip'], [8, 9])
-        self._check_next_tables(dp.tables['eth_dst'], [])
+        self._check_next_tables(dp.tables['eth_dst'], [10])
         self._check_next_tables(dp.tables['flood'], [])
+        self._check_next_tables(dp.tables['egress'], [])
 
     def test_pipeline_config_egress(self):
         """Test pipelines are generated correctly with different configs"""
@@ -1063,19 +1066,12 @@ dps:
         dp = self._get_dps_as_dict(config)[0x1]
         tables = {
             'vlan': 0,
-            'classification': 1,
-            'eth_src': 2,
-            'eth_dst': 3,
-            'flood': 4,
-            'egress': 5
+            'eth_src': 1,
+            'eth_dst': 2,
+            'flood': 3,
+            'egress': 4
             }
         self._check_table_names_numbers(dp, tables)
-        self._check_next_tables(dp.tables['vlan'], [1])
-        self._check_next_tables(dp.tables['classification'], [2, 3, 4])
-        self._check_next_tables(dp.tables['eth_src'], [3, 4])
-        self._check_next_tables(dp.tables['eth_dst'], [5])
-        self._check_next_tables(dp.tables['flood'], [])
-        self._check_next_tables(dp.tables['egress'], [])
 
 
     ###########################################

--- a/tests/unit/faucet/test_config.py
+++ b/tests/unit/faucet/test_config.py
@@ -1045,6 +1045,38 @@ dps:
         self._check_next_tables(dp.tables['eth_dst'], [])
         self._check_next_tables(dp.tables['flood'], [])
 
+    def test_pipeline_config_egress(self):
+        """Test pipelines are generated correctly with different configs"""
+        config = """
+vlans:
+    office:
+        vid: 100
+dps:
+    sw1:
+        egress_pipeline: True
+        dp_id: 0x1
+        interfaces:
+            1:
+                native_vlan: office
+"""
+        self.check_config_success(config, cp.dp_parser)
+        dp = self._get_dps_as_dict(config)[0x1]
+        tables = {
+            'vlan': 0,
+            'classification': 1,
+            'eth_src': 2,
+            'eth_dst': 3,
+            'flood': 4,
+            'egress': 5
+            }
+        self._check_table_names_numbers(dp, tables)
+        self._check_next_tables(dp.tables['vlan'], [1])
+        self._check_next_tables(dp.tables['classification'], [2, 3, 4])
+        self._check_next_tables(dp.tables['eth_src'], [3, 4])
+        self._check_next_tables(dp.tables['eth_dst'], [5])
+        self._check_next_tables(dp.tables['flood'], [])
+        self._check_next_tables(dp.tables['egress'], [])
+
 
     ###########################################
     # Tests of Configuration Failure Handling #

--- a/tests/unit/faucet/test_valve.py
+++ b/tests/unit/faucet/test_valve.py
@@ -66,6 +66,7 @@ FAUCET_MAC = '0e:00:00:00:00:01'
 # (ie. do not output to in_port)
 DP1_CONFIG = """
         dp_id: 1
+        egress_pipeline: True
         ignore_learn_ins: 100
         combinatorial_port_flood: True
         ofchannel_log: '/dev/null'
@@ -312,7 +313,7 @@ class ValveTestBases:
         DP = 's1'
         DP_ID = 1
         NUM_PORTS = 5
-        NUM_TABLES = 9
+        NUM_TABLES = 10
         P1_V100_MAC = '00:00:00:01:00:01'
         P2_V200_MAC = '00:00:00:02:00:02'
         P3_V200_MAC = '00:00:00:02:00:03'
@@ -1372,6 +1373,12 @@ class ValveTestCase(ValveTestBases.ValveTestBig):
 
     pass
 
+class ValveTestEgressPipeline(ValveTestBases.ValveTestBig):
+    """Run complete set of basic tests."""
+
+    DP1_CONFIG = """
+            egress_pipeline: True
+    """ + DP1_CONFIG
 
 class ValveFuzzTestCase(ValveTestBases.ValveTestSmall):
     """Test unknown ports/VLANs."""


### PR DESCRIPTION
A step towards having an egress pipeline. This creates an egress table for unicast traffic.

Instead of outputting directly the eth_dst table will set metadata matching vlan and port and forward the traffic to the egress table, which then matches metadata and vlan and applies vlan actions and outputs the packet.

It has to match vlan so it can use a pop vlan action.