### PR TITLE
Valve pipeline

### DIFF
--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -316,8 +316,8 @@ class Valve:
         ofmsgs = []
         if vlan.acls_in:
             acl_table = self.dp.tables['vlan_acl']
-            acl_allow_inst = acl_table.goto(self.dp.classification_table())
-            acl_force_port_vlan_inst = acl_table.goto(self.dp.output_table())
+            acl_allow_inst = self.pipeline.accept_to_classification()[0]
+            acl_force_port_vlan_inst = self.pipeline.accept_to_l2_forwarding()[0]
             ofmsgs = valve_acl.build_acl_ofmsgs(
                 vlan.acls_in, acl_table,
                 acl_allow_inst, acl_force_port_vlan_inst,

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -368,11 +368,6 @@ class Valve:
         ofmsgs.extend(self._vlan_add_acl(vlan))
         for manager in self._get_managers():
             ofmsgs.extend(manager.add_vlan(vlan))
-        # add controller IPs if configured.
-        for ipv in vlan.ipvs():
-            route_manager = self._route_manager_by_ipv[ipv]
-            ofmsgs.extend(self._add_faucet_vips(
-                route_manager, vlan, vlan.faucet_vips_by_ipv(ipv)))
         # install eth_dst_table flood ofmsgs
         ofmsgs.extend(self.flood_manager.build_flood_rules(vlan))
         return ofmsgs
@@ -1496,13 +1491,6 @@ class Valve:
         else:
             ofmsgs = []
         self._notify({'CONFIG_CHANGE': {'restart_type': restart_type}})
-        return ofmsgs
-
-    @staticmethod
-    def _add_faucet_vips(route_manager, vlan, faucet_vips):
-        ofmsgs = []
-        for faucet_vip in faucet_vips:
-            ofmsgs.extend(route_manager.add_faucet_vip(vlan, faucet_vip))
         return ofmsgs
 
     def add_authed_mac(self, port_num, mac):

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -289,9 +289,6 @@ class Valve:
     def _add_default_drop_flows(self):
         """Add default drop rules on all FAUCET tables."""
         ofmsgs = []
-        ofmsgs.extend(self.pipeline.initialise_tables())
-        flood_table = self.dp.tables['flood']
-
         for table in list(self.dp.tables.values()):
             miss_table_name = table.table_config.miss_goto
             if miss_table_name:
@@ -303,15 +300,8 @@ class Valve:
                 ofmsgs.append(table.flowdrop(
                     priority=self.dp.lowest_priority))
 
-        ofmsgs.append(flood_table.flowdrop(
-            flood_table.match(
-                eth_dst=valve_packet.CISCO_SPANNING_GROUP_ADDRESS),
-            priority=self.dp.highest_priority))
-        ofmsgs.append(flood_table.flowdrop(
-            flood_table.match(
-                eth_dst=valve_packet.BRIDGE_GROUP_ADDRESS,
-                eth_dst_mask=valve_packet.BRIDGE_GROUP_MASK),
-            priority=self.dp.highest_priority))
+        ofmsgs.extend(self.pipeline.initialise_tables())
+        ofmsgs.extend(self.flood_manager.initialise_tables())
 
         return ofmsgs
 

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -728,7 +728,6 @@ class Valve:
         ofmsgs = []
         vlans_with_ports_added = set()
         eth_src_table = self.dp.tables['eth_src']
-        classification_table = self.dp.classification_table()
         vlan_table = self.dp.tables['vlan']
 
         for port_num in port_nums:
@@ -788,7 +787,7 @@ class Valve:
                 ofmsgs.append(vlan_table.flowmod(
                     match=vlan_table.match(in_port=port_num),
                     priority=self.dp.low_priority,
-                    inst=[vlan_table.goto(classification_table)]))
+                    inst=self.pipeline.accept_to_classification()))
                 port_vlans = list(self.dp.vlans.values())
             else:
                 mirror_act = port.mirror_actions()

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -213,12 +213,11 @@ class Valve:
             host_manager_cl = valve_host.ValveHostFlowRemovedManager
         self.host_manager = host_manager_cl(
             self.logger, self.dp.ports,
-            self.dp.vlans, classification_table,
-            self.dp.tables['eth_src'], self.dp.tables['eth_dst'],
-            eth_dst_hairpin_table, egress_table, self.dp.timeout,
-            self.dp.learn_jitter, self.dp.learn_ban_timeout,
-            self.dp.low_priority, self.dp.highest_priority,
-            self.dp.cache_update_guard_time)
+            self.dp.vlans, self.dp.tables['eth_src'],
+            self.dp.tables['eth_dst'], eth_dst_hairpin_table, egress_table,
+            self.pipeline, self.dp.timeout, self.dp.learn_jitter,
+            self.dp.learn_ban_timeout, self.dp.low_priority,
+            self.dp.highest_priority, self.dp.cache_update_guard_time)
         table_configs = sorted([
             (table.table_id, str(table.table_config)) for table in self.dp.tables.values()])
         for table_id, table_config in table_configs:

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -368,8 +368,6 @@ class Valve:
         ofmsgs.extend(self._vlan_add_acl(vlan))
         for manager in self._get_managers():
             ofmsgs.extend(manager.add_vlan(vlan))
-        # install eth_dst_table flood ofmsgs
-        ofmsgs.extend(self.flood_manager.build_flood_rules(vlan))
         return ofmsgs
 
     def _del_vlan(self, vlan):

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -31,6 +31,7 @@ from faucet import valve_packet
 from faucet import valve_route
 from faucet import valve_table
 from faucet import valve_util
+from faucet import valve_pipeline
 
 from faucet.port import STACK_STATE_INIT, STACK_STATE_UP, STACK_STATE_DOWN
 from faucet.vlan import NullVLAN
@@ -157,6 +158,7 @@ class Valve:
 
         self.dp.reset_refs()
 
+        self.pipeline = valve_pipeline.ValvePipeline(self.dp)
         classification_table = self.dp.classification_table()
         for vlan_vid in list(self.dp.vlans.keys()):
             self._port_highwater[vlan_vid] = {}
@@ -180,6 +182,7 @@ class Valve:
                 self.dp.multi_out,
                 fib_table, self.dp.tables['vip'],
                 classification_table, self.dp.output_table(),
+                self.pipeline,
                 self.dp.highest_priority, self.dp.routers)
             self._route_manager_by_ipv[route_manager.IPV] = route_manager
             for vlan in list(self.dp.vlans.values()):

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -212,7 +212,7 @@ class Valve:
         self.host_manager = host_manager_cl(
             self.logger, self.dp.ports,
             self.dp.vlans, self.dp.tables['eth_src'],
-            self.dp.tables['eth_dst'], eth_dst_hairpin_table, egress_table,
+            self.dp.tables['eth_dst'], eth_dst_hairpin_table,
             self.pipeline, self.dp.timeout, self.dp.learn_jitter,
             self.dp.learn_ban_timeout, self.dp.low_priority,
             self.dp.highest_priority, self.dp.cache_update_guard_time)

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -205,7 +205,6 @@ class Valve:
                 self.dp.group_table, self.dp.groups,
                 self.dp.combinatorial_port_flood)
         eth_dst_hairpin_table = self.dp.tables.get('eth_dst_hairpin', None)
-        egress_table = self.dp.tables.get('egress', None)
         host_manager_cl = valve_host.ValveHostManager
         if self.dp.use_idle_timeout:
             host_manager_cl = valve_host.ValveHostFlowRemovedManager
@@ -727,7 +726,6 @@ class Valve:
         """
         ofmsgs = []
         vlans_with_ports_added = set()
-        eth_src_table = self.dp.tables['eth_src']
         vlan_table = self.dp.tables['vlan']
 
         for port_num in port_nums:

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -181,7 +181,7 @@ class Valve:
                 self.DEC_TTL,
                 self.dp.multi_out,
                 fib_table, self.dp.tables['vip'],
-                classification_table, self.dp.output_table(),
+                self.dp.output_table(),
                 self.pipeline,
                 self.dp.highest_priority, self.dp.routers)
             self._route_manager_by_ipv[route_manager.IPV] = route_manager

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -792,15 +792,6 @@ class Valve:
                     pkt = self._lacp_pkt(port.dyn_last_lacp_pkt, port)
                     ofmsgs.append(valve_of.packetout(port.number, pkt.data))
 
-            if port.override_output_port:
-                ofmsgs.append(eth_src_table.flowmod(
-                    match=eth_src_table.match(
-                        in_port=port_num),
-                    priority=self.dp.low_priority + 1,
-                    inst=[valve_of.apply_actions([
-                        valve_of.output_controller(),
-                        valve_of.output_port(port.override_output_port.number)])]))
-
             if port.dot1x:
                 ofmsgs.extend(self.dot1x.get_port_acls(self, port))
 

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -701,9 +701,6 @@ class Valve:
         """Delete flows/state for a port."""
         ofmsgs = []
         ofmsgs.extend(self._delete_all_port_match_flows(port))
-        if self.dp.egress_pipeline:
-            ofmsgs.extend(
-                self.dp.tables['egress'].flowdel(out_port=port.number))
         for manager in self._get_managers():
             ofmsgs.extend(manager.del_port(port))
         if port.permanent_learn:

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -703,11 +703,6 @@ class Valve:
         ofmsgs.extend(self._delete_all_port_match_flows(port))
         for manager in self._get_managers():
             ofmsgs.extend(manager.del_port(port))
-        if port.permanent_learn:
-            classification_table = self.dp.classification_table()
-            for entry in port.hosts():
-                ofmsgs.extend(classification_table.flowdel(
-                    match=classification_table.match(eth_src=entry.eth_src)))
         for vlan in port.vlans():
             vlan.clear_cache_hosts_on_port(port)
         return ofmsgs

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -221,6 +221,18 @@ class Valve:
         for table_id, table_config in table_configs:
             self.logger.info('table ID %u %s' % (table_id, table_config))
 
+    def _get_managers(self):
+        managers = (
+            self.pipeline,
+            self.host_manager,
+            self._route_manager_by_ipv.get(4),
+            self._route_manager_by_ipv.get(6),
+            self.flood_manager
+            )
+        for manager in managers:
+            if manager is not None:
+                yield manager
+
     def _notify(self, event_dict):
         """Send an event notification."""
         self.notifier.notify(self.dp.dp_id, self.dp.name, event_dict)
@@ -299,10 +311,6 @@ class Valve:
             else:
                 ofmsgs.append(table.flowdrop(
                     priority=self.dp.lowest_priority))
-
-        ofmsgs.extend(self.pipeline.initialise_tables())
-        ofmsgs.extend(self.flood_manager.initialise_tables())
-
         return ofmsgs
 
     def _vlan_add_acl(self, vlan):
@@ -621,6 +629,8 @@ class Valve:
                 'reason': 'cold_start'}})
         ofmsgs = []
         ofmsgs.extend(self._add_default_flows())
+        for manager in self._get_managers():
+            ofmsgs.extend(manager.initialise_tables())
         ofmsgs.extend(self._add_ports_and_vlans(discovered_up_ports))
         ofmsgs.append(
             valve_of.faucet_async(

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -159,7 +159,6 @@ class Valve:
         self.dp.reset_refs()
 
         self.pipeline = valve_pipeline.ValvePipeline(self.dp)
-        classification_table = self.dp.classification_table()
         for vlan_vid in list(self.dp.vlans.keys()):
             self._port_highwater[vlan_vid] = {}
             for port_number in list(self.dp.ports.keys()):
@@ -290,10 +289,10 @@ class Valve:
 
     def _add_default_drop_flows(self):
         """Add default drop rules on all FAUCET tables."""
-        classification_table = self.dp.classification_table()
+        ofmsgs = []
+        ofmsgs.extend(self.pipeline.initialise_tables())
         flood_table = self.dp.tables['flood']
 
-        ofmsgs = []
         for table in list(self.dp.tables.values()):
             miss_table_name = table.table_config.miss_goto
             if miss_table_name:
@@ -304,24 +303,6 @@ class Valve:
             else:
                 ofmsgs.append(table.flowdrop(
                     priority=self.dp.lowest_priority))
-
-        # drop broadcast sources
-        if self.dp.drop_broadcast_source_address:
-            ofmsgs.append(classification_table.flowdrop(
-                classification_table.match(eth_src=valve_of.mac.BROADCAST_STR),
-                priority=self.dp.highest_priority))
-
-        ofmsgs.append(classification_table.flowdrop(
-            classification_table.match(eth_type=valve_of.ECTP_ETH_TYPE),
-            priority=self.dp.highest_priority))
-
-        # antispoof for FAUCET's MAC address
-        # TODO: antispoof for controller IPs on this VLAN, too.
-        if self.dp.drop_spoofed_faucet_mac:
-            for vlan in list(self.dp.vlans.values()):
-                ofmsgs.append(classification_table.flowdrop(
-                    classification_table.match(eth_src=vlan.faucet_mac),
-                    priority=self.dp.high_priority))
 
         ofmsgs.append(flood_table.flowdrop(
             flood_table.match(

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -373,12 +373,6 @@ class Valve:
                 route_manager, vlan, vlan.faucet_vips_by_ipv(ipv)))
         # install eth_dst_table flood ofmsgs
         ofmsgs.extend(self.flood_manager.build_flood_rules(vlan))
-        # add learn rule for this VLAN.
-        eth_src_table = self.dp.tables['eth_src']
-        ofmsgs.append(eth_src_table.flowcontroller(
-            eth_src_table.match(vlan=vlan),
-            priority=self.dp.low_priority,
-            inst=[eth_src_table.goto(self.dp.output_table())]))
         return ofmsgs
 
     def _del_vlan(self, vlan):

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -180,7 +180,6 @@ class Valve:
                 self.DEC_TTL,
                 self.dp.multi_out,
                 fib_table, self.dp.tables['vip'],
-                self.dp.output_table(),
                 self.pipeline,
                 self.dp.highest_priority, self.dp.routers)
             self._route_manager_by_ipv[route_manager.IPV] = route_manager

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -701,8 +701,6 @@ class Valve:
         """Delete flows/state for a port."""
         ofmsgs = []
         ofmsgs.extend(self._delete_all_port_match_flows(port))
-        for table in self.dp.output_tables():
-            ofmsgs.extend(table.flowdel(out_port=port.number))
         if self.dp.egress_pipeline:
             ofmsgs.extend(
                 self.dp.tables['egress'].flowdel(out_port=port.number))

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -366,6 +366,8 @@ class Valve:
         self.logger.info('Configuring %s' % vlan)
         # add ACL rules
         ofmsgs.extend(self._vlan_add_acl(vlan))
+        for manager in self._get_managers():
+            ofmsgs.extend(manager.add_vlan(vlan))
         # add controller IPs if configured.
         for ipv in vlan.ipvs():
             route_manager = self._route_manager_by_ipv[ipv]

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -683,24 +683,6 @@ class Valve:
             inst=inst
             )
 
-    def _add_egress_table_rule(self, port, vlan, mirror_act, pop_vlan=True):
-        egress_table = self.dp.tables['egress']
-        metadata, metadata_mask = get_egress_metadata(port.number, vlan.vid)
-        actions = copy.copy(mirror_act)
-        if pop_vlan:
-            actions.append(valve_of.pop_vlan())
-        actions.append(valve_of.output_port(port.number))
-        inst = [valve_of.apply_actions(actions)]
-        return egress_table.flowmod(
-            egress_table.match(
-                vlan=vlan,
-                metadata=metadata,
-                metadata_mask=metadata_mask
-                ),
-            priority=self.dp.high_priority,
-            inst=inst
-            )
-
     def _find_forwarding_table(self, vlan):
         if vlan.acls_in:
             return self.dp.tables['vlan_acl']
@@ -711,15 +693,9 @@ class Valve:
         for vlan in port.tagged_vlans:
             ofmsgs.append(self._port_add_vlan_rules(
                 port, vlan, mirror_act, push_vlan=False))
-            if self.dp.egress_pipeline:
-                ofmsgs.append(self._add_egress_table_rule(
-                    port, vlan, mirror_act, pop_vlan=False))
         if port.native_vlan is not None:
             ofmsgs.append(self._port_add_vlan_rules(
                 port, port.native_vlan, mirror_act))
-            if self.dp.egress_pipeline:
-                ofmsgs.append(self._add_egress_table_rule(
-                    port, port.native_vlan, mirror_act))
         return ofmsgs
 
     def _port_delete_flows_state(self, port):

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -704,6 +704,8 @@ class Valve:
         if self.dp.egress_pipeline:
             ofmsgs.extend(
                 self.dp.tables['egress'].flowdel(out_port=port.number))
+        for manager in self._get_managers():
+            ofmsgs.extend(manager.del_port(port))
         if port.permanent_learn:
             classification_table = self.dp.classification_table()
             for entry in port.hosts():

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -767,6 +767,9 @@ class Valve:
             if not port.running():
                 continue
 
+            for manager in self._get_managers():
+                ofmsgs.extend(manager.add_port(port))
+
             if port.output_only:
                 ofmsgs.append(vlan_table.flowdrop(
                     match=vlan_table.match(in_port=port_num),

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -35,7 +35,6 @@ from faucet import valve_pipeline
 
 from faucet.port import STACK_STATE_INIT, STACK_STATE_UP, STACK_STATE_DOWN
 from faucet.vlan import NullVLAN
-from faucet.faucet_metadata import get_egress_metadata
 
 
 class ValveLogger:
@@ -81,6 +80,7 @@ class Valve:
         'dp',
         'flood_manager',
         'host_manager',
+        'pipeline',
         'logger',
         'logname',
         'metrics',

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -192,14 +192,14 @@ class Valve:
                 self._route_manager_by_eth_type[eth_type] = route_manager
         if self.dp.stack:
             self.flood_manager = valve_flood.ValveFloodStackManager(
-                self.dp.tables['flood'], self.dp.tables['eth_src'],
+                self.dp.tables['flood'], self.pipeline,
                 self.dp.group_table, self.dp.groups,
                 self.dp.combinatorial_port_flood,
                 self.dp.stack, self.dp.stack_ports,
                 self.dp.shortest_path_to_root, self.dp.shortest_path_port)
         else:
             self.flood_manager = valve_flood.ValveFloodManager(
-                self.dp.tables['flood'], self.dp.tables['eth_src'],
+                self.dp.tables['flood'], self.pipeline,
                 self.dp.group_table, self.dp.groups,
                 self.dp.combinatorial_port_flood)
         eth_dst_hairpin_table = self.dp.tables.get('eth_dst_hairpin', None)

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -181,7 +181,7 @@ class Valve:
                 self.dp.multi_out,
                 fib_table, self.dp.tables['vip'],
                 self.pipeline,
-                self.dp.highest_priority, self.dp.routers)
+                self.dp.routers)
             self._route_manager_by_ipv[route_manager.IPV] = route_manager
             for vlan in list(self.dp.vlans.values()):
                 if vlan.faucet_vips_by_ipv(route_manager.IPV):
@@ -193,7 +193,6 @@ class Valve:
         if self.dp.stack:
             self.flood_manager = valve_flood.ValveFloodStackManager(
                 self.dp.tables['flood'], self.dp.tables['eth_src'],
-                self.dp.low_priority, self.dp.highest_priority,
                 self.dp.group_table, self.dp.groups,
                 self.dp.combinatorial_port_flood,
                 self.dp.stack, self.dp.stack_ports,
@@ -201,7 +200,6 @@ class Valve:
         else:
             self.flood_manager = valve_flood.ValveFloodManager(
                 self.dp.tables['flood'], self.dp.tables['eth_src'],
-                self.dp.low_priority, self.dp.highest_priority,
                 self.dp.group_table, self.dp.groups,
                 self.dp.combinatorial_port_flood)
         eth_dst_hairpin_table = self.dp.tables.get('eth_dst_hairpin', None)
@@ -213,8 +211,7 @@ class Valve:
             self.dp.vlans, self.dp.tables['eth_src'],
             self.dp.tables['eth_dst'], eth_dst_hairpin_table,
             self.pipeline, self.dp.timeout, self.dp.learn_jitter,
-            self.dp.learn_ban_timeout, self.dp.low_priority,
-            self.dp.highest_priority, self.dp.cache_update_guard_time)
+            self.dp.learn_ban_timeout, self.dp.cache_update_guard_time)
         table_configs = sorted([
             (table.table_id, str(table.table_config)) for table in self.dp.tables.values()])
         for table_id, table_config in table_configs:

--- a/faucet/valve_flood.py
+++ b/faucet/valve_flood.py
@@ -67,6 +67,20 @@ class ValveFloodManager:
             in_port=in_port,
             exclude_ports=exclude_ports)
 
+    def initialise_tables(self):
+        ofmsgs = []
+        ofmsgs.append(self.flood_table.flowdrop(
+            self.flood_table.match(
+                eth_dst=valve_packet.CISCO_SPANNING_GROUP_ADDRESS),
+            priority=self.bypass_priority))
+        ofmsgs.append(self.flood_table.flowdrop(
+            self.flood_table.match(
+                eth_dst=valve_packet.BRIDGE_GROUP_ADDRESS,
+                eth_dst_mask=valve_packet.BRIDGE_GROUP_MASK),
+            priority=self.bypass_priority))
+        return ofmsgs
+
+
     def _build_flood_rule_actions(self, vlan, exclude_unicast, in_port):
         return self._build_flood_local_rule_actions(
             vlan, exclude_unicast, in_port)

--- a/faucet/valve_flood.py
+++ b/faucet/valve_flood.py
@@ -19,9 +19,10 @@
 
 from faucet import valve_of
 from faucet import valve_packet
+from faucet.valve_manager_base import ValveManagerBase
 
 
-class ValveFloodManager:
+class ValveFloodManager(ValveManagerBase):
     """Implement dataplane based flooding for standalone dataplanes."""
 
     # Enumerate possible eth_dst flood destinations.

--- a/faucet/valve_flood.py
+++ b/faucet/valve_flood.py
@@ -202,6 +202,9 @@ class ValveFloodManager(ValveManagerBase):
             flood_priority += 1
         return ofmsgs
 
+    def add_vlan(self, vlan):
+        return self.build_flood_rules(vlan)
+
     def build_flood_rules(self, vlan, modify=False):
         """Add flows to flood packets to unknown destinations on a VLAN."""
         # TODO: group table support is still fairly uncommon, so

--- a/faucet/valve_flood.py
+++ b/faucet/valve_flood.py
@@ -393,11 +393,11 @@ class ValveFloodStackManager(ValveFloodManager):
         # don't try to learn broadcast sources from stacking ports.
         for port in self.stack_ports:
             ofmsgs.extend(self.pipeline.filter_packets(self.flood_table, {
-                    'in_port': port.number,
-                    'vlan': vlan,
-                    'eth_dst': valve_packet.BRIDGE_GROUP_ADDRESS,
-                    'eth_dst_mask': valve_packet.BRIDGE_GROUP_MASK
-                    }))
+                'in_port': port.number,
+                'vlan': vlan,
+                'eth_dst': valve_packet.BRIDGE_GROUP_ADDRESS,
+                'eth_dst_mask': valve_packet.BRIDGE_GROUP_MASK
+                }))
         for unicast_eth_dst, eth_dst, eth_dst_mask in self.FLOOD_DSTS:
             if unicast_eth_dst:
                 continue

--- a/faucet/valve_flood.py
+++ b/faucet/valve_flood.py
@@ -373,7 +373,7 @@ class ValveFloodStackManager(ValveFloodManager):
             for port in self.stack_ports:
                 ofmsgs.extend(self._build_flood_rule_for_port(
                     vlan, eth_dst, eth_dst_mask,
-                    exclude_unicast, command, flood_priority + 1,
+                    exclude_unicast, command, flood_priority + 10,
                     port, mirror_acts))
             ofmsgs.extend(self._build_flood_rule_for_vlan(
                 vlan, eth_dst, eth_dst_mask,

--- a/faucet/valve_flood.py
+++ b/faucet/valve_flood.py
@@ -37,14 +37,12 @@ class ValveFloodManager(ValveManagerBase):
         (False, valve_of.mac.BROADCAST_STR, None), # flood on ethernet broadcasts
     )
 
-    def __init__(self, flood_table, eth_src_table, # pylint: disable=too-many-arguments
-                 flood_priority, bypass_priority,
-                 use_group_table, groups,
-                 combinatorial_port_flood):
+    def __init__(self, flood_table, eth_src_table,
+                 use_group_table, groups, combinatorial_port_flood):
         self.flood_table = flood_table
         self.eth_src_table = eth_src_table
-        self.bypass_priority = bypass_priority
-        self.flood_priority = flood_priority
+        self.bypass_priority = self._FILTER_PRIORITY
+        self.flood_priority = self._STATIC_MATCH_PRIORITY
         self.use_group_table = use_group_table
         self.groups = groups
         self.combinatorial_port_flood = combinatorial_port_flood
@@ -237,14 +235,12 @@ class ValveFloodStackManager(ValveFloodManager):
     """Implement dataplane based flooding for stacked dataplanes."""
 
     def __init__(self, flood_table, eth_src_table, # pylint: disable=too-many-arguments
-                 flood_priority, bypass_priority,
                  use_group_table, groups,
                  combinatorial_port_flood,
                  stack, stack_ports,
                  dp_shortest_path_to_root, shortest_path_port):
         super(ValveFloodStackManager, self).__init__(
             flood_table, eth_src_table,
-            flood_priority, bypass_priority,
             use_group_table, groups,
             combinatorial_port_flood)
         self.stack = stack

--- a/faucet/valve_host.py
+++ b/faucet/valve_host.py
@@ -86,6 +86,14 @@ class ValveHostManager(ValveManagerBase):
                             vlan.max_hosts, vlan.vid, eth_src, port))
         return ofmsgs
 
+    def initialise_tables(self):
+        ofmsgs = []
+        # add learn rule for this VLAN.
+        ofmsgs.append(self.eth_src_table.flowcontroller(
+            priority=self.low_priority,
+            inst=[self.eth_src_table.goto(self.output_table)]))
+        return ofmsgs
+
     def _temp_ban_host_learning(self, match):
         return self.eth_src_table.flowdrop(
             match,

--- a/faucet/valve_host.py
+++ b/faucet/valve_host.py
@@ -98,6 +98,14 @@ class ValveHostManager(ValveManagerBase):
                     valve_of.output_port(port.override_output_port.number)])]))
         return ofmsgs
 
+    def del_port(self, port):
+        ofmsgs = []
+        if port.permanent_learn:
+            for entry in port.hosts():
+                ofmsgs.extend(self.pipeline.remove_filter(
+                    self.eth_src_table, {'eth_src': entry.eth_src}))
+        return ofmsgs
+
     def initialise_tables(self):
         ofmsgs = []
         # add learn rule for this VLAN.

--- a/faucet/valve_host.py
+++ b/faucet/valve_host.py
@@ -86,6 +86,18 @@ class ValveHostManager(ValveManagerBase):
                             vlan.max_hosts, vlan.vid, eth_src, port))
         return ofmsgs
 
+    def add_port(self, port):
+        ofmsgs = []
+        if port.override_output_port:
+            ofmsgs.append(self.eth_src_table.flowmod(
+                match=eth_src_table.match(
+                    in_port=port_num),
+                priority=self.dp.low_priority + 1,
+                inst=[valve_of.apply_actions([
+                    valve_of.output_controller(),
+                    valve_of.output_port(port.override_output_port.number)])]))
+        return ofmsgs
+
     def initialise_tables(self):
         ofmsgs = []
         # add learn rule for this VLAN.

--- a/faucet/valve_host.py
+++ b/faucet/valve_host.py
@@ -21,9 +21,10 @@ import random
 
 from faucet import valve_of
 from faucet.faucet_metadata import get_egress_metadata
+from faucet.valve_manager_base import ValveManagerBase
 
 
-class ValveHostManager:
+class ValveHostManager(ValveManagerBase):
     """Manage host learning on VLANs."""
 
     def __init__(self, logger, ports, vlans, eth_src_table, eth_dst_table,

--- a/faucet/valve_host.py
+++ b/faucet/valve_host.py
@@ -20,7 +20,6 @@
 import random
 
 from faucet import valve_of
-from faucet.faucet_metadata import get_egress_metadata
 from faucet.valve_manager_base import ValveManagerBase
 
 
@@ -89,9 +88,9 @@ class ValveHostManager(ValveManagerBase):
         ofmsgs = []
         if port.override_output_port:
             ofmsgs.append(self.eth_src_table.flowmod(
-                match=eth_src_table.match(
-                    in_port=port_num),
-                priority=self.dp.low_priority + 1,
+                match=self.eth_src_table.match(
+                    in_port=port.number),
+                priority=self.low_priority + 1,
                 inst=[valve_of.apply_actions([
                     valve_of.output_controller(),
                     valve_of.output_port(port.override_output_port.number)])]))

--- a/faucet/valve_host.py
+++ b/faucet/valve_host.py
@@ -29,8 +29,7 @@ class ValveHostManager(ValveManagerBase):
 
     def __init__(self, logger, ports, vlans, eth_src_table, eth_dst_table,
                  eth_dst_hairpin_table, pipeline, learn_timeout,
-                 learn_jitter, learn_ban_timeout, low_priority, host_priority,
-                 cache_update_guard_time):
+                 learn_jitter, learn_ban_timeout, cache_update_guard_time):
         self.logger = logger
         self.ports = ports
         self.vlans = vlans
@@ -41,8 +40,8 @@ class ValveHostManager(ValveManagerBase):
         self.learn_timeout = learn_timeout
         self.learn_jitter = learn_jitter
         self.learn_ban_timeout = learn_ban_timeout
-        self.low_priority = low_priority
-        self.host_priority = host_priority
+        self.low_priority = self._LOW_PRIORITY
+        self.host_priority = self._STATIC_MATCH_PRIORITY
         self.cache_update_guard_time = cache_update_guard_time
         self.output_table = self.eth_dst_table
         if self.eth_dst_hairpin_table:

--- a/faucet/valve_host.py
+++ b/faucet/valve_host.py
@@ -26,18 +26,18 @@ from faucet.faucet_metadata import get_egress_metadata
 class ValveHostManager:
     """Manage host learning on VLANs."""
 
-    def __init__(self, logger, ports, vlans, classification_table,
-                 eth_src_table, eth_dst_table, eth_dst_hairpin_table,
-                 egress_table, learn_timeout, learn_jitter, learn_ban_timeout,
-                 low_priority, host_priority, cache_update_guard_time):
+    def __init__(self, logger, ports, vlans, eth_src_table, eth_dst_table,
+                 eth_dst_hairpin_table, egress_table, pipeline, learn_timeout,
+                 learn_jitter, learn_ban_timeout, low_priority, host_priority,
+                 cache_update_guard_time):
         self.logger = logger
         self.ports = ports
         self.vlans = vlans
-        self.classification_table = classification_table
         self.eth_src_table = eth_src_table
         self.eth_dst_table = eth_dst_table
         self.eth_dst_hairpin_table = eth_dst_hairpin_table
         self.egress_table = egress_table
+        self.pipeline = pipeline
         self.learn_timeout = learn_timeout
         self.learn_jitter = learn_jitter
         self.learn_ban_timeout = learn_ban_timeout
@@ -85,12 +85,6 @@ class ValveHostManager:
                         'and not learning %s on %s' % (
                             vlan.max_hosts, vlan.vid, eth_src, port))
         return ofmsgs
-
-    def _block_host_on_port(self, eth_src, port_num, timeout=0):
-        return [self.classification_table.flowdrop(
-            self.classification_table.match(eth_src=eth_src, in_port=port_num),
-            priority=self.host_priority
-            )]
 
     def _temp_ban_host_learning(self, match):
         return self.eth_src_table.flowdrop(
@@ -230,7 +224,9 @@ class ValveHostManager:
                 delete_existing = False
         elif entry.port.permanent_learn:
             if entry.port != port:
-                ofmsgs.extend(self._block_host_on_port(eth_src, port.number))
+                ofmsgs.extend(self.pipeline.filter_packets(
+                    self.eth_src_table,
+                    {'eth_src': eth_src, 'in_port': port.number}))
             return (ofmsgs, entry.port)
         else:
             cache_age = now - entry.cache_time

--- a/faucet/valve_host.py
+++ b/faucet/valve_host.py
@@ -27,7 +27,7 @@ class ValveHostManager:
     """Manage host learning on VLANs."""
 
     def __init__(self, logger, ports, vlans, eth_src_table, eth_dst_table,
-                 eth_dst_hairpin_table, egress_table, pipeline, learn_timeout,
+                 eth_dst_hairpin_table, pipeline, learn_timeout,
                  learn_jitter, learn_ban_timeout, low_priority, host_priority,
                  cache_update_guard_time):
         self.logger = logger
@@ -36,7 +36,6 @@ class ValveHostManager:
         self.eth_src_table = eth_src_table
         self.eth_dst_table = eth_dst_table
         self.eth_dst_hairpin_table = eth_dst_hairpin_table
-        self.egress_table = egress_table
         self.pipeline = pipeline
         self.learn_timeout = learn_timeout
         self.learn_jitter = learn_jitter
@@ -177,20 +176,11 @@ class ValveHostManager:
             return ofmsgs
 
         # Output packets for this MAC to specified port.
-        if self.egress_table is not None:
-            metadata, metadata_mask = get_egress_metadata(port.number, vlan.vid)
-            ofmsgs.append(self.eth_dst_table.flowmod(
-                self.eth_dst_table.match(vlan=vlan, eth_dst=eth_src),
-                priority=self.host_priority,
-                inst=valve_of.metadata_goto_table(
-                    metadata, metadata_mask, self.egress_table),
-                idle_timeout=dst_rule_idle_timeout))
-        else:
-            ofmsgs.append(self.eth_dst_table.flowmod(
-                self.eth_dst_table.match(vlan=vlan, eth_dst=eth_src),
-                priority=self.host_priority,
-                inst=[valve_of.apply_actions(vlan.output_port(port))],
-                idle_timeout=dst_rule_idle_timeout))
+        ofmsgs.append(self.eth_dst_table.flowmod(
+            self.eth_dst_table.match(vlan=vlan, eth_dst=eth_src),
+            priority=self.host_priority,
+            inst=self.pipeline.output(port, vlan),
+            idle_timeout=dst_rule_idle_timeout))
 
         # If port is in hairpin mode, install a special rule
         # that outputs packets destined to this MAC back out the same

--- a/faucet/valve_host.py
+++ b/faucet/valve_host.py
@@ -86,6 +86,12 @@ class ValveHostManager:
                             vlan.max_hosts, vlan.vid, eth_src, port))
         return ofmsgs
 
+    def _block_host_on_port(self, eth_src, port_num, timeout=0):
+        return [self.classification_table.flowdrop(
+            self.classification_table.match(eth_src=eth_src, in_port=port_num),
+            priority=self.host_priority
+            )]
+
     def _temp_ban_host_learning(self, match):
         return self.eth_src_table.flowdrop(
             match,
@@ -150,21 +156,9 @@ class ValveHostManager:
         """Return flows that implement learning a host on a port."""
         ofmsgs = []
 
-        if port.permanent_learn:
-            # Antispoofing rule for this MAC.
-            if self.classification_table != self.eth_src_table:
-                ofmsgs.append(self.classification_table.flowmod(
-                    self.classification_table.match(
-                        in_port=port.number, vlan=vlan, eth_src=eth_src),
-                    priority=self.host_priority,
-                    inst=[self.classification_table.goto(self.eth_src_table)]))
-            ofmsgs.append(self.classification_table.flowdrop(
-                self.classification_table.match(vlan=vlan, eth_src=eth_src),
-                priority=(self.host_priority - 2)))
-        else:
-            # Delete any existing entries for MAC.
-            if delete_existing:
-                ofmsgs.extend(self.delete_host_from_vlan(eth_src, vlan))
+        # Delete any existing entries for MAC.
+        if delete_existing:
+            ofmsgs.extend(self.delete_host_from_vlan(eth_src, vlan))
 
         # Associate this MAC with source port.
         src_match = self.eth_src_table.match(
@@ -234,6 +228,10 @@ class ValveHostManager:
                     (vlan.dyn_last_time_hosts_expired is None or
                      vlan.dyn_last_time_hosts_expired < last_dp_coldstart_time)):
                 delete_existing = False
+        elif entry.port.permanent_learn:
+            if entry.port != port:
+                ofmsgs.extend(self._block_host_on_port(eth_src, port.number))
+            return (ofmsgs, entry.port)
         else:
             cache_age = now - entry.cache_time
             cache_port = entry.port

--- a/faucet/valve_manager_base.py
+++ b/faucet/valve_manager_base.py
@@ -14,3 +14,9 @@ class ValveManagerBase(object):
 
     def add_port(self, port):
         return []
+
+    def del_vlan(self, vlan):
+        return []
+
+    def del_port(self, port):
+        return []

--- a/faucet/valve_manager_base.py
+++ b/faucet/valve_manager_base.py
@@ -6,6 +6,14 @@ class ValveManagerBase(object):
     Expected to control the installation of flows into datapath tables.
 
     Ideally each datapath table should be controlled by 1 manager only."""
+
+    _MISS_PRIORITY = 0
+    _LOW_PRIORITY = 0x1000
+    _STATIC_MATCH_PRIORITY = 0x2000
+    _LPM_PRIORITY = 0x3000
+    _HIGH_PRIORITY = 0x4000
+    _FILTER_PRIORITY = 0x5000
+
     def initialise_tables(self):
         return []
 

--- a/faucet/valve_manager_base.py
+++ b/faucet/valve_manager_base.py
@@ -8,3 +8,6 @@ class ValveManagerBase(object):
     Ideally each datapath table should be controlled by 1 manager only."""
     def initialise_tables(self):
         return []
+
+    def add_vlan(self, vlan):
+        return []

--- a/faucet/valve_manager_base.py
+++ b/faucet/valve_manager_base.py
@@ -11,3 +11,6 @@ class ValveManagerBase(object):
 
     def add_vlan(self, vlan):
         return []
+
+    def add_port(self, port):
+        return []

--- a/faucet/valve_manager_base.py
+++ b/faucet/valve_manager_base.py
@@ -1,6 +1,8 @@
 """Valve Manager base class"""
 
-class ValveManagerBase(object):
+# pylint: disable=R0201
+# pylint: disable=W0613
+class ValveManagerBase:
     """Base class for ValveManager objects.
 
     Expected to control the installation of flows into datapath tables.
@@ -15,16 +17,36 @@ class ValveManagerBase(object):
     _FILTER_PRIORITY = 0x5000
 
     def initialise_tables(self):
+        """initialise tables for this manager.
+
+        returns:
+            list of ofmsgs"""
         return []
 
     def add_vlan(self, vlan):
+        """update tables for the addition of a vlan
+
+        returns:
+            list of ofmsgs"""
         return []
 
     def add_port(self, port):
+        """update tables for the addition of a port
+
+        returns:
+            list of ofmsgs"""
         return []
 
     def del_vlan(self, vlan):
+        """update tables for the removal of a vlan
+
+        returns:
+            list of ofmsgs"""
         return []
 
     def del_port(self, port):
+        """update tables for the removal of a port
+
+        returns:
+            list of ofmsgs"""
         return []

--- a/faucet/valve_manager_base.py
+++ b/faucet/valve_manager_base.py
@@ -1,0 +1,10 @@
+"""Valve Manager base class"""
+
+class ValveManagerBase(object):
+    """Base class for ValveManager objects.
+
+    Expected to control the installation of flows into datapath tables.
+
+    Ideally each datapath table should be controlled by 1 manager only."""
+    def initialise_tables(self):
+        return []

--- a/faucet/valve_pipeline.py
+++ b/faucet/valve_pipeline.py
@@ -77,14 +77,19 @@ class ValvePipeline(ValveManagerBase):
                 ))
 
         ofmsgs.extend(self.filter_packets(
-            self.classification_table, {'eth_type': valve_of.ECTP_ETH_TYPE}))
+            self.classification_table,
+            {'eth_type': valve_of.ECTP_ETH_TYPE},
+            priority_offset=0x5))
 
         # antispoof for FAUCET's MAC address
         # TODO: antispoof for controller IPs on this VLAN, too.
         if self.dp.drop_spoofed_faucet_mac:
             for vlan in list(self.dp.vlans.values()):
                 ofmsgs.extend(self.filter_packets(
-                    self.classification_table, {'eth_src': vlan.faucet_mac}))
+                    self.classification_table,
+                    {'eth_src': vlan.faucet_mac},
+                    priority_offset=0x80
+                    ))
 
         return ofmsgs
 

--- a/faucet/valve_pipeline.py
+++ b/faucet/valve_pipeline.py
@@ -47,7 +47,7 @@ class ValvePipeline(object):
             inst.append(valve_of.apply_actions(actions))
         return inst
 
-    def filter_packets(self, match):
+    def filter_packets(self, target_table, match_dict):
         # TODO: if you have an overlapping match here then it shouldnt matter
         # since these are always explicit drop rules, but it would be good to
         # validate this. It is possible the rules wont get accepted if they
@@ -56,16 +56,16 @@ class ValvePipeline(object):
         # possibly we could have a hierarchy of modules that determines the
         # priority for rules from that module
         return [self.classification_table.flowdrop(
-            self.classification_table.match(match),
-            priority=(self.high_priority))]
+            self.classification_table.match(**match_dict),
+            priority=(self.filter_priority))]
 
-    def select_packets(self, target_table, match, actions=None):
+    def select_packets(self, target_table, match_dict, actions=None):
         """retrieve rules to redirect packets matching match_dict to table"""
-        inst = [self.target_table.goto_this()]
+        inst = [target_table.goto_this()]
         if actions is not None:
             inst.append(valve_of.apply_actions(actions))
         return [self.classification_table.flowmod(
-            self.classification_table.match(match),
-            priority=self.low_priority,
+            self.classification_table.match(**match_dict),
+            priority=self.select_priority,
             inst=inst)]
 

--- a/faucet/valve_pipeline.py
+++ b/faucet/valve_pipeline.py
@@ -28,17 +28,20 @@ class ValvePipeline(object):
     def dp_connect(self):
         pass
 
-    def output(self, output_port, vlan, actions=None):
+    def output(self, port, vlan, actions=None):
         if actions is not None:
             actions = copy.copy(actions)
         else:
             actions = []
         instructions = []
-        if self.egress_pipeline:
+        instructions.append(valve_of.apply_actions(actions))
+        if self.egress_table:
             metadata, metadata_mask = get_egress_metadata(
-                output_port.number, vlan.vid)
-            instructions.append(valve_of.metadata_goto_table(
+                port.number, vlan.vid)
+            instructions.extend(valve_of.metadata_goto_table(
                 metadata, metadata_mask, self.egress_table))
+        else:
+            instructions.append(valve_of.apply_actions(vlan.output_port(port)))
         return instructions
 
     def accept_to_l2_forwarding(self, actions=None):

--- a/faucet/valve_pipeline.py
+++ b/faucet/valve_pipeline.py
@@ -1,5 +1,6 @@
+"""Manager movement of packets through the faucet pipeline"""
 import copy
-import faucet.faucet_metadata as faucet_metadata
+import faucet.faucet_metadata as faucet_md
 from faucet import valve_of
 from faucet.valve_manager_base import ValveManagerBase
 
@@ -13,7 +14,6 @@ class ValvePipeline(ValveManagerBase):
     Responsible for installing flows in the vlan, egress and classification
     tables"""
 
-    # TODO: initialise tables
     def __init__(self, dp):
         self.dp = dp
         self.classification_table = dp.classification_table()
@@ -23,20 +23,25 @@ class ValvePipeline(ValveManagerBase):
             self.egress_table = dp.tables['egress']
         self.vlan_table = dp.tables['vlan']
         self.use_group_table = dp.group_table
-        self.filter_priority = self._FILTER_PRIORITY
-        self.select_priority = self._HIGH_PRIORITY
-
-    def dp_connect(self):
-        pass
 
     def output(self, port, vlan, actions=None):
+        """Get instructions list to output a packet through the regular
+        pipeline.
+
+        args:
+            port: Port object of port to output packet to
+            vlan: Vlan object of vlan to output packet on
+            actions: list of actions to apply to packet before outputting
+        returns:
+            list of Instructions
+        """
         if actions is not None:
             actions = copy.copy(actions)
         else:
             actions = []
         instructions = []
         if self.egress_table:
-            metadata, metadata_mask = faucet_metadata.get_egress_metadata(
+            metadata, metadata_mask = faucet_md.get_egress_metadata(
                 port.number, vlan.vid)
             instructions.extend(valve_of.metadata_goto_table(
                 metadata, metadata_mask, self.egress_table))
@@ -51,7 +56,7 @@ class ValvePipeline(ValveManagerBase):
             result = 0x300
         elif table.name in ('eth_src', 'eth_dst'):
             result = 0x200
-        elif table.name in ('flood'):
+        elif table.name == 'flood':
             result = 0x100
         return result
 
@@ -62,12 +67,31 @@ class ValvePipeline(ValveManagerBase):
         return inst
 
     def accept_to_classification(self, actions=None):
+        """Get instructions to forward packet to the classification table.
+
+        args:
+            actions: (optional) list of actions to apply to packet.
+        returns:
+            list of instructions
+        """
         return self._accept_to_table(self.classification_table, actions)
 
     def accept_to_l2_forwarding(self, actions=None):
+        """Get instructions to forward packet through the pipeline to l2
+        forwarding.
+
+        args:
+            actions: (optional) list of actions to apply to packet.
+        returns:
+            list of instructions
+        """
         return self._accept_to_table(self.output_table, actions)
 
     def initialise_tables(self):
+        """initialise the classification table
+
+        returns:
+            list of ofmsgs"""
         ofmsgs = []
         # drop broadcast sources
         if self.dp.drop_broadcast_source_address:
@@ -94,7 +118,7 @@ class ValvePipeline(ValveManagerBase):
         return ofmsgs
 
     def _add_egress_table_rule(self, port, vlan, pop_vlan=True):
-        metadata, metadata_mask = faucet_metadata.get_egress_metadata(
+        metadata, metadata_mask = faucet_md.get_egress_metadata(
             port.number, vlan.vid)
         actions = copy.copy(port.mirror_actions())
         if pop_vlan:
@@ -107,66 +131,110 @@ class ValvePipeline(ValveManagerBase):
                 metadata=metadata,
                 metadata_mask=metadata_mask
                 ),
-            priority=self.dp.high_priority,
+            priority=self._STATIC_MATCH_PRIORITY,
             inst=inst
             )
 
     def add_port(self, port):
+        """get flow messages to install when a new port comes up.
+
+        args:
+            port: a Port object
+        returns:
+            list of openflow messages
+        """
         ofmsgs = []
         if self.egress_table is None:
             return ofmsgs
         for vlan in port.tagged_vlans:
             ofmsgs.append(self._add_egress_table_rule(
-               port, vlan, pop_vlan=False))
+                port, vlan, pop_vlan=False))
         if port.native_vlan is not None:
             ofmsgs.append(self._add_egress_table_rule(
                 port, port.native_vlan))
         return ofmsgs
 
     def del_port(self, port):
+        """get flow messages in response to a port going down
+
+        args:
+            port: a Port object
+        returns:
+            list of openflow messages
+        """
         ofmsgs = []
         if self.egress_table:
-            mask = faucet_metadata.PORT_METADATA_MASK
+            mask = faucet_md.PORT_METADATA_MASK
             ofmsgs.extend(self.egress_table.flowdel(self.egress_table.match(
                 metadata=port.number & mask,
-                metadata_mask = mask
+                metadata_mask=mask
                 )))
         return ofmsgs
 
     def filter_packets(self, target_table, match_dict, priority_offset=0):
-        # TODO: if you have an overlapping match here then it shouldnt matter
-        # since these are always explicit drop rules, but it would be good to
-        # validate this. It is possible the rules wont get accepted if they
-        # overlap.
+        """get a list of flow modification messages to filter packets from
+        the pipeline.
 
-        # possibly we could have a hierarchy of modules that determines the
-        # priority for rules from that module
-        priority = self._get_offset(target_table) + self.filter_priority
+        Any packets filtered here will be filtered for all modules, not just
+        the module requesting the filter. So be careful what you filter.
+
+        You can specify overlapping filters (IE filters that can match the same
+        packets) by using the priority offset so that your filters will not
+        have the same priority. Priority offsets should be between 1 and 127.
+        (128+ is reserved for this module)
+
+        args:
+            target_table: the table requesting the filtering
+            match_dict: a dictionary specifying the match fields
+            priority_offset: an offset for the flow_mod priority to avoid
+            overlapping flows
+        """
+        priority = self._get_offset(target_table) + self._FILTER_PRIORITY
         return [self.classification_table.flowdrop(
             self.classification_table.match(**match_dict),
-            priority= priority + priority_offset)]
+            priority=priority + priority_offset)]
 
     def select_packets(self, target_table, match_dict, actions=None,
                        priority_offset=0):
-        """retrieve rules to redirect packets matching match_dict to table"""
+        """retrieve rules to redirect packets matching match_dict to table
+
+        notes:
+            - there is a hierarchy of modules as to who will receive packets
+            when two modules give the same rules. The hierarchy is 1st:
+            routing, 2nd: host, 3rd: flood, 4th: anything else
+        args:
+            target_table: the table to direct packets to
+            match_dict: a dictionary specifying the match fields
+            priority_offset: an offset for the flow_mod priority to avoid
+            overlapping flows"""
         inst = [target_table.goto_this()]
-        priority = self._get_offset(target_table) + self.select_priority
+        priority = self._get_offset(target_table) + self._HIGH_PRIORITY
         if actions is not None:
             inst.append(valve_of.apply_actions(actions))
         return [self.classification_table.flowmod(
             self.classification_table.match(**match_dict),
-            priority=self.select_priority + priority_offset,
+            priority=priority + priority_offset,
             inst=inst)]
 
     def remove_filter(self, target_table, match_dict, strict=True,
                       priority_offset=0):
+        """retrieve rules to remove a filter from the classification table
+
+        args:
+            target_table: the table requesting the filter
+            match_dict: a dictionary specifying the match fields
+            strict: use a delete strict rather than delete
+            priority_offset: an offset for the flow_mod priority for use with
+            strict matching
+        returns:
+            list of flow mod messages"""
         #TODO: We need a mechanism to stop a module from removing filters added
         #by another module. Cookies seems like the logical approach. For now
-        # modules are trusted
+        # modules are trusted to be careful with their approach.
         priority = None
         if strict:
-            priorty = self._get_offset(target_table)\
-                + self.filter_priority + priority_offset
+            priority = self._get_offset(target_table)\
+                + self._FILTER_PRIORITY + priority_offset
         return self.classification_table.flowdel(
             self.classification_table.match(**match_dict),
             priority=priority,
@@ -174,10 +242,20 @@ class ValvePipeline(ValveManagerBase):
 
     def remove_selection(self, target_table, match_dict, strict=True,
                          priority_offset=0):
+        """retrieve rules to remove a select from the classification table
+
+        args:
+            target_table: the table to direct packets to
+            match_dict: a dictionary specifying the match fields
+            strict: use a delete strict rather than delete
+            priority_offset: an offset for the flow_mod priority for use with
+            strict matching
+        returns:
+            list of flow mod messages"""
         priority = None
         if strict:
-            priorty = self._get_offset(target_table)\
-                + self.select_priority + priority_offset
+            priority = self._get_offset(target_table)\
+                + self._HIGH_PRIORITY + priority_offset
         return self.classification_table.flowdel(
             self.classification_table.match(**match_dict),
             priority=priority,

--- a/faucet/valve_pipeline.py
+++ b/faucet/valve_pipeline.py
@@ -144,21 +144,19 @@ class ValvePipeline(ValveManagerBase):
         #TODO: We need a mechanism to stop a module from removing filters added
         #by another module. Cookies seems like the logical approach. For now
         # modules are trusted
-        ofmsgs = []
         priority = None
         if strict:
             priorty = self.filter_priority
-        return [self.classification_table.flowdel(
+        return self.classification_table.flowdel(
             self.classification_table.match(**match_dict),
             priority=priority,
-            strict=strict)]
+            strict=strict)
 
     def remove_selection(self, target_table, match_dict, strict=True):
-        ofmsgs = []
         priority = None
         if strict:
             priorty = self.select_priority
-        return [self.classification_table.flowdel(
+        return self.classification_table.flowdel(
             self.classification_table.match(**match_dict),
             priority=priority,
-            strict=strict)]
+            strict=strict)

--- a/faucet/valve_pipeline.py
+++ b/faucet/valve_pipeline.py
@@ -1,0 +1,71 @@
+import copy
+from faucet import valve_of
+from faucet.faucet_metadata import get_egress_metadata
+
+class ValvePipeline(object):
+    """Responsible for maintaing the integrity of the Faucet pipeline for a
+    single valve.
+
+    Controls what packets a module sees in its tables and how it can pass
+    packets through the pipeline.
+
+    Responsible for installing flows in the vlan, egress and classification
+    tables"""
+
+    # TODO: initialise tables
+    def __init__(self, dp):
+        self.dp = dp
+        self.classification_table = dp.classification_table()
+        self.output_table = dp.output_table()
+        self.egress_table = None
+        if dp.egress_pipeline:
+            self.egress_table = dp.tables['egress']
+        self.vlan_table = dp.tables['vlan']
+        self.use_group_table = dp.group_table
+        self.high_priority = dp.high_priority
+        self.low_priority = dp.low_priority
+
+    def dp_connect(self):
+        pass
+
+    def output(self, output_port, vlan, actions=None):
+        if actions is not None:
+            actions = copy.copy(actions)
+        else:
+            actions = []
+        instructions = []
+        if self.egress_pipeline:
+            metadata, metadata_mask = get_egress_metadata(
+                output_port.number, vlan.vid)
+            instructions.append(valve_of.metadata_goto_table(
+                metadata, metadata_mask, self.egress_table))
+        return instructions
+
+    def accept_to_l2_forwarding(self, actions=None):
+        inst = [self.output_table.goto_this()]
+        if actions is not None:
+            inst.append(valve_of.apply_actions(actions))
+        return inst
+
+    def filter_packets(self, match):
+        # TODO: if you have an overlapping match here then it shouldnt matter
+        # since these are always explicit drop rules, but it would be good to
+        # validate this. It is possible the rules wont get accepted if they
+        # overlap.
+
+        # possibly we could have a hierarchy of modules that determines the
+        # priority for rules from that module
+        return [self.classification_table.flowdrop(
+            self.classification_table.match(match),
+            priority=(self.high_priority))]
+
+    def select_packets(self, target_table, match, actions=None):
+        """retrieve rules to redirect packets matching match_dict to table"""
+        inst = [self.target_table.goto_this()]
+        if actions is not None:
+            inst.append(valve_of.apply_actions(actions))
+        return [self.classification_table.flowmod(
+            self.classification_table.match(match),
+            priority=self.low_priority,
+            inst=inst)]
+

--- a/faucet/valve_pipeline.py
+++ b/faucet/valve_pipeline.py
@@ -35,14 +35,14 @@ class ValvePipeline(ValveManagerBase):
         else:
             actions = []
         instructions = []
-        instructions.append(valve_of.apply_actions(actions))
         if self.egress_table:
             metadata, metadata_mask = faucet_metadata.get_egress_metadata(
                 port.number, vlan.vid)
             instructions.extend(valve_of.metadata_goto_table(
                 metadata, metadata_mask, self.egress_table))
         else:
-            instructions.append(valve_of.apply_actions(vlan.output_port(port)))
+            actions.extend(vlan.output_port(port))
+        instructions.append(valve_of.apply_actions(actions))
         return instructions
 
     def _accept_to_table(self, table, actions):

--- a/faucet/valve_pipeline.py
+++ b/faucet/valve_pipeline.py
@@ -45,11 +45,17 @@ class ValvePipeline(ValveManagerBase):
             instructions.append(valve_of.apply_actions(vlan.output_port(port)))
         return instructions
 
-    def accept_to_l2_forwarding(self, actions=None):
-        inst = [self.output_table.goto_this()]
+    def _accept_to_table(self, table, actions):
+        inst = [table.goto_this()]
         if actions is not None:
             inst.append(valve_of.apply_actions(actions))
         return inst
+
+    def accept_to_classification(self, actions=None):
+        return self._accept_to_table(self.classification_table, actions)
+
+    def accept_to_l2_forwarding(self, actions=None):
+        return self._accept_to_table(self.output_table, actions)
 
     def initialise_tables(self):
         ofmsgs = []

--- a/faucet/valve_pipeline.py
+++ b/faucet/valve_pipeline.py
@@ -23,8 +23,8 @@ class ValvePipeline(ValveManagerBase):
             self.egress_table = dp.tables['egress']
         self.vlan_table = dp.tables['vlan']
         self.use_group_table = dp.group_table
-        self.filter_priority = dp.highest_priority + 1
-        self.select_priority = dp.highest_priority
+        self.filter_priority = self._FILTER_PRIORITY
+        self.select_priority = self._HIGH_PRIORITY
 
     def dp_connect(self):
         pass

--- a/faucet/valve_pipeline.py
+++ b/faucet/valve_pipeline.py
@@ -1,8 +1,9 @@
 import copy
 from faucet import valve_of
 from faucet.faucet_metadata import get_egress_metadata
+from faucet.valve_manager_base import ValveManagerBase
 
-class ValvePipeline(object):
+class ValvePipeline(ValveManagerBase):
     """Responsible for maintaing the integrity of the Faucet pipeline for a
     single valve.
 

--- a/faucet/valve_pipeline.py
+++ b/faucet/valve_pipeline.py
@@ -22,8 +22,8 @@ class ValvePipeline(object):
             self.egress_table = dp.tables['egress']
         self.vlan_table = dp.tables['vlan']
         self.use_group_table = dp.group_table
-        self.high_priority = dp.high_priority
-        self.low_priority = dp.low_priority
+        self.filter_priority = dp.highest_priority + 1
+        self.select_priority = dp.highest_priority
 
     def dp_connect(self):
         pass

--- a/faucet/valve_pipeline.py
+++ b/faucet/valve_pipeline.py
@@ -95,3 +95,25 @@ class ValvePipeline(ValveManagerBase):
             priority=self.select_priority,
             inst=inst)]
 
+    def remove_filter(self, target_table, match_dict, strict=True):
+        #TODO: We need a mechanism to stop a module from removing filters added
+        #by another module. Cookies seems like the logical approach. For now
+        # modules are trusted
+        ofmsgs = []
+        priority = None
+        if strict:
+            priorty = self.filter_priority
+        return [self.classification_table.flowdel(
+            self.classification_table.match(**match_dict),
+            priority=priority,
+            strict=strict)]
+
+    def remove_selection(self, target_table, match_dict, strict=True):
+        ofmsgs = []
+        priority = None
+        if strict:
+            priorty = self.select_priority
+        return [self.classification_table.flowdel(
+            self.classification_table.match(**match_dict),
+            priority=priority,
+            strict=strict)]

--- a/faucet/valve_route.py
+++ b/faucet/valve_route.py
@@ -115,7 +115,7 @@ class ValveRouteManager(ValveManagerBase):
     def __init__(self, logger, global_vlan, neighbor_timeout,
                  max_hosts_per_resolve_cycle, max_host_fib_retry_count,
                  max_resolve_backoff_time, proactive_learn, dec_ttl, multi_out,
-                 fib_table, vip_table, pipeline, route_priority, routers):
+                 fib_table, vip_table, pipeline, routers):
         self.logger = logger
         self.global_vlan = AnonVLAN(global_vlan)
         self.neighbor_timeout = neighbor_timeout
@@ -128,7 +128,7 @@ class ValveRouteManager(ValveManagerBase):
         self.fib_table = fib_table
         self.vip_table = vip_table
         self.pipeline = pipeline
-        self.route_priority = route_priority
+        self.route_priority = self._LPM_PRIORITY
         self.routers = routers
         self.active = False
         self.global_routing = self._global_routing()

--- a/faucet/valve_route.py
+++ b/faucet/valve_route.py
@@ -116,6 +116,7 @@ class ValveRouteManager:
                  max_hosts_per_resolve_cycle, max_host_fib_retry_count,
                  max_resolve_backoff_time, proactive_learn, dec_ttl, multi_out,
                  fib_table, vip_table, classification_table, output_table,
+                 pipeline,
                  route_priority, routers):
         self.logger = logger
         self.global_vlan = AnonVLAN(global_vlan)
@@ -130,6 +131,7 @@ class ValveRouteManager:
         self.vip_table = vip_table
         self.classification_table = classification_table
         self.output_table = output_table
+        self.pipeline = pipeline
         self.route_priority = route_priority
         self.routers = routers
         self.active = False

--- a/faucet/valve_route.py
+++ b/faucet/valve_route.py
@@ -220,15 +220,15 @@ class ValveRouteManager:
         del nexthop_cache[ip_gw]
 
     def _nexthop_actions(self, eth_dst, vlan):
-        ofmsgs = []
+        actions = []
         if self.routers:
-            ofmsgs.append(self.fib_table.set_vlan_vid(vlan.vid))
-        ofmsgs.extend([
+            actions.append(self.fib_table.set_vlan_vid(vlan.vid))
+        actions.extend([
             self.fib_table.set_field(eth_src=vlan.faucet_mac),
             self.fib_table.set_field(eth_dst=eth_dst)])
         if self.dec_ttl:
-            ofmsgs.append(valve_of.dec_ip_ttl())
-        return ofmsgs
+            actions.append(valve_of.dec_ip_ttl())
+        return actions
 
     def _route_match(self, vlan, ip_dst):
         return self.fib_table.match(vlan=vlan, eth_type=self.ETH_TYPE, nw_dst=ip_dst)

--- a/faucet/valve_route.py
+++ b/faucet/valve_route.py
@@ -90,7 +90,7 @@ class ValveRouteManager:
         'dec_ttl',
         'output_table',
         'fib_table',
-        'pipeline'
+        'pipeline',
         'multi_out',
         'global_vlan',
         'global_routing',

--- a/faucet/valve_route.py
+++ b/faucet/valve_route.py
@@ -323,6 +323,8 @@ class ValveRouteManager(ValveManagerBase):
     def _add_faucet_vip_nd(self, vlan, priority, faucet_vip, faucet_vip_host):
         raise NotImplementedError # pragma: no cover
 
+    def add_vlan(self, vlan):
+
     def add_faucet_vip(self, vlan, faucet_vip):
         ofmsgs = []
         max_prefixlen = faucet_vip.ip.max_prefixlen

--- a/faucet/valve_route.py
+++ b/faucet/valve_route.py
@@ -324,16 +324,16 @@ class ValveRouteManager(ValveManagerBase):
         raise NotImplementedError # pragma: no cover
 
     def add_vlan(self, vlan):
-
-    def add_faucet_vip(self, vlan, faucet_vip):
         ofmsgs = []
-        max_prefixlen = faucet_vip.ip.max_prefixlen
-        faucet_vip_host = self._host_from_faucet_vip(faucet_vip)
-        priority = self.route_priority + max_prefixlen
-        ofmsgs.extend(self._add_faucet_vip_nd(
-            vlan, priority, faucet_vip, faucet_vip_host))
-        ofmsgs.extend(self._add_faucet_fib_to_vip(
-            vlan, priority, faucet_vip, faucet_vip_host))
+        # add controller IPs if configured.
+        for faucet_vip in vlan.faucet_vips_by_ipv(self.IPV):
+            max_prefixlen = faucet_vip.ip.max_prefixlen
+            faucet_vip_host = self._host_from_faucet_vip(faucet_vip)
+            priority = self.route_priority + max_prefixlen
+            ofmsgs.extend(self._add_faucet_vip_nd(
+                vlan, priority, faucet_vip, faucet_vip_host))
+            ofmsgs.extend(self._add_faucet_fib_to_vip(
+                vlan, priority, faucet_vip, faucet_vip_host))
         return ofmsgs
 
     def _add_resolved_route(self, vlan, ip_gw, ip_dst, eth_dst, is_updated):

--- a/faucet/valve_route.py
+++ b/faucet/valve_route.py
@@ -88,7 +88,6 @@ class ValveRouteManager:
         'active',
         'neighbor_timeout',
         'dec_ttl',
-        'output_table',
         'fib_table',
         'pipeline',
         'multi_out',
@@ -115,9 +114,7 @@ class ValveRouteManager:
     def __init__(self, logger, global_vlan, neighbor_timeout,
                  max_hosts_per_resolve_cycle, max_host_fib_retry_count,
                  max_resolve_backoff_time, proactive_learn, dec_ttl, multi_out,
-                 fib_table, vip_table, output_table,
-                 pipeline,
-                 route_priority, routers):
+                 fib_table, vip_table, pipeline, route_priority, routers):
         self.logger = logger
         self.global_vlan = AnonVLAN(global_vlan)
         self.neighbor_timeout = neighbor_timeout
@@ -129,7 +126,6 @@ class ValveRouteManager:
         self.multi_out = multi_out
         self.fib_table = fib_table
         self.vip_table = vip_table
-        self.output_table = output_table
         self.pipeline = pipeline
         self.route_priority = route_priority
         self.routers = routers
@@ -165,9 +161,8 @@ class ValveRouteManager:
             port, vlan.faucet_mac, eth_dst, faucet_vip.ip, ip_gw)
 
     def _controller_and_flood(self):
-        return [
-            valve_of.apply_actions([valve_of.output_controller(max_len=self.ICMP_SIZE)]),
-            self.vip_table.goto(self.output_table)]
+        return self.pipeline.accept_to_l2_forwarding(
+            actions=[valve_of.output_controller(max_len=self.ICMP_SIZE)])
 
     def _resolve_vip_response(self, pkt_meta, solicited_ip, now):
         ofmsgs = []
@@ -349,8 +344,8 @@ class ValveRouteManager:
             self.logger.info(
                 'Adding new route %s via %s (%s) on VLAN %u' % (
                     ip_dst, ip_gw, eth_dst, vlan.vid))
-        inst = [valve_of.apply_actions(self._nexthop_actions(eth_dst, vlan)),
-                self.fib_table.goto(self.output_table)]
+        inst = self.pipeline.accept_to_l2_forwarding(
+            actions=self._nexthop_actions(eth_dst, vlan))
         routed_vlans = self._routed_vlans(vlan)
         for routed_vlan in routed_vlans:
             in_match = self._route_match(routed_vlan, ip_dst)
@@ -749,7 +744,7 @@ class ValveIPv4RouteManager(ValveRouteManager):
             self.vip_table.match(
                 eth_type=valve_of.ether.ETH_TYPE_ARP),
             priority=priority,
-            inst=[self.vip_table.goto(self.output_table)]))
+            inst=self.pipeline.accept_to_l2_forwarding()))
         return ofmsgs
 
     def _control_plane_arp_handler(self, now, pkt_meta):

--- a/faucet/valve_route.py
+++ b/faucet/valve_route.py
@@ -26,6 +26,7 @@ from ryu.lib.packet import arp, icmp, icmpv6, ipv4, ipv6
 
 from faucet import valve_of
 from faucet import valve_packet
+from faucet.valve_manager_base import ValveManagerBase
 
 
 class AnonVLAN:
@@ -81,7 +82,7 @@ class NextHop:
         return False
 
 
-class ValveRouteManager:
+class ValveRouteManager(ValveManagerBase):
     """Base class to implement RIB/FIB."""
 
     __slots__ = [

--- a/faucet/valve_table.py
+++ b/faucet/valve_table.py
@@ -54,6 +54,9 @@ class ValveTable: # pylint: disable=too-many-arguments,too-many-instance-attribu
                 next_table.name, self.name))
         return valve_of.goto_table(next_table)
 
+    def goto_this(self):
+        return valve_of.goto_table(self)
+
     def goto_miss(self, next_table):
         """Add miss goto table instruction."""
         assert next_table.name == self.table_config.miss_goto, (

--- a/tests/integration/mininet_tests.py
+++ b/tests/integration/mininet_tests.py
@@ -3011,11 +3011,16 @@ vlans:
     def test_untagged(self):
         self.ping_all_when_learned(hard_timeout=0)
         first_host, second_host, third_host = self.net.hosts[0:3]
-        # 3rd host impersonates 1st, 3rd host breaks but 1st host still OK
+        self.assertTrue(self.prom_mac_learned(first_host.MAC(), port=1))
+
+        # 3rd host impersonates 1st but 1st host still OK
         original_third_host_mac = third_host.MAC()
         third_host.setMAC(first_host.MAC())
         self.assertEqual(100.0, self.net.ping((second_host, third_host)))
+        self.assertTrue(self.prom_mac_learned(first_host.MAC(), port=1))
+        self.assertFalse(self.prom_mac_learned(first_host.MAC(), port=3))
         self.retry_net_ping(hosts=(first_host, second_host))
+
         # 3rd host stops impersonating, now everything fine again.
         third_host.setMAC(original_third_host_mac)
         self.ping_all_when_learned(hard_timeout=0)

--- a/tests/integration/mininet_tests.py
+++ b/tests/integration/mininet_tests.py
@@ -1235,7 +1235,6 @@ class FaucetUntaggedPrometheusGaugeTest(FaucetUntaggedTest):
                     'cookie': cookie,
                     'eth_dst': host.MAC(),
                     'inst_count': str(1),
-                    'priority': str(9099),
                     'table_id': str(self._ETH_DST_TABLE),
                     'vlan': str(100),
                     'vlan_vid': str(4196)

--- a/tests/unit/faucet/fakeoftable.py
+++ b/tests/unit/faucet/fakeoftable.py
@@ -311,6 +311,7 @@ class FlowMod:
         """flowmod is a ryu flow modification message object"""
         self.priority = flowmod.priority
         self.instructions = flowmod.instructions
+        self.validate_instructions()
         self.match_values = {}
         self.match_masks = {}
         self.out_port = None
@@ -328,6 +329,14 @@ class FlowMod:
             val = self.match_to_bits(key, val) & mask
             self.match_values[key] = val
             self.match_masks[key] = mask
+
+    def validate_instructions(self):
+        instruction_types = set()
+        for instruction in self.instructions:
+            if instruction.type in instruction_types:
+                raise FakeOFTableException(
+                    'FlowMod with Multiple instructions of the '
+                    'same type: {}'.format(self.instructions))
 
     def out_port_matches(self, other):
         """returns True if other has an output action to this flowmods

--- a/tests/unit/faucet/fakeoftable.py
+++ b/tests/unit/faucet/fakeoftable.py
@@ -86,16 +86,14 @@ class FakeOFTable:
             # entries which will cause ambiguous behaviour. This is
             # obviously unnacceptable so we will assume this is
             # always set
-            add = True
             for fte in table:
                 if flowmod.fte_matches(fte, strict=True):
                     table.remove(fte)
                     break
                 elif flowmod.overlaps(fte):
-                    add = False
-                    break
-            if add:
-                table.append(flowmod)
+                    raise FakeOFTableException(
+                        'Overlapping flowmod {}'.format(flowmod))
+            table.append(flowmod)
 
         def _del(table, flowmod):
             removals = [fte for fte in table if flowmod.fte_matches(fte)]


### PR DESCRIPTION
Make each datapath table the responsibility of a single module. So that, for the most part, only one module installs flows into any given table.

Adds a ValvePipeline manager for controlling the movement of packets through the faucet pipeline and for installing flows into the classification and egress tables.

FakeOFTable now tests for overlapping flows or flow mod messages with multiple of the same instruction.

All managers inherit from a ValveManager base class.

Permanent learn now installs mac spoofing prevention flows only in response to seeing a spoofed mac address. This may fix not well understood issues with permanent learn.

Most flow mods now use priorities set in the ValveManager base class rather than those configured.