### PR TITLE
Valve host pipeline

### DIFF
--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -81,6 +81,7 @@ class Valve:
         'dp',
         'flood_manager',
         'host_manager',
+        'pipeline',
         'logger',
         'logname',
         'metrics',

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -181,7 +181,7 @@ class Valve:
                 self.DEC_TTL,
                 self.dp.multi_out,
                 fib_table, self.dp.tables['vip'],
-                classification_table, self.dp.output_table(),
+                self.dp.output_table(),
                 self.pipeline,
                 self.dp.highest_priority, self.dp.routers)
             self._route_manager_by_ipv[route_manager.IPV] = route_manager

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -214,12 +214,11 @@ class Valve:
             host_manager_cl = valve_host.ValveHostFlowRemovedManager
         self.host_manager = host_manager_cl(
             self.logger, self.dp.ports,
-            self.dp.vlans, classification_table,
-            self.dp.tables['eth_src'], self.dp.tables['eth_dst'],
-            eth_dst_hairpin_table, egress_table, self.dp.timeout,
-            self.dp.learn_jitter, self.dp.learn_ban_timeout,
-            self.dp.low_priority, self.dp.highest_priority,
-            self.dp.cache_update_guard_time)
+            self.dp.vlans, self.dp.tables['eth_src'],
+            self.dp.tables['eth_dst'], eth_dst_hairpin_table, egress_table,
+            self.pipeline, self.dp.timeout, self.dp.learn_jitter,
+            self.dp.learn_ban_timeout, self.dp.low_priority,
+            self.dp.highest_priority, self.dp.cache_update_guard_time)
         table_configs = sorted([
             (table.table_id, str(table.table_config)) for table in self.dp.tables.values()])
         for table_id, table_config in table_configs:

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -31,6 +31,7 @@ from faucet import valve_packet
 from faucet import valve_route
 from faucet import valve_table
 from faucet import valve_util
+from faucet import valve_pipeline
 
 from faucet.port import STACK_STATE_INIT, STACK_STATE_UP, STACK_STATE_DOWN
 from faucet.vlan import NullVLAN
@@ -157,6 +158,7 @@ class Valve:
 
         self.dp.reset_refs()
 
+        self.pipeline = valve_pipeline.ValvePipeline(self.dp)
         classification_table = self.dp.classification_table()
         for vlan_vid in self.dp.vlans.keys():
             self._port_highwater[vlan_vid] = {}
@@ -180,6 +182,7 @@ class Valve:
                 self.dp.multi_out,
                 fib_table, self.dp.tables['vip'],
                 classification_table, self.dp.output_table(),
+                self.pipeline,
                 self.dp.highest_priority, self.dp.routers)
             self._route_manager_by_ipv[route_manager.IPV] = route_manager
             for vlan in self.dp.vlans.values():

--- a/faucet/valve_pipeline.py
+++ b/faucet/valve_pipeline.py
@@ -1,0 +1,46 @@
+"""Manages movement of packets through the faucet pipeline"""
+from faucet import valve_of
+
+class ValvePipeline(object):
+    """Responsible for maintaing the integrity of the Faucet pipeline for a
+    single valve.
+
+    Controls what packets a module sees in its tables and how it can pass
+    packets through the pipeline.
+
+    Responsible for installing flows in the vlan, egress and classification
+    tables"""
+
+    # TODO: initialise tables
+    def __init__(self, dp):
+        self.dp = dp
+        self.classification_table = dp.classification_table()
+        self.output_table = dp.output_table()
+        self.egress_table = None
+        if dp.egress_pipeline:
+            self.egress_table = dp.tables['egress']
+        self.filter_priority = dp.highest_priority + 1
+        self.select_priority = dp.highest_priority
+
+    # pylint: disable=W0613
+    def filter_packets(self, target_table, match_dict):
+        """get a list of flow modification messages to filter packets from
+        the pipeline.
+        args:
+            target_table: the table requesting the filtering
+            match_dict: a dictionary specifying the match fields
+        """
+        return [self.classification_table.flowdrop(
+            self.classification_table.match(match),
+            priority=(self.high_priority))]
+
+    def select_packets(self, target_table, match, actions=None):
+        """retrieve rules to redirect packets matching match_dict to table"""
+        inst = [self.target_table.goto_this()]
+        if actions is not None:
+            inst.append(valve_of.apply_actions(actions))
+        return [self.classification_table.flowmod(
+            self.classification_table.match(match),
+            priority=self.low_priority,
+            inst=inst)]
+

--- a/faucet/valve_pipeline.py
+++ b/faucet/valve_pipeline.py
@@ -1,7 +1,7 @@
 """Manages movement of packets through the faucet pipeline"""
 from faucet import valve_of
 
-class ValvePipeline(object):
+class ValvePipeline:
     """Responsible for maintaing the integrity of the Faucet pipeline for a
     single valve.
 
@@ -11,7 +11,6 @@ class ValvePipeline(object):
     Responsible for installing flows in the vlan, egress and classification
     tables"""
 
-    # TODO: initialise tables
     def __init__(self, dp):
         self.dp = dp
         self.classification_table = dp.classification_table()
@@ -43,4 +42,3 @@ class ValvePipeline(object):
             self.classification_table.match(**match_dict),
             priority=self.select_priority,
             inst=inst)]
-

--- a/faucet/valve_pipeline.py
+++ b/faucet/valve_pipeline.py
@@ -31,16 +31,16 @@ class ValvePipeline(object):
             match_dict: a dictionary specifying the match fields
         """
         return [self.classification_table.flowdrop(
-            self.classification_table.match(match),
-            priority=(self.high_priority))]
+            self.classification_table.match(**match_dict),
+            priority=(self.filter_priority))]
 
-    def select_packets(self, target_table, match, actions=None):
+    def select_packets(self, target_table, match_dict, actions=None):
         """retrieve rules to redirect packets matching match_dict to table"""
-        inst = [self.target_table.goto_this()]
+        inst = [target_table.goto_this()]
         if actions is not None:
             inst.append(valve_of.apply_actions(actions))
         return [self.classification_table.flowmod(
-            self.classification_table.match(match),
-            priority=self.low_priority,
+            self.classification_table.match(**match_dict),
+            priority=self.select_priority,
             inst=inst)]
 

--- a/faucet/valve_route.py
+++ b/faucet/valve_route.py
@@ -116,6 +116,7 @@ class ValveRouteManager:
                  max_hosts_per_resolve_cycle, max_host_fib_retry_count,
                  max_resolve_backoff_time, proactive_learn, dec_ttl, multi_out,
                  fib_table, vip_table, classification_table, output_table,
+                 pipeline,
                  route_priority, routers):
         self.logger = logger
         self.global_vlan = AnonVLAN(global_vlan)
@@ -130,6 +131,7 @@ class ValveRouteManager:
         self.vip_table = vip_table
         self.classification_table = classification_table
         self.output_table = output_table
+        self.pipeline = pipeline
         self.route_priority = route_priority
         self.routers = routers
         self.active = False

--- a/faucet/valve_route.py
+++ b/faucet/valve_route.py
@@ -89,8 +89,8 @@ class ValveRouteManager:
         'neighbor_timeout',
         'dec_ttl',
         'output_table',
-        'classification_table',
         'fib_table',
+        'pipeline'
         'multi_out',
         'global_vlan',
         'global_routing',
@@ -115,7 +115,7 @@ class ValveRouteManager:
     def __init__(self, logger, global_vlan, neighbor_timeout,
                  max_hosts_per_resolve_cycle, max_host_fib_retry_count,
                  max_resolve_backoff_time, proactive_learn, dec_ttl, multi_out,
-                 fib_table, vip_table, classification_table, output_table,
+                 fib_table, vip_table, output_table,
                  pipeline,
                  route_priority, routers):
         self.logger = logger
@@ -129,7 +129,6 @@ class ValveRouteManager:
         self.multi_out = multi_out
         self.fib_table = fib_table
         self.vip_table = vip_table
-        self.classification_table = classification_table
         self.output_table = output_table
         self.pipeline = pipeline
         self.route_priority = route_priority
@@ -266,17 +265,18 @@ class ValveRouteManager:
         ofmsgs = []
         learn_connected_priority = self.route_priority + faucet_vip.network.prefixlen
         faucet_mac = vlan.faucet_mac
-        insts = [self.classification_table.goto(self.fib_table)]
+        actions = None
         if self.global_routing:
             vlan_mac = valve_packet.int_in_mac(faucet_mac, vlan.vid)
-            insts = [valve_of.apply_actions([
+            actions = [
                 self.fib_table.set_field(eth_dst=vlan_mac),
-                self.fib_table.set_vlan_vid(self.global_vlan.vid)])] + insts
-        ofmsgs.append(self.classification_table.flowmod(
-            self.classification_table.match(
-                eth_type=self.ETH_TYPE, eth_dst=faucet_mac, vlan=vlan),
-            priority=self.route_priority,
-            inst=insts))
+                self.fib_table.set_vlan_vid(self.global_vlan.vid)
+                ]
+        ofmsgs.extend(self.pipeline.select_packets(
+            self.fib_table,
+            {'eth_type': self.ETH_TYPE, 'eth_dst': faucet_mac, 'vlan': vlan},
+            actions
+            ))
         if self.global_routing:
             vlan = self.global_vlan
         ofmsgs.append(self.fib_table.flowmod(
@@ -729,12 +729,10 @@ class ValveIPv4RouteManager(ValveRouteManager):
     def _add_faucet_vip_nd(self, vlan, priority, faucet_vip, faucet_vip_host):
         ofmsgs = []
         # ARP
-        ofmsgs.append(self.classification_table.flowmod(
-            self.classification_table.match(
-                eth_type=valve_of.ether.ETH_TYPE_ARP,
-                vlan=vlan),
-            priority=priority,
-            inst=[self.classification_table.goto(self.vip_table)]))
+        ofmsgs.extend(self.pipeline.select_packets(
+            self.vip_table,
+            {'eth_type': valve_of.ether.ETH_TYPE_ARP, 'vlan': vlan}
+            ))
         # ARP for FAUCET VIP
         ofmsgs.append(self.vip_table.flowcontroller(
             self.vip_table.match(
@@ -835,13 +833,12 @@ class ValveIPv6RouteManager(ValveRouteManager):
         ofmsgs = []
         # RA if this is a link local FAUCET VIP
         if faucet_vip.ip.is_link_local:
-            ofmsgs.append(self.classification_table.flowmod(
-                self.classification_table.match(
-                    eth_type=self.ETH_TYPE,
-                    eth_dst=valve_packet.IPV6_ALL_ROUTERS_MCAST,
-                    vlan=vlan),
-                priority=priority,
-                inst=[self.classification_table.goto(self.vip_table)]))
+            match = {
+                'eth_type': self.ETH_TYPE,
+                'eth_dst': valve_packet.IPV6_ALL_ROUTERS_MCAST,
+                'vlan': vlan
+                }
+            ofmsgs.extend(self.pipeline.select_packets(self.vip_table, match))
             ofmsgs.append(self.vip_table.flowmod(
                 self.vip_table.match(
                     eth_type=self.ETH_TYPE,
@@ -869,13 +866,12 @@ class ValveIPv6RouteManager(ValveRouteManager):
             priority=priority,
             max_len=self.ICMP_SIZE))
         # IPv6 NS for FAUCET VIP
-        ofmsgs.append(self.classification_table.flowmod(
-            self.classification_table.match(
-                eth_type=self.ETH_TYPE,
-                eth_dst=faucet_vip_host_nd_mcast,
-                vlan=vlan),
-            priority=priority,
-            inst=[self.classification_table.goto(self.vip_table)]))
+        match = {
+            'eth_type': self.ETH_TYPE,
+            'eth_dst': faucet_vip_host_nd_mcast,
+            'vlan': vlan
+            }
+        ofmsgs.extend(self.pipeline.select_packets(self.vip_table, match))
         ofmsgs.append(self.vip_table.flowmod(
             self.vip_table.match(
                 eth_type=self.ETH_TYPE,

--- a/faucet/valve_route.py
+++ b/faucet/valve_route.py
@@ -90,7 +90,7 @@ class ValveRouteManager:
         'dec_ttl',
         'output_table',
         'fib_table',
-        'pipeline'
+        'pipeline',
         'multi_out',
         'global_vlan',
         'global_routing',

--- a/faucet/valve_table.py
+++ b/faucet/valve_table.py
@@ -54,6 +54,9 @@ class ValveTable: # pylint: disable=too-many-arguments,too-many-instance-attribu
                 next_table.name, self.name))
         return valve_of.goto_table(next_table)
 
+    def goto_this(self):
+        return valve_of.goto_table(self)
+
     def goto_miss(self, next_table):
         """Add miss goto table instruction."""
         assert next_table.name == self.table_config.miss_goto, (

--- a/tests/integration/mininet_tests.py
+++ b/tests/integration/mininet_tests.py
@@ -3012,11 +3012,16 @@ vlans:
     def test_untagged(self):
         self.ping_all_when_learned(hard_timeout=0)
         first_host, second_host, third_host = self.net.hosts[0:3]
-        # 3rd host impersonates 1st, 3rd host breaks but 1st host still OK
+        self.assertTrue(self.prom_mac_learned(first_host.MAC(), port=1))
+
+        # 3rd host impersonates 1st but 1st host still OK
         original_third_host_mac = third_host.MAC()
         third_host.setMAC(first_host.MAC())
         self.assertEqual(100.0, self.net.ping((second_host, third_host)))
+        self.assertTrue(self.prom_mac_learned(first_host.MAC(), port=1))
+        self.assertFalse(self.prom_mac_learned(first_host.MAC(), port=3))
         self.retry_net_ping(hosts=(first_host, second_host))
+
         # 3rd host stops impersonating, now everything fine again.
         third_host.setMAC(original_third_host_mac)
         self.ping_all_when_learned(hard_timeout=0)


### PR DESCRIPTION
Builds on https://github.com/faucetsdn/faucet/pull/2526

Removes references to classification table from valve host by using the pipeline module.

This involves a change to the functionality of permanent learn.

Permanent learn now only blocks spoofed mac addresses when they are seen by the controller. Rules blocking the port/mac combination are installed in response to receiving any packet from a permanent learn mac address on a different port.