### PR TITLE
Move pytype options to setup.cfg.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,3 +35,13 @@ console_scripts =
     gauge = faucet.__main__:main
     check_faucet_config = faucet.check_faucet_config:main
     fctl = faucet.fctl:main
+
+[pytype]
+python_version = 3.5
+pythonpath =
+    .:
+    faucet:
+    clib
+disable =
+    pyi-error,
+    import-error

--- a/tests/codecheck/pytype.sh
+++ b/tests/codecheck/pytype.sh
@@ -4,10 +4,10 @@
 # TODO: until 3.6 safe, force 3.5
 PYV="3.5"
 FAUCETHOME=`dirname $0`"/../.."
-PYTHONPATH=$FAUCETHOME:$FAUCETHOME/faucet:$FAUCETHOME/clib
+CONFIG="$FAUCETHOME/setup.cfg"
 PARARGS="parallel --delay 1 --bar"
 PYTYPE=`which pytype`
-PYTYPEARGS="python$PYV  $PYTYPE --pythonpath $PYTHONPATH -d pyi-error,import-error -V$PYV"
+PYTYPEARGS="python$PYV  $PYTYPE --config $CONFIG"
 PYHEADER=`head -1 $PYTYPE`
 SRCFILES="$FAUCETHOME/tests/codecheck/src_files.sh"
 echo "Using $PYTYPE (header $PYHEADER)"


### PR DESCRIPTION
Thank you for using pytype! I'm one of the maintainers, and putting your pytype options in setup.cfg would be really helpful for us: it makes it easier to track pytype use cases and figure out what features to prioritize.