### PR TITLE
Pipeline egress and initialise tables

### DIFF
--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -280,10 +280,10 @@ class Valve:
 
     def _add_default_drop_flows(self):
         """Add default drop rules on all FAUCET tables."""
-        classification_table = self.dp.classification_table()
+        ofmsgs = []
+        ofmsgs.extend(self.pipeline.initialise_tables())
         flood_table = self.dp.tables['flood']
 
-        ofmsgs = []
         for table in self.dp.tables.values():
             miss_table_name = table.table_config.miss_goto
             if miss_table_name:
@@ -294,24 +294,6 @@ class Valve:
             else:
                 ofmsgs.append(table.flowdrop(
                     priority=self.dp.lowest_priority))
-
-        # drop broadcast sources
-        if self.dp.drop_broadcast_source_address:
-            ofmsgs.append(classification_table.flowdrop(
-                classification_table.match(eth_src=valve_of.mac.BROADCAST_STR),
-                priority=self.dp.highest_priority))
-
-        ofmsgs.append(classification_table.flowdrop(
-            classification_table.match(eth_type=valve_of.ECTP_ETH_TYPE),
-            priority=self.dp.highest_priority))
-
-        # antispoof for FAUCET's MAC address
-        # TODO: antispoof for controller IPs on this VLAN, too.
-        if self.dp.drop_spoofed_faucet_mac:
-            for vlan in self.dp.vlans.values():
-                ofmsgs.append(classification_table.flowdrop(
-                    classification_table.match(eth_src=vlan.faucet_mac),
-                    priority=self.dp.high_priority))
 
         ofmsgs.append(flood_table.flowdrop(
             flood_table.match(

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -281,9 +281,6 @@ class Valve:
     def _add_default_drop_flows(self):
         """Add default drop rules on all FAUCET tables."""
         ofmsgs = []
-        ofmsgs.extend(self.pipeline.initialise_tables())
-        flood_table = self.dp.tables['flood']
-
         for table in self.dp.tables.values():
             miss_table_name = table.table_config.miss_goto
             if miss_table_name:
@@ -295,15 +292,8 @@ class Valve:
                 ofmsgs.append(table.flowdrop(
                     priority=self.dp.lowest_priority))
 
-        ofmsgs.append(flood_table.flowdrop(
-            flood_table.match(
-                eth_dst=valve_packet.CISCO_SPANNING_GROUP_ADDRESS),
-            priority=self.dp.highest_priority))
-        ofmsgs.append(flood_table.flowdrop(
-            flood_table.match(
-                eth_dst=valve_packet.BRIDGE_GROUP_ADDRESS,
-                eth_dst_mask=valve_packet.BRIDGE_GROUP_MASK),
-            priority=self.dp.highest_priority))
+        ofmsgs.extend(self.pipeline.initialise_tables())
+        ofmsgs.extend(self.flood_manager.initialise_tables())
 
         return ofmsgs
 

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -208,10 +208,10 @@ class Valve:
         self.host_manager = host_manager_cl(
             self.logger, self.dp.ports,
             self.dp.vlans, self.dp.tables['eth_src'],
-            self.dp.tables['eth_dst'], eth_dst_hairpin_table, egress_table,
-            self.pipeline, self.dp.timeout, self.dp.learn_jitter,
-            self.dp.learn_ban_timeout, self.dp.low_priority,
-            self.dp.highest_priority, self.dp.cache_update_guard_time)
+            self.dp.tables['eth_dst'], eth_dst_hairpin_table, self.pipeline,
+            self.dp.timeout, self.dp.learn_jitter, self.dp.learn_ban_timeout,
+            self.dp.low_priority, self.dp.highest_priority,
+            self.dp.cache_update_guard_time)
         table_configs = sorted([
             (table.table_id, str(table.table_config)) for table in self.dp.tables.values()])
         for table_id, table_config in table_configs:

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -160,7 +160,6 @@ class Valve:
         self.dp.reset_refs()
 
         self.pipeline = valve_pipeline.ValvePipeline(self.dp)
-        classification_table = self.dp.classification_table()
         for vlan_vid in self.dp.vlans.keys():
             self._port_highwater[vlan_vid] = {}
             for port_number in self.dp.ports.keys():

--- a/faucet/valve_flood.py
+++ b/faucet/valve_flood.py
@@ -67,6 +67,21 @@ class ValveFloodManager:
             in_port=in_port,
             exclude_ports=exclude_ports)
 
+    def initialise_tables(self):
+        """initialise the flood table with filtering flows"""
+        ofmsgs = []
+        ofmsgs.append(self.flood_table.flowdrop(
+            self.flood_table.match(
+                eth_dst=valve_packet.CISCO_SPANNING_GROUP_ADDRESS),
+            priority=self.bypass_priority))
+        ofmsgs.append(self.flood_table.flowdrop(
+            self.flood_table.match(
+                eth_dst=valve_packet.BRIDGE_GROUP_ADDRESS,
+                eth_dst_mask=valve_packet.BRIDGE_GROUP_MASK),
+            priority=self.bypass_priority))
+        return ofmsgs
+
+
     def _build_flood_rule_actions(self, vlan, exclude_unicast, in_port):
         return self._build_flood_local_rule_actions(
             vlan, exclude_unicast, in_port)


### PR DESCRIPTION
Use valve_pipeline for controlling the output of packets via the regular pipeline (IE when not outputting directly).

And move the responsibility for initialising tables to the modules that control those tables, Currently with the exception of the default table actions.