### PR TITLE
Catch exceptions from BGP events.

### DIFF
--- a/faucet/faucet.py
+++ b/faucet/faucet.py
@@ -107,7 +107,8 @@ class Faucet(RyuAppBase):
         super(Faucet, self).__init__(*args, **kwargs)
         self.api = kwargs['faucet_experimental_api']
         self.metrics = faucet_metrics.FaucetMetrics(reg=self._reg)
-        self.bgp = faucet_bgp.FaucetBgp(self.logger, self.metrics, self._send_flow_msgs)
+        self.bgp = faucet_bgp.FaucetBgp(
+            self.logger, self.exc_logname, self.metrics, self._send_flow_msgs)
         self.dot1x = faucet_dot1x.FaucetDot1x(
             self.logger, self.metrics, self._send_flow_msgs)
         self.notifier = faucet_experimental_event.FaucetExperimentalEventNotifier(

--- a/faucet/valve_route.py
+++ b/faucet/valve_route.py
@@ -583,6 +583,12 @@ class ValveRouteManager(ValveManagerBase):
         router = self._router_for_vlan(vlan)
         if router is not None:
             vlan, _ = router.vip_map(ip_gw)
+            if vlan is None:
+                self.logger.error(
+                    ('Cannot resolve destination VLAN for gateway %s in router %s '
+                     '(not in global router?)' % (
+                         ip_gw, router)))
+                return ofmsgs
         if vlan.is_faucet_vip(ip_dst):
             return ofmsgs
         routes = self._vlan_routes(vlan)

--- a/tests/unit/faucet/test_valve.py
+++ b/tests/unit/faucet/test_valve.py
@@ -360,7 +360,8 @@ class ValveTestBases:
             # TODO: verify events
             self.notifier = faucet_experimental_event.FaucetExperimentalEventNotifier(
                 self.faucet_event_sock, self.metrics, self.logger)
-            self.bgp = faucet_bgp.FaucetBgp(self.logger, self.metrics, self.send_flows_to_dp_by_id)
+            self.bgp = faucet_bgp.FaucetBgp(
+                self.logger, logfile, self.metrics, self.send_flows_to_dp_by_id)
             self.dot1x = faucet_dot1x.FaucetDot1x(
                 self.logger, self.metrics, self.send_flows_to_dp_by_id)
             self.valves_manager = valves_manager.ValvesManager(


### PR DESCRIPTION
Check for an unresolved VLAN at runtime (e.g. when we get a route from BGP that we can't find a VLAN for).