### PR TITLE
ValveTableConfig for *_acl tables should use sorted tuples

### DIFF
--- a/faucet/dp.py
+++ b/faucet/dp.py
@@ -393,15 +393,14 @@ configuration.
                 set_fields.update(acl.set_fields)
                 meter = meter or acl.meter
                 exact_match = acl.exact_match
-            matches = set(matches.items())
             table_config[table_name] = ValveTableConfig(
                 table_name,
                 default.table_id,
                 exact_match=exact_match,
                 meter=meter,
                 output=True,
-                match_types=matches,
-                set_fields=tuple(set_fields),
+                match_types=tuple(sorted(matches.items())),
+                set_fields=tuple(sorted(set_fields)),
                 next_tables=default.next_tables)
         # TODO: dynamically configure output attribue
         return table_config


### PR DESCRIPTION
Sets in python are unordered. The ValveTableConfig compares config objects as strings but the results of converting a set to a string are not deterministic and may depend on PYTHONHASHSEED or other factors. This is not serious, but leads to an unnecessary cold-start.

I made this change in the zof port because I was seeing random test failures for tests that expect a warm-start. Since I’ve made this change, these random test failures have gone away.

I never saw any such failures in the mainline travis tests. I'd have expected the same tests to fail randomly.