### PR TITLE
Add port_description to port Prometheus variables, Gauge uses port not port_name.

### DIFF
--- a/clib/mininet_test_base.py
+++ b/clib/mininet_test_base.py
@@ -1713,11 +1713,13 @@ dbs:
             time.sleep(1)
         self.fail(msg=msg)
 
+    def port_labels(self, port_no):
+        return {'port': port_no, 'port_description': 'b%u' % port_no}
+
     def wait_port_status(self, dpid, port_no, status, expected_status, timeout=10):
         for _ in range(timeout):
             port_status = self.scrape_prometheus_var(
-                'port_status', {'port': port_no, 'port_description': 'b%u' % port_no},
-                default=None, dpid=dpid)
+                'port_status', self.port_labels(port_no), default=None, dpid=dpid)
             if port_status is not None and port_status == expected_status:
                 return
             self._portmod(dpid, port_no, status, OFPPC_PORT_DOWN)

--- a/clib/mininet_test_base.py
+++ b/clib/mininet_test_base.py
@@ -1718,7 +1718,8 @@ dbs:
         self.fail(msg=msg)
 
     def port_labels(self, port_no):
-        remapped_port_no = self.port_map['port_%u' % port_no]
+        remap_key = 'port_%u' % port_no
+        remapped_port_no = self.port_map.get(remap_key, port_no)
         return {'port': remapped_port_no, 'port_description': 'b%u' % port_no}
 
     def wait_port_status(self, dpid, port_no, status, expected_status, timeout=10):

--- a/clib/mininet_test_base.py
+++ b/clib/mininet_test_base.py
@@ -1716,7 +1716,8 @@ dbs:
     def wait_port_status(self, dpid, port_no, status, expected_status, timeout=10):
         for _ in range(timeout):
             port_status = self.scrape_prometheus_var(
-                'port_status', {'port': port_no}, default=None, dpid=dpid)
+                'port_status', {'port': port_no, 'port_description': 'b%u' % port_no},
+                default=None, dpid=dpid)
             if port_status is not None and port_status == expected_status:
                 return
             self._portmod(dpid, port_no, status, OFPPC_PORT_DOWN)

--- a/clib/mininet_test_base.py
+++ b/clib/mininet_test_base.py
@@ -1718,7 +1718,8 @@ dbs:
         self.fail(msg=msg)
 
     def port_labels(self, port_no):
-        return {'port': port_no, 'port_description': 'b%u' % port_no}
+        remapped_port_no = self.port_map['port_%u' % port_no]
+        return {'port': remapped_port_no, 'port_description': 'b%u' % port_no}
 
     def wait_port_status(self, dpid, port_no, status, expected_status, timeout=10):
         for _ in range(timeout):

--- a/faucet/faucet_metrics.py
+++ b/faucet/faucet_metrics.py
@@ -32,7 +32,7 @@ class FaucetMetrics(PromClient):
 
     def __init__(self, reg=None):
         super(FaucetMetrics, self).__init__(reg=reg)
-        self.PORT_REQUIRED_LABELS = self.REQUIRED_LABELS + ['port']
+        self.PORT_REQUIRED_LABELS = self.REQUIRED_LABELS + ['port', 'port_description']
         self._dpid_counters = {}
         self._dpid_gauges = {}
         self.faucet_config_reload_requests = self._counter(

--- a/faucet/gauge_pollers.py
+++ b/faucet/gauge_pollers.py
@@ -118,7 +118,7 @@ class GaugePoller:
             port_description = port.description
         port_labels = dict(
             dp_id=hex(dp_id), dp_name=self.dp.name,
-            port_name=port_name, port_description=port_description)
+            port=port_name, port_description=port_description)
         return port_labels
 
     @staticmethod

--- a/faucet/gauge_pollers.py
+++ b/faucet/gauge_pollers.py
@@ -110,6 +110,17 @@ class GaugePoller:
         self.logger.debug('stats for unknown port %u', stat.port_no)
         return str(stat.port_no)
 
+    def _stat_port_labels(self, msg, stat, dp_id):
+        port = self.dp.ports.get(stat.port_no, None)
+        port_name = self._stat_port_name(msg, stat, dp_id)
+        port_description = port_name
+        if port is not None:
+            port_description = port.description
+        port_labels = dict(
+            dp_id=hex(dp_id), dp_name=self.dp.name,
+            port_name=port_name, port_description=port_description)
+        return port_labels
+
     @staticmethod
     def _format_port_stats(delim, stat):
         formatted_port_stats = []

--- a/faucet/gauge_prom.py
+++ b/faucet/gauge_prom.py
@@ -62,7 +62,8 @@ class GaugePrometheusClient(PromClient):
             exported_prom_var = PROM_PREFIX_DELIM.join(
                 (PROM_PORT_PREFIX, prom_var))
             self.metrics[exported_prom_var] = Gauge( # pylint: disable=unexpected-keyword-arg
-                exported_prom_var, '', self.REQUIRED_LABELS + ['port_name'],
+                exported_prom_var, '',
+                self.REQUIRED_LABELS + ['port_name', 'port_description'],
                 registry=self._reg)
 
     def reregister_flow_vars(self, table_name, table_tags):
@@ -98,8 +99,7 @@ class GaugePortStatsPrometheusPoller(GaugePortStatsPoller):
     def update(self, rcv_time, dp_id, msg):
         super(GaugePortStatsPrometheusPoller, self).update(rcv_time, dp_id, msg)
         for stat in msg.body:
-            port_name = self._stat_port_name(msg, stat, dp_id)
-            port_labels = dict(dp_id=hex(dp_id), dp_name=self.dp.name, port_name=port_name)
+            port_labels = self._stat_port_labels(msg, stat, dp_id)
             for stat_name, stat_val in self._format_port_stats(
                     PROM_PREFIX_DELIM, stat):
                 self.prom_client.metrics[stat_name].labels(**port_labels).set(stat_val)
@@ -111,13 +111,14 @@ class GaugePortStatePrometheusPoller(GaugePortStatePoller):
     def update(self, rcv_time, dp_id, msg):
         super(GaugePortStatePrometheusPoller, self).update(rcv_time, dp_id, msg)
         port_no = msg.desc.port_no
-        if port_no in self.dp.ports:
-            port_name = self.dp.ports[port_no].name
-            port_labels = dict(dp_id=hex(dp_id), dp_name=self.dp.name, port_name=port_name)
-            for prom_var in PROM_PORT_STATE_VARS:
-                exported_prom_var = PROM_PREFIX_DELIM.join((PROM_PORT_PREFIX, prom_var))
-                msg_value = msg.reason if prom_var == 'reason' else getattr(msg.desc, prom_var)
-                self.prom_client.metrics[exported_prom_var].labels(**port_labels).set(msg_value)
+        port = self.dp.ports.get(port_no, None)
+        if port is None:
+            return
+        port_labels = self._stat_port_labels(msg, msg.desc, dp_id)
+        for prom_var in PROM_PORT_STATE_VARS:
+            exported_prom_var = PROM_PREFIX_DELIM.join((PROM_PORT_PREFIX, prom_var))
+            msg_value = msg.reason if prom_var == 'reason' else getattr(msg.desc, prom_var)
+            self.prom_client.metrics[exported_prom_var].labels(**port_labels).set(msg_value)
 
 
 class GaugeFlowTablePrometheusPoller(GaugeFlowTablePoller):

--- a/faucet/gauge_prom.py
+++ b/faucet/gauge_prom.py
@@ -63,7 +63,7 @@ class GaugePrometheusClient(PromClient):
                 (PROM_PORT_PREFIX, prom_var))
             self.metrics[exported_prom_var] = Gauge( # pylint: disable=unexpected-keyword-arg
                 exported_prom_var, '',
-                self.REQUIRED_LABELS + ['port_name', 'port_description'],
+                self.REQUIRED_LABELS + ['port', 'port_description'],
                 registry=self._reg)
 
     def reregister_flow_vars(self, table_name, table_tags):

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -117,10 +117,11 @@ class Valve:
         self.dp_init()
 
     def port_labels(self, port):
-        return dict(self.base_prom_labels, port=port.number)
+        return dict(
+            self.base_prom_labels, port=port.number, port_description=port.description)
 
     def _port_vlan_labels(self, port, vlan):
-        return dict(self.base_prom_labels, vlan=vlan.vid, port=port.number)
+        return dict(self.port_labels(port), vlan=vlan.vid)
 
     def _inc_var(self, var, labels=None, val=1):
         if labels is None:
@@ -419,8 +420,11 @@ class Valve:
 
     def _set_port_status(self, port_no, port_status):
         """Set port operational status."""
-        labels = dict(self.base_prom_labels, port=port_no)
-        self._set_var('port_status', port_status, labels=labels)
+        port = self.dp.ports.get(port_no, None)
+        if port is None:
+            return
+        port_labels = self.port_labels(port)
+        self._set_var('port_status', port_status, labels=port_labels)
         if port_status:
             self.dp.dyn_up_ports.add(port_no)
         else:

--- a/tests/integration/mininet_tests.py
+++ b/tests/integration/mininet_tests.py
@@ -1210,10 +1210,7 @@ class FaucetUntaggedPrometheusGaugeTest(FaucetUntaggedTest):
 
     def scrape_port_counters(self, port, port_vars):
         port_counters = {}
-        port_labels = {
-            'port': self.port_map['port_%u' % port],
-            'port_description': 'b%u' % port,
-        }
+        port_labels = self.port_labels(self.port_map['port_%u' % port])
         for port_var in port_vars:
             val = self.scrape_prometheus_var(
                 port_var, labels=port_labels, controller='gauge', dpid=True, retries=3)

--- a/tests/integration/mininet_tests.py
+++ b/tests/integration/mininet_tests.py
@@ -3219,14 +3219,14 @@ vlans:
                 lacp: 1
             %(port_2)d:
                 native_vlan: 100
-                description: "b1"
+                description: "b2"
                 lacp: 1
             %(port_3)d:
                 native_vlan: 100
-                description: "b2"
+                description: "b3"
             %(port_4)d:
                 native_vlan: 100
-                description: "b2"
+                description: "b4"
 """
 
     def setUp(self): # pylint: disable=invalid-name
@@ -4447,7 +4447,7 @@ vlans:
         self.flap_all_switch_ports()
         self.change_port_config(
             self.port_map['port_3'], 'mirror', ['b1', 'b2'],
-            restart=True, cold_start=True, hup=True)
+            restart=True, cold_start=False, hup=True)
         self.verify_ping_mirrored_multi(
             ping_pairs, mirror_host, both_mirrored=True)
 

--- a/tests/integration/mininet_tests.py
+++ b/tests/integration/mininet_tests.py
@@ -177,21 +177,25 @@ vlans:
             %(port_1)d:
                 name: b1
                 native_vlan: 100
-                description: "b1 - 802.1x client."
+                description: "b1"
+                # 802.1x client.
                 dot1x: True
             %(port_2)d:
                 name: b2
                 native_vlan: 100
-                description: "b2 - 802.1X client."
+                description: "b2"
+                # 802.1X client.
                 dot1x: True
             %(port_3)d:
                 name: b3
                 native_vlan: 100
-                description: "b3 - ping host."
+                description: "b3"
+                # ping host.
             %(port_4)d:
                 name: b4
                 native_vlan: 100
-                description: "NFV host - interface used by controller."
+                description: "b4"
+                # "NFV host - interface used by controller."
 """
 
     wpasupplicant_conf_1 = """
@@ -270,10 +274,10 @@ network={
             self.eapol1_host, 1, self.wpasupplicant_conf_1, and_logoff=False)
         self.assertEqual(
             1,
-            self.scrape_prometheus_var('port_dot1x_success', labels={'port': 1}, default=0))
+            self.scrape_prometheus_var('port_dot1x_success', labels=self.port_labels(1), default=0))
         self.assertEqual(
             0,
-            self.scrape_prometheus_var('port_dot1x_success', labels={'port': 2}, default=0))
+            self.scrape_prometheus_var('port_dot1x_success', labels=self.port_labels(2), default=0))
 
         self.one_ipv4_ping(self.eapol2_host, self.ping_host.IP(),
                            require_host_learned=False, expected_result=False)
@@ -545,13 +549,13 @@ class Faucet8021XFailureTest(Faucet8021XSuccessTest):
             self.scrape_prometheus_var('dp_dot1x_success', default=0))
         self.assertEqual(
             0,
-            self.scrape_prometheus_var('port_dot1x_success', labels={'port': 1}, default=0))
+            self.scrape_prometheus_var('port_dot1x_success', labels=self.port_labels(1), default=0))
         self.assertEqual(
             0,
             self.scrape_prometheus_var('dp_dot1x_logoff', default=0))
         self.assertEqual(
             0,
-            self.scrape_prometheus_var('port_dot1x_logoff', labels={'port': 1}, default=0))
+            self.scrape_prometheus_var('port_dot1x_logoff', labels=self.port_labels(1), default=0))
         self.assertEqual(
             1,
             self.scrape_prometheus_var('dp_dot1x_failure', default=0))
@@ -1902,11 +1906,11 @@ vlans:
         self.assertEqual(self.MAX_HOSTS, len(flows))
         self.assertGreater(
             self.scrape_prometheus_var(
-                'port_learn_bans', {'port': self.port_map['port_2']}), 0)
+                'port_learn_bans', self.port_labels(self.port_map['port_2'])), 0)
         learned_macs = [
             mac for _, mac in self.scrape_prometheus_var(
                 'learned_macs',
-                {'port': self.port_map['port_2'], 'vlan': '100'},
+                dict(self.port_labels(self.port_map['port_2']), vlan=100),
                 multiple=True) if mac]
         self.assertEqual(self.MAX_HOSTS, len(learned_macs))
 
@@ -3322,7 +3326,7 @@ details partner lacp pdu:
             lacp_up_ports = 0
             for lacp_port in lag_ports:
                 lacp_up_ports += self.scrape_prometheus_var(
-                    'port_lacp_status', {'port': str(lacp_port)})
+                    'port_lacp_status', self.port_labels(lacp_port))
             return lacp_up_ports
 
         self.assertEqual(0, prom_lag_status())
@@ -4431,6 +4435,9 @@ vlans:
                 description: "b2"
             %(port_3)d:
                 description: "b3"
+                output_only: True
+            %(port_4)d:
+                description: "b4"
                 output_only: True
 """
 

--- a/tests/integration/mininet_tests.py
+++ b/tests/integration/mininet_tests.py
@@ -1901,7 +1901,7 @@ vlans:
         self.assertEqual(self.MAX_HOSTS, len(flows))
         self.assertGreater(
             self.scrape_prometheus_var(
-                'port_learn_bans', self.port_labels(2), 0))
+                'port_learn_bans', self.port_labels(2)), 0)
         learned_macs = [
             mac for _, mac in self.scrape_prometheus_var(
                 'learned_macs',

--- a/tests/integration/mininet_tests.py
+++ b/tests/integration/mininet_tests.py
@@ -1209,7 +1209,7 @@ class FaucetUntaggedPrometheusGaugeTest(FaucetUntaggedTest):
         port_labels = {
             'dp_id': self.dpid,
             'dp_name': self.DP_NAME,
-            'port_name': self.port_map['port_%u' % port],
+            'port': self.port_map['port_%u' % port],
             'port_description': 'b%u' % port,
         }
         for port_var in port_vars:

--- a/tests/integration/mininet_tests.py
+++ b/tests/integration/mininet_tests.py
@@ -6251,10 +6251,9 @@ class FaucetStringOfDPTest(FaucetTest):
                         peer_stack_port_base = first_stack_port + self.topo.switch_to_switch_links
                     for stack_dp_port in range(self.topo.switch_to_switch_links):
                         peer_port = peer_stack_port_base + stack_dp_port
-                        description = 'to %s port %u' % (dp_name(peer_dp), peer_port)
                         interfaces_config[port] = {
                             'name': stack_name(i, port),
-                            'description': description,
+                            'description': 'b%u' % port,
                         }
                         if stack:
                             # make this a stacking link.
@@ -6551,11 +6550,9 @@ class FaucetStackRingOfDPTest(FaucetStringOfDPTest):
         self.last_host = self.net.hosts[self.NUM_HOSTS + self.NUM_DPS]
 
     def wait_for_stack_port_status(self, dpid, dp_name, port_no, status, timeout=25):
-        labels = {
-            'dp_id': '0x%x' % int(dpid), 'dp_name': dp_name, 'port': port_no}
         for _ in range(timeout):
             actual_status = self.scrape_prometheus_var(
-                'port_stack_state', labels=labels, dpid=False, default=None)
+                'port_stack_state', labels=self.port_labels(port_no), dpid=dpid, default=None)
             if actual_status == status:
                 return
             time.sleep(1)

--- a/tests/integration/mininet_tests.py
+++ b/tests/integration/mininet_tests.py
@@ -1210,6 +1210,7 @@ class FaucetUntaggedPrometheusGaugeTest(FaucetUntaggedTest):
             'dp_id': self.dpid,
             'dp_name': self.DP_NAME,
             'port_name': self.port_map['port_%u' % port],
+            'port_description': 'b%u' % port,
         }
         for port_var in port_vars:
             val = self.scrape_prometheus_var(

--- a/tests/integration/mininet_tests.py
+++ b/tests/integration/mininet_tests.py
@@ -561,7 +561,7 @@ class Faucet8021XFailureTest(Faucet8021XSuccessTest):
             self.scrape_prometheus_var('dp_dot1x_failure', default=0))
         self.assertEqual(
             1,
-            self.scrape_prometheus_var('port_dot1x_failure', labels={'port': 1}, default=0))
+            self.scrape_prometheus_var('port_dot1x_failure', labels=self.port_labels(1), default=0))
 
 
 class Faucet8021XPortChangesTest(Faucet8021XSuccessTest):

--- a/tests/integration/mininet_tests.py
+++ b/tests/integration/mininet_tests.py
@@ -1210,7 +1210,10 @@ class FaucetUntaggedPrometheusGaugeTest(FaucetUntaggedTest):
 
     def scrape_port_counters(self, port, port_vars):
         port_counters = {}
-        port_labels = self.port_labels(self.port_map['port_%u' % port])
+        port_labels = {
+            'port': self.port_map['port_%u' % port],
+            'port_description': 'b%u' % port,
+        }
         for port_var in port_vars:
             val = self.scrape_prometheus_var(
                 port_var, labels=port_labels, controller='gauge', dpid=True, retries=3)

--- a/tests/integration/mininet_tests.py
+++ b/tests/integration/mininet_tests.py
@@ -3125,14 +3125,14 @@ vlans:
                 description: "b1"
             %(port_2)d:
                 native_vlan: 100
-                description: "b1"
+                description: "b2"
             %(port_3)d:
                 native_vlan: 100
-                description: "b2"
+                description: "b3"
                 loop_protect: True
             %(port_4)d:
                 native_vlan: 100
-                description: "b2"
+                description: "b4"
                 loop_protect: True
 """
 
@@ -3150,7 +3150,7 @@ vlans:
             in_port = 'port_%u' % (i + 1)
             dp_port = self.port_map[in_port]
             total_bans += self.scrape_prometheus_var(
-                'port_learn_bans', {'port': str(dp_port)}, dpid=True, default=0)
+                'port_learn_bans', self.port_labels(dp_port), dpid=True, default=0)
         return total_bans
 
     def test_untagged(self):

--- a/tests/unit/gauge/test_gauge.py
+++ b/tests/unit/gauge/test_gauge.py
@@ -237,7 +237,7 @@ class GaugePrometheusTests(unittest.TestCase): # pytype: disable=module-attr
             labels = line[index + 1:line.find('}')].split(',')
 
             for label in labels:
-                lab_name, lab_val = label.split('=')
+                lab_name, lab_val = label.split('=', 1)
                 lab_val = lab_val.replace('"', '')
                 if lab_name == 'dp_id':
                     dp_id = int(lab_val, 16)
@@ -245,7 +245,7 @@ class GaugePrometheusTests(unittest.TestCase): # pytype: disable=module-attr
                     port_name = lab_val
 
             key = (dp_id, port_name)
-            stat_val = line.split(' ')[1]
+            stat_val = line.split(' ')[-1]
             if key not in parsed_output:
                 parsed_output[key] = []
 

--- a/tests/unit/gauge/test_gauge.py
+++ b/tests/unit/gauge/test_gauge.py
@@ -241,7 +241,7 @@ class GaugePrometheusTests(unittest.TestCase): # pytype: disable=module-attr
                 lab_val = lab_val.replace('"', '')
                 if lab_name == 'dp_id':
                     dp_id = int(lab_val, 16)
-                elif lab_name == 'port_name':
+                elif lab_name == 'port':
                     port_name = lab_val
 
             key = (dp_id, port_name)


### PR DESCRIPTION
Fixes https://github.com/faucetsdn/faucet/issues/2597.