### PR TITLE
Notify Chewie of port status events.

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -408,7 +408,6 @@ Implemented:
 Not Supported (yet):
 
 - RADIUS Accounting.
-- Port status changes do not affect the authentication status.
 - Multiple RADIUS Servers.
 - Other EAP types. E.g. TLS, ...
 - Dynamic assignment of VLAN/ACL.

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -786,7 +786,7 @@ class Valve:
 
             if port.dot1x \
                     or (self.dp.dot1x and port.number == self.dp.dot1x['nfv_sw_port']):
-                ofmsgs.extend(self.dot1x.get_port_acls(self, port))
+                ofmsgs.extend(self.dot1x.port_up(self, port))
 
             if not self.dp.dp_acls:
                 acl_ofmsgs = self._port_add_acl(port)
@@ -1492,12 +1492,18 @@ class Valve:
             priority=self.dp.highest_priority-1,
             inst=[port_acl_table.goto(self.dp.tables['vlan'])])]
 
-    def del_authed_mac(self, port_num, mac):
+    def del_authed_mac(self, port_num, mac=None):
         port_acl_table = self.dp.tables['port_acl']
+        if mac:
+            return [port_acl_table.flowdel(
+                port_acl_table.match(
+                    in_port=port_num,
+                    eth_src=mac),
+                priority=self.dp.highest_priority-1,
+                strict=True)]
         return [port_acl_table.flowdel(
             port_acl_table.match(
-                in_port=port_num,
-                eth_src=mac),
+                in_port=port_num),
             priority=self.dp.highest_priority-1,
             strict=True)]
 

--- a/tests/integration/mininet_tests.py
+++ b/tests/integration/mininet_tests.py
@@ -560,7 +560,7 @@ class Faucet8021XFailureTest(Faucet8021XSuccessTest):
             self.scrape_prometheus_var('port_dot1x_failure', labels={'port': 1}, default=0))
 
 
-class Faucet8021XPortChangesTest(Faucet8021XSuccessTest):
+class Faucet8021XPortStatusTest(Faucet8021XSuccessTest):
 
     RADIUS_PORT = 1860
 
@@ -615,6 +615,24 @@ class Faucet8021XPortChangesTest(Faucet8021XSuccessTest):
 
         self.assertTrue(self.get_matching_flow(match=match, table_id=0, actions=actions),
                         self.get_all_flows_from_dpid(self.dpid, 0))
+
+        # When the port goes down, and up the host should not be authenticated anymore.
+        tcpdump_txt_1 = self.try_8021x(
+            self.eapol1_host, 1, self.wpasupplicant_conf_1, and_logoff=False)
+        self.assertEqual(
+            1,
+            self.scrape_prometheus_var('port_dot1x_success', labels={'port': 1}, default=0))
+        self.assertIn('Success', tcpdump_txt_1)
+        self.one_ipv4_ping(self.eapol1_host, self.ping_host.IP(), require_host_learned=False)
+        self.set_port_down(1)
+
+        self.set_port_up(1)
+        actions, match = get_actions_and_match(4, 1)
+        self.assertTrue(self.get_matching_flow(match=match, table_id=0, actions=actions),
+                        self.get_all_flows_from_dpid(self.dpid, 0))
+
+        self.one_ipv4_ping(self.eapol1_host, self.ping_host.IP(),
+                           require_host_learned=False, expected_result=False)
 
 
 class Faucet8021XConfigReloadTest(Faucet8021XSuccessTest):


### PR DESCRIPTION
Also added code to explicitly remove the ACLs from the port_acl table, although this isn't actually necessary as the caller clears the table for anything that matches the port number.

https://travis-ci.org/Bairdo/faucet/builds/452148059