### PR TITLE
Restrict testing of metadata to OVS (only platform currently supporting it)

### DIFF
--- a/clib/clib_mininet_test_main.py
+++ b/clib/clib_mininet_test_main.py
@@ -51,6 +51,10 @@ SUPPORTS_METERS = (
     'ZodiacGX',
 )
 
+SUPPORTS_METADATA = (
+    DEFAULT_HARDWARE,
+)
+
 
 EXTERNAL_DEPENDENCIES = (
     ('ryu-manager', ['--version'],
@@ -334,6 +338,9 @@ def filter_test_hardware(test_obj, hw_config):
         test_hardware = hw_config['hardware']
 
     if test_obj.REQUIRES_METERS and test_hardware not in SUPPORTS_METERS:
+        return False
+
+    if test_obj.REQUIRES_METADATA and test_hardware not in SUPPORTS_METADATA:
         return False
 
     if testing_hardware:

--- a/clib/mininet_test_base.py
+++ b/clib/mininet_test_base.py
@@ -75,6 +75,7 @@ class FaucetTestBase(unittest.TestCase):
 
     RUN_GAUGE = True
     REQUIRES_METERS = False
+    REQUIRES_METADATA = False
 
     _PORT_ACL_TABLE = 0
     _VLAN_TABLE = 1

--- a/tests/integration/mininet_tests.py
+++ b/tests/integration/mininet_tests.py
@@ -1752,7 +1752,10 @@ vlans:
         self.verify_broadcast()
         self.verify_no_bcast_to_self()
 
+
 class FaucetTaggedAndUntaggedSameVlanEgressTest(FaucetTaggedAndUntaggedSameVlanTest):
+
+    REQUIRES_METADATA = True
     CONFIG = """
         egress_pipeline: True
         interfaces:
@@ -1769,6 +1772,7 @@ class FaucetTaggedAndUntaggedSameVlanEgressTest(FaucetTaggedAndUntaggedSameVlanT
                 native_vlan: 100
                 description: "b4"
 """
+
 
 class FaucetTaggedAndUntaggedSameVlanGroupTest(FaucetTaggedAndUntaggedSameVlanTest):
 


### PR DESCRIPTION
Fixes https://github.com/faucetsdn/faucet/issues/2624

