### PR TITLE
When flooding to a port that is being mirrored, the mirrored packet must not have a tag if the mirrored port is untagged.

### DIFF
--- a/faucet/valve_flood.py
+++ b/faucet/valve_flood.py
@@ -384,7 +384,7 @@ class ValveFloodStackManager(ValveFloodManager):
                         vlan=vlan,
                         eth_dst=valve_packet.BRIDGE_GROUP_ADDRESS,
                         eth_dst_mask=valve_packet.BRIDGE_GROUP_MASK),
-                        priority=self.bypass_priority + 1))
+                    priority=self.bypass_priority + 1))
                 # Because stacking uses reflected broadcasts from the root,
                 # don't try to learn broadcast sources from stacking ports.
                 if eth_dst is not None:

--- a/faucet/valve_flood.py
+++ b/faucet/valve_flood.py
@@ -82,7 +82,8 @@ class ValveFloodManager(ValveManagerBase):
             in_port=in_port,
             exclude_ports=exclude_ports)
 
-    def _vlan_flood_mirror_acts(self, vlan):
+    @staticmethod
+    def _vlan_flood_mirror_acts(vlan):
         mirror_acts = []
         for mirrored_port in vlan.mirrored_ports():
             mirror_acts.extend([act for act in mirrored_port.mirror_actions()])
@@ -207,7 +208,7 @@ class ValveFloodManager(ValveManagerBase):
 
     def update_stack_topo(self, event, dp, port=None): # pylint: disable=unused-argument,invalid-name
         """Update the stack topology. It has nothing to do for non-stacking DPs."""
-        pass
+        return
 
     @staticmethod
     def edge_learn_port(_other_valves, pkt_meta):

--- a/faucet/valve_flood.py
+++ b/faucet/valve_flood.py
@@ -65,7 +65,7 @@ class ValveFloodManager(ValveManagerBase):
 
     def _require_combinatorial_flood(self, vlan):
         """Must use in_port style flood rules if configured to or hairpinning/LAGs are in use."""
-        return self.combinatorial_port_flood or vlan.hairpin_ports() or vlan.lags()
+        return self.combinatorial_port_flood or vlan.hairpin_ports() or vlan.lags() or vlan.mirrored_ports()
 
     @staticmethod
     def _vlan_all_ports(vlan, exclude_unicast):

--- a/faucet/valve_flood.py
+++ b/faucet/valve_flood.py
@@ -34,7 +34,7 @@ class ValveFloodManager(ValveManagerBase):
         (False, valve_packet.BRIDGE_GROUP_ADDRESS, valve_packet.mac_byte_mask(3)), # 802.x
         (False, '01:00:5E:00:00:00', valve_packet.mac_byte_mask(3)), # IPv4 multicast
         (False, '33:33:00:00:00:00', valve_packet.mac_byte_mask(2)), # IPv6 multicast
-        (False, valve_of.mac.BROADCAST_STR, valve_packet.mac_byte_mask(6)), # flood on ethernet broadcasts
+        (False, valve_of.mac.BROADCAST_STR, valve_packet.mac_byte_mask(6)), # eth broadcasts
     )
 
     def __init__(self, flood_table, eth_src_table, # pylint: disable=too-many-arguments
@@ -65,7 +65,8 @@ class ValveFloodManager(ValveManagerBase):
 
     def _require_combinatorial_flood(self, vlan):
         """Must use in_port style flood rules if configured to or hairpinning/LAGs are in use."""
-        return self.combinatorial_port_flood or vlan.hairpin_ports() or vlan.lags() or vlan.mirrored_ports()
+        return (self.combinatorial_port_flood or vlan.hairpin_ports()
+                or vlan.lags() or vlan.mirrored_ports())
 
     @staticmethod
     def _vlan_all_ports(vlan, exclude_unicast):
@@ -197,7 +198,8 @@ class ValveFloodManager(ValveManagerBase):
             return self._build_group_flood_rules(vlan, modify, command)
         return self._build_multiout_flood_rules(vlan, command)
 
-    def update_stack_topo(self, event, dp, port=None): # pylint: disable=unused-argument,invalid-name
+    @staticmethod
+    def update_stack_topo(event, dp, port=None): # pylint: disable=unused-argument,invalid-name
         """Update the stack topology. It has nothing to do for non-stacking DPs."""
         return
 

--- a/faucet/valve_of.py
+++ b/faucet/valve_of.py
@@ -892,7 +892,8 @@ def flood_tagged_port_outputs(ports, in_port=None, exclude_ports=None):
             if exclude_ports and port in exclude_ports:
                 continue
             flood_acts.append(output_port(port.number))
-    return flood_acts
+            flood_acts.extend(port.mirror_actions())
+    return dedupe_output_port_acts(flood_acts)
 
 
 def flood_untagged_port_outputs(ports, in_port=None, exclude_ports=None):

--- a/faucet/valve_packet.py
+++ b/faucet/valve_packet.py
@@ -20,6 +20,7 @@
 import ipaddress
 import socket
 import struct
+from netaddr import EUI
 
 from ryu.lib import addrconv
 from ryu.lib.mac import BROADCAST, is_multicast, haddr_to_bin
@@ -61,6 +62,16 @@ LLDP_FAUCET_DP_ID = 1
 LLDP_FAUCET_STACK_STATE = 2
 
 LACP_SIZE = 124
+
+EUI_BITS = len(EUI(0).packed*8)
+MAC_MASK_BITMAP = {(2**EUI_BITS - 2**i): (EUI_BITS - i) for i in range(0, EUI_BITS + 1)}
+
+
+def mac_mask_bits(mac_mask):
+    """Return number of bits in MAC mask or 0."""
+    if mac_mask is not None:
+        return MAC_MASK_BITMAP.get(EUI(mac_mask).value, 0)
+    return 0
 
 
 def int_from_mac(mac):

--- a/tests/unit/faucet/test_valve.py
+++ b/tests/unit/faucet/test_valve.py
@@ -2129,10 +2129,6 @@ dps:
             p4:
                 number: 4
                 tagged_vlans: [v200]
-            p5:
-                number: 5
-                output_only: True
-                mirror: 4
 vlans:
     v100:
         vid: 0x100


### PR DESCRIPTION
Fixes https://github.com/faucetsdn/faucet/issues/2593