### PR TITLE
Fix travis test runs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: required
-dist: trusty
+dist: xenial
 language: python
 python:
   - '3.4'
@@ -7,9 +7,7 @@ python:
 services:
   - docker
 before_install:
-  - sudo ./docker/retrycmd.sh "apt-get -qy update"
-  - sudo ./docker/retrycmd.sh "apt-get install -qy openvswitch-switch"
-  - sudo ./docker/retrycmd.sh "apt-get install docker-ce"
+  - sudo modprobe openvswitch
 cache:
   pip: true
 env:

--- a/travis/runtests.sh
+++ b/travis/runtests.sh
@@ -75,6 +75,7 @@ docker images
 
 echo Shard $MATRIX_SHARD: $FAUCETTESTS
 sudo docker run --privileged --sysctl net.ipv6.conf.all.disable_ipv6=0 \
+  -v /var/local/lib/docker:/var/lib/docker \
   -v $HOME/.cache/pip:/var/tmp/pip-cache \
   -e FAUCET_TESTS="${FAUCET_TESTS}" \
   -e PY_FILES_CHANGED="${PY_FILES_CHANGED}" \


### PR DESCRIPTION
clib test suite is failing due to docker-in-docker file system overlaps (can't run another AUFS on top of another AUFS filesystem).