### PR TITLE
remove pointless delete messages

### DIFF
--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -685,8 +685,6 @@ class Valve:
         """Delete flows/state for a port."""
         ofmsgs = []
         ofmsgs.extend(self._delete_all_port_match_flows(port))
-        for table in self.dp.output_tables():
-            ofmsgs.append(table.flowdel(out_port=port.number))
         if self.dp.egress_pipeline:
             ofmsgs.append(
                 self.dp.tables['egress'].flowdel(out_port=port.number))


### PR DESCRIPTION
We never set the out_port on any flow table entry, so deleting things that match that out_port is a no op.