### PR TITLE
Re-enable groups for stacking.

### DIFF
--- a/faucet/dp.py
+++ b/faucet/dp.py
@@ -355,8 +355,6 @@ configuration.
                 self.lldp_beacon['system_name'] = self.name
         if self.stack:
             self._check_conf_types(self.stack, self.stack_defaults_types)
-            # TODO: groups silently disabled when stacking until better tested.
-            self.group_table = False
         if self.dot1x:
             self._check_conf_types(self.dot1x, self.dot1x_defaults_types)
         self._check_conf_types(self.table_sizes, self.default_table_sizes_types)

--- a/tests/integration/mininet_tests.py
+++ b/tests/integration/mininet_tests.py
@@ -6328,11 +6328,13 @@ class FaucetStackStringOfDPUntaggedTest(FaucetStringOfDPTest):
 
     def test_untagged(self):
         """All untagged hosts in stack topology can reach each other."""
-        self.verify_stack_hosts()
-        self.verify_no_cable_errors()
-        self.verify_traveling_dhcp_mac()
-        self.verify_unicast_not_looped()
-        self.verify_no_bcast_to_self()
+        for _ in range(2):
+            self.verify_stack_hosts()
+            self.verify_no_cable_errors()
+            self.verify_traveling_dhcp_mac()
+            self.verify_unicast_not_looped()
+            self.verify_no_bcast_to_self()
+            self.flap_all_switch_ports()
 
 
 class FaucetGroupStackStringOfDPUntaggedTest(FaucetStackStringOfDPUntaggedTest):


### PR DESCRIPTION
Don't send group with same actions but different ID for unicast flooding (may cause hash collision).
Add more port flap tests to stacking.