### PR TITLE
allow dot1x to run on < 65535 ports per dp.

### DIFF
--- a/faucet/faucet_dot1x.py
+++ b/faucet/faucet_dot1x.py
@@ -40,7 +40,9 @@ def get_mac_str(valve_index, port_num):
     Returns:
         str
     """
-    return '00:00:00:00:%02x:%02x' % (valve_index, port_num)
+    two_byte_port_num = ("%04x" % port_num)
+    two_byte_port_num_formatted = two_byte_port_num[:2] + ':' + two_byte_port_num[2:]
+    return '00:00:00:%02x:%s' % (valve_index, two_byte_port_num_formatted)
 
 
 class FaucetDot1x:

--- a/faucet/port.py
+++ b/faucet/port.py
@@ -188,8 +188,8 @@ class Port(Conf):
             self.hairpin and self.hairpin_unicast,
             'Cannot have both hairpin and hairpin_unicast enabled')
         if self.dot1x:
-            test_config_condition(self.number > 255, (
-                '802.1x not supported on ports > 255'))
+            test_config_condition(self.number > 65535, (
+                '802.1x not supported on ports > 65535'))
         if self.mirror:
             test_config_condition(self.tagged_vlans or self.native_vlan, (
                 'mirror port %s cannot have any VLANs assigned' % self))


### PR DESCRIPTION
closes [faucetsdn/chewie issue 98](https://github.com/faucetsdn/chewie/issues/98)