### PR TITLE
Static priority

### DIFF
--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -166,9 +166,11 @@ class Valve:
             proactive_learn = getattr(self.dp, 'proactive_learn_v%u' % ipv)
             route_manager = route_manager_class(
                 self.logger, self.dp.global_vlan, neighbor_timeout,
-                self.dp.max_hosts_per_resolve_cycle, self.dp.max_host_fib_retry_count,
-                self.dp.max_resolve_backoff_time, proactive_learn, self.DEC_TTL, self.dp.multi_out,
-                fib_table, self.dp.tables['vip'], self.pipeline, self.dp.highest_priority, self.dp.routers)
+                self.dp.max_hosts_per_resolve_cycle,
+                self.dp.max_host_fib_retry_count,
+                self.dp.max_resolve_backoff_time, proactive_learn,
+                self.DEC_TTL, self.dp.multi_out, fib_table,
+                self.dp.tables['vip'], self.pipeline, self.dp.routers)
             self._route_manager_by_ipv[route_manager.IPV] = route_manager
             for vlan in self.dp.vlans.values():
                 if vlan.faucet_vips_by_ipv(route_manager.IPV):
@@ -180,7 +182,6 @@ class Valve:
         if self.dp.stack:
             self.flood_manager = valve_flood.ValveFloodStackManager(
                 self.dp.tables['flood'], self.dp.tables['eth_src'],
-                self.dp.low_priority, self.dp.highest_priority,
                 self.dp.group_table, self.dp.groups,
                 self.dp.combinatorial_port_flood,
                 self.dp.stack, self.dp.stack_ports,
@@ -188,7 +189,6 @@ class Valve:
         else:
             self.flood_manager = valve_flood.ValveFloodManager(
                 self.dp.tables['flood'], self.dp.tables['eth_src'],
-                self.dp.low_priority, self.dp.highest_priority,
                 self.dp.group_table, self.dp.groups,
                 self.dp.combinatorial_port_flood)
         eth_dst_hairpin_table = self.dp.tables.get('eth_dst_hairpin', None)
@@ -200,7 +200,6 @@ class Valve:
             self.dp.vlans, self.dp.tables['eth_src'],
             self.dp.tables['eth_dst'], eth_dst_hairpin_table, self.pipeline,
             self.dp.timeout, self.dp.learn_jitter, self.dp.learn_ban_timeout,
-            self.dp.low_priority, self.dp.highest_priority,
             self.dp.cache_update_guard_time, self.dp.idle_dst)
         table_configs = sorted([
             (table.table_id, str(table.table_config)) for table in self.dp.tables.values()])

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -181,16 +181,14 @@ class Valve:
                 self._route_manager_by_eth_type[eth_type] = route_manager
         if self.dp.stack:
             self.flood_manager = valve_flood.ValveFloodStackManager(
-                self.dp.tables['flood'], self.dp.tables['eth_src'],
-                self.dp.group_table, self.dp.groups,
-                self.dp.combinatorial_port_flood,
+                self.dp.tables['flood'], self.pipeline, self.dp.group_table,
+                self.dp.groups, self.dp.combinatorial_port_flood,
                 self.dp.stack, self.dp.stack_ports,
                 self.dp.shortest_path_to_root, self.dp.shortest_path_port)
         else:
             self.flood_manager = valve_flood.ValveFloodManager(
-                self.dp.tables['flood'], self.dp.tables['eth_src'],
-                self.dp.group_table, self.dp.groups,
-                self.dp.combinatorial_port_flood)
+                self.dp.tables['flood'], self.pipeline, self.dp.group_table,
+                self.dp.groups, self.dp.combinatorial_port_flood)
         eth_dst_hairpin_table = self.dp.tables.get('eth_dst_hairpin', None)
         host_manager_cl = valve_host.ValveHostManager
         if self.dp.use_idle_timeout:

--- a/faucet/valve_flood.py
+++ b/faucet/valve_flood.py
@@ -37,14 +37,12 @@ class ValveFloodManager(ValveManagerBase):
         (False, valve_of.mac.BROADCAST_STR, valve_packet.mac_byte_mask(6)), # eth broadcasts
     )
 
-    def __init__(self, flood_table, eth_src_table, # pylint: disable=too-many-arguments
-                 flood_priority, bypass_priority,
-                 use_group_table, groups,
-                 combinatorial_port_flood):
+    def __init__(self, flood_table, eth_src_table,
+                 use_group_table, groups, combinatorial_port_flood):
         self.flood_table = flood_table
         self.eth_src_table = eth_src_table
-        self.bypass_priority = bypass_priority
-        self.flood_priority = flood_priority
+        self.bypass_priority = self._FILTER_PRIORITY
+        self.flood_priority = self._MATCH_PRIORITY
         self.use_group_table = use_group_table
         self.groups = groups
         self.combinatorial_port_flood = combinatorial_port_flood
@@ -231,14 +229,12 @@ class ValveFloodStackManager(ValveFloodManager):
     """Implement dataplane based flooding for stacked dataplanes."""
 
     def __init__(self, flood_table, eth_src_table, # pylint: disable=too-many-arguments
-                 flood_priority, bypass_priority,
                  use_group_table, groups,
                  combinatorial_port_flood,
                  stack, stack_ports,
                  dp_shortest_path_to_root, shortest_path_port):
         super(ValveFloodStackManager, self).__init__(
             flood_table, eth_src_table,
-            flood_priority, bypass_priority,
             use_group_table, groups,
             combinatorial_port_flood)
         self.stack = stack

--- a/faucet/valve_flood.py
+++ b/faucet/valve_flood.py
@@ -37,15 +37,16 @@ class ValveFloodManager(ValveManagerBase):
         (False, valve_of.mac.BROADCAST_STR, valve_packet.mac_byte_mask(6)), # eth broadcasts
     )
 
-    def __init__(self, flood_table, eth_src_table,
+    def __init__(self, flood_table, pipeline,
                  use_group_table, groups, combinatorial_port_flood):
         self.flood_table = flood_table
-        self.eth_src_table = eth_src_table
+        self.pipeline = pipeline
         self.bypass_priority = self._FILTER_PRIORITY
         self.flood_priority = self._MATCH_PRIORITY
         self.use_group_table = use_group_table
         self.groups = groups
         self.combinatorial_port_flood = combinatorial_port_flood
+        self.classification_offset = 0x100
 
     def initialise_tables(self):
         """Initialise the flood table with filtering flows."""
@@ -228,13 +229,13 @@ class ValveFloodManager(ValveManagerBase):
 class ValveFloodStackManager(ValveFloodManager):
     """Implement dataplane based flooding for stacked dataplanes."""
 
-    def __init__(self, flood_table, eth_src_table, # pylint: disable=too-many-arguments
+    def __init__(self, flood_table, pipeline, # pylint: disable=too-many-arguments
                  use_group_table, groups,
                  combinatorial_port_flood,
                  stack, stack_ports,
                  dp_shortest_path_to_root, shortest_path_port):
         super(ValveFloodStackManager, self).__init__(
-            flood_table, eth_src_table,
+            flood_table, pipeline,
             use_group_table, groups,
             combinatorial_port_flood)
         self.stack = stack
@@ -369,26 +370,27 @@ class ValveFloodStackManager(ValveFloodManager):
             ofmsgs.append(port_flood_ofmsg)
             if not self._dp_is_root():
                 # Drop bridge local traffic immediately.
-                ofmsgs.append(self.eth_src_table.flowdrop(
-                    self.eth_src_table.match(
-                        in_port=port.number,
-                        vlan=vlan,
-                        eth_dst=valve_packet.BRIDGE_GROUP_ADDRESS,
-                        eth_dst_mask=valve_packet.BRIDGE_GROUP_MASK),
-                    priority=self.bypass_priority + 2))
+                bridge_local_match = {
+                    'in_port': port.number,
+                    'vlan': vlan,
+                    'eth_dst': valve_packet.BRIDGE_GROUP_ADDRESS,
+                    'eth_dst_mask': valve_packet.BRIDGE_GROUP_MASK
+                    }
+                ofmsgs.extend(self.pipeline.filter_packets(
+                    bridge_local_match, priority_offset=self.classification_offset))
                 # Because stacking uses reflected broadcasts from the root,
                 # don't try to learn broadcast sources from stacking ports.
                 if eth_dst is not None:
-                    match = self.eth_src_table.match(
-                        in_port=port.number,
-                        vlan=vlan,
-                        eth_dst=eth_dst,
-                        eth_dst_mask=eth_dst_mask)
-                    ofmsgs.append(self.eth_src_table.flowmod(
-                        match=match,
-                        command=command,
-                        inst=[self.eth_src_table.goto(self.flood_table)],
-                        priority=self.bypass_priority + 1))
+                    match = {
+                        'in_port': port.number,
+                        'vlan': vlan,
+                        'eth_dst': eth_dst,
+                        'eth_dst_mask': eth_dst_mask
+                        }
+                    ofmsgs.extend(self.pipeline.select_packets(
+                        self.flood_table, match,
+                        priority_offset=self.classification_offset
+                        ))
         return ofmsgs
 
     def _vlan_all_ports(self, vlan, exclude_unicast):

--- a/faucet/valve_flood.py
+++ b/faucet/valve_flood.py
@@ -375,7 +375,7 @@ class ValveFloodStackManager(ValveFloodManager):
                         vlan=vlan,
                         eth_dst=valve_packet.BRIDGE_GROUP_ADDRESS,
                         eth_dst_mask=valve_packet.BRIDGE_GROUP_MASK),
-                    priority=self.bypass_priority + 1))
+                    priority=self.bypass_priority + 2))
                 # Because stacking uses reflected broadcasts from the root,
                 # don't try to learn broadcast sources from stacking ports.
                 if eth_dst is not None:
@@ -388,7 +388,7 @@ class ValveFloodStackManager(ValveFloodManager):
                         match=match,
                         command=command,
                         inst=[self.eth_src_table.goto(self.flood_table)],
-                        priority=self.bypass_priority))
+                        priority=self.bypass_priority + 1))
         return ofmsgs
 
     def _vlan_all_ports(self, vlan, exclude_unicast):

--- a/faucet/valve_host.py
+++ b/faucet/valve_host.py
@@ -28,9 +28,8 @@ class ValveHostManager(ValveManagerBase):
     """Manage host learning on VLANs."""
 
     def __init__(self, logger, ports, vlans, eth_src_table, eth_dst_table,
-                 eth_dst_hairpin_table, pipeline, learn_timeout,
-                 learn_jitter, learn_ban_timeout, low_priority, host_priority,
-                 cache_update_guard_time, idle_dst):
+                 eth_dst_hairpin_table, pipeline, learn_timeout, learn_jitter,
+                 learn_ban_timeout, cache_update_guard_time, idle_dst):
         self.logger = logger
         self.ports = ports
         self.vlans = vlans
@@ -41,8 +40,8 @@ class ValveHostManager(ValveManagerBase):
         self.learn_timeout = learn_timeout
         self.learn_jitter = learn_jitter
         self.learn_ban_timeout = learn_ban_timeout
-        self.low_priority = low_priority
-        self.host_priority = host_priority
+        self.low_priority = self._LOW_PRIORITY
+        self.host_priority = self._MATCH_PRIORITY
         self.cache_update_guard_time = cache_update_guard_time
         self.output_table = self.eth_dst_table
         self.idle_dst = idle_dst

--- a/faucet/valve_host.py
+++ b/faucet/valve_host.py
@@ -247,7 +247,6 @@ class ValveHostManager(ValveManagerBase):
         elif entry.port.permanent_learn:
             if entry.port != port:
                 ofmsgs.extend(self.pipeline.filter_packets(
-                    self.eth_src_table,
                     {'eth_src': eth_src, 'in_port': port.number}))
             return (ofmsgs, entry.port)
         else:

--- a/faucet/valve_manager_base.py
+++ b/faucet/valve_manager_base.py
@@ -9,6 +9,13 @@ class ValveManagerBase: # pylint: disable=too-few-public-methods
 
     Ideally each datapath table should be controlled by 1 manager only."""
 
+    _MISS_PRIORITY = 0
+    _LOW_PRIORITY = 0x1000
+    _MATCH_PRIORITY = 0x2000
+    _LPM_PRIORITY = 0x3000
+    _HIGH_PRIORITY = 0x4000
+    _FILTER_PRIORITY = 0x5000
+
     def initialise_tables(self):
         '''initialise tables controlled by this manager'''
         return []

--- a/faucet/valve_pipeline.py
+++ b/faucet/valve_pipeline.py
@@ -158,24 +158,25 @@ class ValvePipeline(ValveManagerBase):
         """
         return [self.classification_table.flowdrop(
             self.classification_table.match(**match_dict),
-            priority=(self.filter_priority + priority_offset))]
+            priority=self.filter_priority + priority_offset)]
 
-    def select_packets(self, target_table, match_dict, actions=None):
+    def select_packets(self, target_table, match_dict, actions=None,
+                       priority_offset=0):
         """retrieve rules to redirect packets matching match_dict to table"""
         inst = [target_table.goto_this()]
         if actions is not None:
             inst.append(valve_of.apply_actions(actions))
         return [self.classification_table.flowmod(
             self.classification_table.match(**match_dict),
-            priority=self.select_priority,
+            priority=self.select_priority + priority_offset,
             inst=inst)]
 
-    def remove_filter(self, match_dict, strict=True):
+    def remove_filter(self, match_dict, strict=True, priority_offset=0):
         """retrieve flow mods to remove a filter from the classification table
         """
         priority = None
         if strict:
-            priorty = self.filter_priority
+            priority = self.filter_priority + priority_offset
         return [self.classification_table.flowdel(
             self.classification_table.match(**match_dict),
             priority=priority,

--- a/faucet/valve_pipeline.py
+++ b/faucet/valve_pipeline.py
@@ -98,7 +98,7 @@ class ValvePipeline(ValveManagerBase):
                 ))
 
         ofmsgs.extend(self.filter_packets(
-            {'eth_type': valve_of.ECTP_ETH_TYPE}))
+            {'eth_type': valve_of.ECTP_ETH_TYPE}, priority_offset=10))
 
         # antispoof for FAUCET's MAC address
         # TODO: antispoof for controller IPs on this VLAN, too.

--- a/faucet/valve_pipeline.py
+++ b/faucet/valve_pipeline.py
@@ -39,8 +39,8 @@ class ValvePipeline(ValveManagerBase):
         self.egress_table = None
         if dp.egress_pipeline:
             self.egress_table = dp.tables['egress']
-        self.filter_priority = dp.highest_priority + 1
-        self.select_priority = dp.highest_priority
+        self.filter_priority = self._FILTER_PRIORITY
+        self.select_priority = self._HIGH_PRIORITY
 
     def _accept_to_table(self, table, actions):
         inst = [table.goto_this()]

--- a/faucet/valve_route.py
+++ b/faucet/valve_route.py
@@ -115,7 +115,7 @@ class ValveRouteManager(ValveManagerBase):
     def __init__(self, logger, global_vlan, neighbor_timeout,
                  max_hosts_per_resolve_cycle, max_host_fib_retry_count,
                  max_resolve_backoff_time, proactive_learn, dec_ttl, multi_out,
-                 fib_table, vip_table, pipeline, route_priority, routers):
+                 fib_table, vip_table, pipeline, routers):
         self.logger = logger
         self.global_vlan = AnonVLAN(global_vlan)
         self.neighbor_timeout = neighbor_timeout
@@ -128,7 +128,7 @@ class ValveRouteManager(ValveManagerBase):
         self.fib_table = fib_table
         self.vip_table = vip_table
         self.pipeline = pipeline
-        self.route_priority = route_priority
+        self.route_priority = self._LPM_PRIORITY
         self.routers = routers
         self.active = False
         self.global_routing = self._global_routing()

--- a/tests/integration/mininet_tests.py
+++ b/tests/integration/mininet_tests.py
@@ -1305,7 +1305,6 @@ class FaucetUntaggedPrometheusGaugeTest(FaucetUntaggedTest):
                     'cookie': cookie,
                     'eth_dst': host.MAC(),
                     'inst_count': str(1),
-                    'priority': str(9099),
                     'table_id': str(self._ETH_DST_TABLE),
                     'vlan': str(100),
                     'vlan_vid': str(4196)

--- a/tests/unit/faucet/fakeoftable.py
+++ b/tests/unit/faucet/fakeoftable.py
@@ -86,16 +86,15 @@ class FakeOFTable:
             # entries which will cause ambiguous behaviour. This is
             # obviously unnacceptable so we will assume this is
             # always set
-            add = True
             for fte in table:
                 if flowmod.fte_matches(fte, strict=True):
                     table.remove(fte)
                     break
                 elif flowmod.overlaps(fte):
-                    add = False
-                    break
-            if add:
-                table.append(flowmod)
+                    raise FakeOFTableException(
+                        'Overlapping flowmods {} and {}'.format(
+                            flowmod, fte))
+            table.append(flowmod)
 
         def _del(table, flowmod):
             removals = [fte for fte in table if flowmod.fte_matches(fte)]


### PR DESCRIPTION
Make priorities statically determined rather than configurable.
Add unit tests that prevent overlapping flow rules with identical priorities being added to a table.
With new priority structure in place, remove the references to the eth_src table from valve_flood, and use pipeline filters and selects instead.
