### PR TITLE
Internal API change - allow packet in handler to return ofmsgs for other Valves.

### DIFF
--- a/faucet/faucet.py
+++ b/faucet/faucet.py
@@ -312,8 +312,7 @@ class Faucet(RyuAppBase):
         valve, _, msg = self._get_valve(ryu_event, require_running=True)
         if valve is None:
             return
-        self._send_flow_msgs(valve, valve.port_status_handler(
-            msg.desc.port_no, msg.reason, msg.desc.state))
+        self.valves_manager.valve_port_status_handler(valve, msg)
 
     @set_ev_cls(ofp_event.EventOFPFlowRemoved, MAIN_DISPATCHER) # pylint: disable=no-member
     @kill_on_exception(exc_logname)

--- a/faucet/valves_manager.py
+++ b/faucet/valves_manager.py
@@ -186,7 +186,7 @@ class ValvesManager:
             return
         with self.metrics.faucet_packet_in_secs.labels( # pylint: disable=no-member
                 **valve.dp.base_prom_labels()).time():
-            ofmsgs = valve.rcv_packet(now, self._other_running_valves(valve), pkt_meta)
-        if ofmsgs:
+            ofmsgs_by_valve = valve.rcv_packet(now, self._other_running_valves(valve), pkt_meta)
+        valve.update_metrics(now, pkt_meta.port, rate_limited=True)
+        for valve, ofmsgs in ofmsgs_by_valve.items():
             self.send_flows_to_dp_by_id(valve, ofmsgs)
-            valve.update_metrics(now, pkt_meta.port, rate_limited=True)

--- a/tests/unit/faucet/test_valve.py
+++ b/tests/unit/faucet/test_valve.py
@@ -493,13 +493,13 @@ class ValveTestBases:
         def set_port_down(self, port_no):
             """Set port status of port to down."""
             self.table.apply_ofmsgs(self.valve.port_status_handler(
-                port_no, ofp.OFPPR_DELETE, ofp.OFPPS_LINK_DOWN))
+                port_no, ofp.OFPPR_DELETE, ofp.OFPPS_LINK_DOWN)[self.valve])
             self.port_expected_status(port_no, 0)
 
         def set_port_up(self, port_no):
             """Set port status of port to up."""
             self.table.apply_ofmsgs(self.valve.port_status_handler(
-                port_no, ofp.OFPPR_ADD, 0))
+                port_no, ofp.OFPPR_ADD, 0)[self.valve])
             self.port_expected_status(port_no, 1)
 
         def flap_port(self, port_no):
@@ -844,10 +844,10 @@ class ValveTestBases:
                 valve_vlan, ip_gw, ip_dst)
             self.assertFalse(route_add_replies)
             resolve_replies = self.valve.resolve_gateways(
-                time.time(), None)
+                time.time(), None)[self.valve]
             self.assertFalse(resolve_replies)
             resolve_replies = self.valve.resolve_gateways(
-                time.time() + 99, None)
+                time.time() + 99, None)[self.valve]
             self.assertTrue(resolve_replies)
 
         def test_add_del_route(self):
@@ -1341,7 +1341,7 @@ meters:
         def test_lldp_beacon(self):
             """Test LLDP beacon service."""
             # TODO: verify LLDP packet content.
-            self.assertTrue(self.valve.fast_advertise(time.time(), None))
+            self.assertTrue(self.valve.fast_advertise(time.time(), None)[self.valve])
 
         def test_unknown_port(self):
             """Test port status change for unknown port handled."""
@@ -1351,7 +1351,7 @@ meters:
             """Set port status modify."""
             for port_status in (0, 1):
                 self.table.apply_ofmsgs(self.valve.port_status_handler(
-                    1, ofp.OFPPR_MODIFY, port_status))
+                    1, ofp.OFPPR_MODIFY, port_status)[self.valve])
 
         def test_unknown_port_status(self):
             """Test unknown port status message."""
@@ -1359,7 +1359,7 @@ meters:
             unknown_messages = list(set(range(0, len(known_messages) + 1)) - known_messages)
             self.assertTrue(unknown_messages)
             self.assertFalse(self.valve.port_status_handler(
-                1, unknown_messages[0], 1))
+                1, unknown_messages[0], 1)[self.valve])
 
         def test_move_port(self):
             """Test host moves a port."""


### PR DESCRIPTION

This allows us, when a controller is handling multiple switches, to proactively
make flow changes to switches other than the switch receiving the packet in
(e.g this allows us to potentially to apply learning flows to all switches in a
stack on receipt of the packet in on the first).