### PR TITLE
Automatically lookup ubuntu/debian releases for CI package push.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,16 +26,7 @@ deploy-package:
   image: faucet/dbuilder
   script:
     - cd built-packages/
-    - echo "{\"url\":\"https://packagecloud.io\",\"token\":\"$PACKAGECLOUD_TOKEN\"}" > ~/.packagecloud
-    - package_cloud push faucetsdn/faucet/debian/jessie *.deb || true
-    - package_cloud push faucetsdn/faucet/debian/stretch *.deb || true
-    - package_cloud push faucetsdn/faucet/debian/buster *.deb || true
-    - package_cloud push faucetsdn/faucet/raspbian/jessie *.deb || true
-    - package_cloud push faucetsdn/faucet/raspbian/stretch *.deb || true
-    - package_cloud push faucetsdn/faucet/raspbian/buster *.deb || true
-    - package_cloud push faucetsdn/faucet/ubuntu/xenial *.deb || true
-    - package_cloud push faucetsdn/faucet/ubuntu/artful *.deb || true
-    - package_cloud push faucetsdn/faucet/ubuntu/bionic *.deb || true
+    - ../gitlab/deploy_deb.sh
   only:
     - tags
 

--- a/gitlab/deploy_deb.sh
+++ b/gitlab/deploy_deb.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+echo "{\"url\":\"https://packagecloud.io\",\"token\":\"$PACKAGECLOUD_TOKEN\"}" > ~/.packagecloud
+
+curl -o /tmp/ubuntu-releases.csv https://salsa.debian.org/debian/distro-info-data/raw/master/ubuntu.csv
+curl -o /tmp/debian-releases.csv https://salsa.debian.org/debian/distro-info-data/raw/master/debian.csv
+
+for release in $(awk -F ',' -v today="$(date --utc "+%F")" \
+    'BEGIN {OFS=","} NR>1 { if (($6 == "" || $6 >= today) && ($5 != "" && $5 <= today)) print $3 }' \
+    /tmp/ubuntu-releases.csv); do
+
+    package_cloud push faucetsdn/faucet/ubuntu/$release *.deb || true
+done
+
+for release in $(awk -F ',' -v today="$(date --utc "+%F")" \
+    'BEGIN {OFS=","} NR>1 { if (($6 == "" || $6 >= today) && ($4 != "" && $4 <= today)) print $3 }' \
+    /tmp/debian-releases.csv | egrep -v "(sid|experimental)"); do
+
+    package_cloud push faucetsdn/faucet/debian/$release *.deb || true
+    package_cloud push faucetsdn/faucet/raspbian/$release *.deb || true
+done


### PR DESCRIPTION
Parse debian and ubuntu release CSVs from ``distro-info-data`` to push to faucet packages to all currently supported debian/ubuntu repos.