### PR TITLE
test controller restart fixes

### DIFF
--- a/clib/mininet_test_base.py
+++ b/clib/mininet_test_base.py
@@ -393,6 +393,7 @@ class FaucetTestBase(unittest.TestCase):
 
     def _start_faucet(self, controller_intf):
         last_error_txt = ''
+        assert self.net is None # _start_faucet() can't be multiply called
         for _ in range(3):
             mininet_test_util.return_free_ports(
                 self.ports_sock, self._test_name())

--- a/clib/mininet_test_topo.py
+++ b/clib/mininet_test_topo.py
@@ -441,12 +441,13 @@ socket_timeout=15
 
     def stop(self):
         """Stop controller."""
-        while self.healthy():
+        try:
             if self.CPROFILE:
                 os.kill(self.ryu_pid(), 2)
             else:
                 os.kill(self.ryu_pid(), 15)
-            time.sleep(1)
+        except ProcessLookupError:
+            pass
         self._stop_cap()
         super(BaseFAUCET, self).stop()
         if os.path.exists(self.logname()):

--- a/tests/integration/mininet_tests.py
+++ b/tests/integration/mininet_tests.py
@@ -6427,7 +6427,7 @@ class FaucetStackStringOfDPUntaggedTest(FaucetStringOfDPTest):
             self.flap_all_switch_ports()
 
 
-class FaucetStackStringOfDPExtLoopProtUntaggedTest(FaucetStackStringOfDPUntaggedTest):
+class FaucetStackStringOfDPExtLoopProtUntaggedTest(FaucetStringOfDPTest):
     """Test topology of stacked datapaths with untagged hosts."""
 
     NUM_DPS = 2
@@ -6444,6 +6444,16 @@ class FaucetStackStringOfDPExtLoopProtUntaggedTest(FaucetStackStringOfDPUntagged
             hw_dpid=self.hw_dpid,
             first_external=True)
         self.start_net()
+
+    def test_untagged(self):
+        """All untagged hosts in stack topology can reach each other."""
+        for _ in range(2):
+            self.verify_stack_hosts()
+            self.verify_no_cable_errors()
+            self.verify_traveling_dhcp_mac()
+            self.verify_unicast_not_looped()
+            self.verify_no_bcast_to_self()
+            self.flap_all_switch_ports()
 
 
 class FaucetGroupStackStringOfDPUntaggedTest(FaucetStackStringOfDPUntaggedTest):


### PR DESCRIPTION
* Protect against _start_faucet() being multiply called (resulting in stranded topology that interferes with the test one).
* Explicitly kill even unhealthy controllers (otherwise an unhealthy controller can remain and interfere with a test)
* FaucetStackStringOfDPExtLoopProtUntaggedTest shouldn't multiply call _start_faucet().