### PR TITLE
Allow valve event processors to return ofmsgs for other Valves.

### DIFF
--- a/faucet/valves_manager.py
+++ b/faucet/valves_manager.py
@@ -174,7 +174,8 @@ class ValvesManager:
             valve_service_func = getattr(valve, valve_service)
             with self.metrics.faucet_valve_service_secs.labels( # pylint: disable=no-member
                     **valve_service_labels).time():
-                ofmsgs_by_valve[valve].extend(valve_service_func(now, other_valves))
+                for service_valve, ofmsgs in valve_service_func(now, other_valves).items():
+                    ofmsgs_by_valve[service_valve].extend(ofmsgs)
         self._send_ofmsgs_by_valve(ofmsgs_by_valve)
 
     def _other_running_valves(self, valve):

--- a/tests/unit/faucet/test_valve.py
+++ b/tests/unit/faucet/test_valve.py
@@ -495,13 +495,13 @@ class ValveTestBases:
         def set_port_down(self, port_no):
             """Set port status of port to down."""
             self.table.apply_ofmsgs(self.valve.port_status_handler(
-                port_no, ofp.OFPPR_DELETE, ofp.OFPPS_LINK_DOWN))
+                port_no, ofp.OFPPR_DELETE, ofp.OFPPS_LINK_DOWN).get(self.valve, []))
             self.port_expected_status(port_no, 0)
 
         def set_port_up(self, port_no):
             """Set port status of port to up."""
             self.table.apply_ofmsgs(self.valve.port_status_handler(
-                port_no, ofp.OFPPR_ADD, 0))
+                port_no, ofp.OFPPR_ADD, 0).get(self.valve, []))
             self.port_expected_status(port_no, 1)
 
         def flap_port(self, port_no):
@@ -1358,7 +1358,7 @@ meters:
             """Set port status modify."""
             for port_status in (0, 1):
                 self.table.apply_ofmsgs(self.valve.port_status_handler(
-                    1, ofp.OFPPR_MODIFY, port_status))
+                    1, ofp.OFPPR_MODIFY, port_status)[self.valve])
 
         def test_unknown_port_status(self):
             """Test unknown port status message."""
@@ -1366,7 +1366,7 @@ meters:
             unknown_messages = list(set(range(0, len(known_messages) + 1)) - known_messages)
             self.assertTrue(unknown_messages)
             self.assertFalse(self.valve.port_status_handler(
-                1, unknown_messages[0], 1))
+                1, unknown_messages[0], 1).get(self.valve, []))
 
         def test_move_port(self):
             """Test host moves a port."""


### PR DESCRIPTION
Internal API change only.

If a controller manages multiple Valves, this allows a event processor to return ofmsgs to be sent to other Valves. For example, when stacking and learning a packet, we could send ofmsgs to all affected Valves learning the host on the very first packet rather than having the Valves learn individually (we can still do so anyway, but this lets us optimize the case where one controller is controlling more than one affected switch).

At the moment nothing takes advantage of the capability, but future features like redundant connected stacks will.