### PR TITLE
Increase test coverage and hardware test reliability

### DIFF
--- a/faucet/dp.py
+++ b/faucet/dp.py
@@ -448,6 +448,8 @@ configuration.
             flood_table = table_configs['flood']
             flood_table.set_fields = (faucet_pipeline.STACK_LOOP_PROTECT_FIELD,)
             flood_table.match_types += ((faucet_pipeline.STACK_LOOP_PROTECT_FIELD, False),)
+            vlan_table = table_configs['vlan']
+            vlan_table.set_fields += (faucet_pipeline.STACK_LOOP_PROTECT_FIELD,)
 
         for table_name, table_config in table_configs.items():
             size = self.table_sizes.get(table_name, self.min_wildcard_table_size)

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -399,7 +399,7 @@ class Valve:
         port_labels = self.dp.port_labels(port.number)
         self._set_var('port_status', port_status, labels=port_labels)
 
-    def port_status_handler(self, port_no, reason, state):
+    def port_status_handler(self, port_no, reason, state, _other_valves):
         """Return OpenFlow messages responding to port operational status change."""
 
         port_status_codes = {

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -33,6 +33,7 @@ from faucet import valve_table
 from faucet import valve_util
 from faucet import valve_pipeline
 
+from faucet.faucet_pipeline import STACK_LOOP_PROTECT_FIELD
 from faucet.port import STACK_STATE_INIT, STACK_STATE_UP, STACK_STATE_DOWN
 from faucet.vlan import NullVLAN
 
@@ -619,6 +620,9 @@ class Valve:
             actions.extend(valve_of.push_vlan_act(
                 vlan_table, vlan.vid))
             match_vlan = NullVLAN()
+        elif self.dp.stack and self.dp.stack.get('externals', False) and port.loop_protect_external:
+            # Ensure loop protection field cleared on external port.
+            actions.append(valve_of.set_field(**{STACK_LOOP_PROTECT_FIELD: 0}))
         inst = [
             valve_of.apply_actions(actions),
             vlan_table.goto(self._find_forwarding_table(vlan))]

--- a/faucet/valve_flood.py
+++ b/faucet/valve_flood.py
@@ -87,8 +87,8 @@ class ValveFloodManager(ValveManagerBase):
             exclude_ports=exclude_ports)
 
     def _build_flood_rule_actions(self, vlan, exclude_unicast, in_port, exclude_all_external=False):
-        return self._build_flood_local_rule_actions(
-            vlan, exclude_unicast, in_port, exclude_all_external)
+        return valve_of.dedupe_ofmsgs(self._build_flood_local_rule_actions(
+            vlan, exclude_unicast, in_port, exclude_all_external))
 
     def _build_flood_rule(self, match, command, flood_acts, flood_priority):
         return self.flood_table.flowmod(
@@ -448,12 +448,14 @@ class ValveFloodStackManager(ValveFloodManager):
             self.towards_root_stack_ports, in_port)
 
         if self.stack_size == 2:
-            return self._flood_actions_size2(
+            flood_acts = self._flood_actions_size2(
                 in_port, external_ports, away_flood_actions, toward_flood_actions,
                 local_flood_actions)
-        return self._flood_actions(
-            in_port, external_ports, away_flood_actions, toward_flood_actions,
-            local_flood_actions)
+        else:
+            flood_acts = self._flood_actions(
+                in_port, external_ports, away_flood_actions, toward_flood_actions,
+                local_flood_actions)
+        return valve_of.dedupe_ofmsgs(flood_acts)
 
     def _build_mask_flood_rules(self, vlan, eth_dst, eth_dst_mask, # pylint: disable=too-many-arguments
                                 exclude_unicast, command):

--- a/faucet/valve_pipeline.py
+++ b/faucet/valve_pipeline.py
@@ -79,7 +79,7 @@ class ValvePipeline(ValveManagerBase):
         """
         return self._accept_to_table(self.output_table, actions)
 
-    def output(self, port, vlan, hairpin=False):
+    def output(self, port, vlan, hairpin=False, loop_protect_field=None):
         """Get instructions list to output a packet through the regular
         pipeline.
 
@@ -97,7 +97,9 @@ class ValvePipeline(ValveManagerBase):
             instructions.extend(valve_of.metadata_goto_table(
                 metadata, metadata_mask, self.egress_table))
         else:
-            instructions.append(valve_of.apply_actions(vlan.output_port(port, hairpin=hairpin)))
+            instructions.append(valve_of.apply_actions(vlan.output_port(
+                port, hairpin=hairpin, output_table=self.output_table,
+                loop_protect_field=loop_protect_field)))
         return instructions
 
     def initialise_tables(self):

--- a/faucet/valves_manager.py
+++ b/faucet/valves_manager.py
@@ -184,7 +184,8 @@ class ValvesManager:
 
     def port_status_handler(self, valve, msg):
         """Handle a port status change message."""
-        ofmsgs_by_valve = valve.port_status_handler(msg.desc.port_no, msg.reason, msg.desc.state)
+        ofmsgs_by_valve = valve.port_status_handler(
+            msg.desc.port_no, msg.reason, msg.desc.state, self._other_running_valves(valve))
         self._send_ofmsgs_by_valve(ofmsgs_by_valve)
 
     def valve_packet_in(self, now, valve, msg):

--- a/tests/integration/mininet_tests.py
+++ b/tests/integration/mininet_tests.py
@@ -6389,16 +6389,10 @@ class FaucetStringOfDPLACPUntaggedTest(FaucetStringOfDPTest):
             self.verify_stack_hosts()
             self.flap_all_switch_ports()
 
-    def wait_for_lacp_port_up(self, port_no, timeout=10):
-        controller = self._get_controller()
-        count = 0
-        for _ in range(timeout):
-            count = controller.cmd(
-                    'grep -c "LAG.*port %u up" %s' % (port_no, self.env['faucet']['FAUCET_LOG']))
-            if int(count) != 0:
-                break
-            time.sleep(1)
-        self.assertGreaterEqual(int(count), 1, 'LACP port %u not up' % port_no)
+    def wait_for_lacp_port_up(self, port_no):
+        log_file = self.env['faucet']['FAUCET_LOG']
+        lacp_up_re = r'.+LAG.+port %u up$' % port_no
+        self.wait_until_matching_lines_from_file(lacp_up_re, log_file)
 
     def test_lacp_port_down(self):
         """LACP to switch to a working port when the primary port fails."""
@@ -7005,17 +6999,10 @@ vlans:
             time.sleep(1)
         self.fail('Not received OFPFlowRemoved for host %s' % mac)
 
-    def wait_for_host_log_msg(self, host_mac, msg, timeout=15):
-        controller = self._get_controller()
-        count = 0
-        for _ in range(timeout):
-            count = controller.cmd('grep -c "%s %s" %s' % (
-                msg, host_mac, self.env['faucet']['FAUCET_LOG']))
-            if int(count) != 0:
-                break
-            time.sleep(1)
-        self.assertGreaterEqual(
-            int(count), 1, 'log msg "%s" for host %s not found' % (msg, host_mac))
+    def wait_for_host_log_msg(self, host_mac, msg):
+        log_file = self.env['faucet']['FAUCET_LOG']
+        host_log_re = r'.*%s %s.*' % (msg, host_mac)
+        self.wait_until_matching_lines_from_file(host_log_re, log_file)
 
     def test_untagged(self):
         self.ping_all_when_learned()

--- a/tests/integration/mininet_tests.py
+++ b/tests/integration/mininet_tests.py
@@ -1188,6 +1188,10 @@ class FaucetSanityTest(FaucetUntaggedTest):
                     in_port, dp_port))
             self.verify_dp_port_healthy(dp_port)
             self.require_host_learned(host, in_port=dp_port)
+        learned = self.prom_macs_learned()
+        self.assertEqual(len(self.net.hosts), len(learned),
+            msg='test requires exactly %u hosts learned (got %s)' % (
+                len(self.net.hosts), learned))
 
     def test_listening(self):
         msg_template = (

--- a/tests/unit/faucet/test_valve.py
+++ b/tests/unit/faucet/test_valve.py
@@ -495,13 +495,13 @@ class ValveTestBases:
         def set_port_down(self, port_no):
             """Set port status of port to down."""
             self.table.apply_ofmsgs(self.valve.port_status_handler(
-                port_no, ofp.OFPPR_DELETE, ofp.OFPPS_LINK_DOWN).get(self.valve, []))
+                port_no, ofp.OFPPR_DELETE, ofp.OFPPS_LINK_DOWN, []).get(self.valve, []))
             self.port_expected_status(port_no, 0)
 
         def set_port_up(self, port_no):
             """Set port status of port to up."""
             self.table.apply_ofmsgs(self.valve.port_status_handler(
-                port_no, ofp.OFPPR_ADD, 0).get(self.valve, []))
+                port_no, ofp.OFPPR_ADD, 0, []).get(self.valve, []))
             self.port_expected_status(port_no, 1)
 
         def flap_port(self, port_no):
@@ -1358,7 +1358,7 @@ meters:
             """Set port status modify."""
             for port_status in (0, 1):
                 self.table.apply_ofmsgs(self.valve.port_status_handler(
-                    1, ofp.OFPPR_MODIFY, port_status)[self.valve])
+                    1, ofp.OFPPR_MODIFY, port_status, [])[self.valve])
 
         def test_unknown_port_status(self):
             """Test unknown port status message."""
@@ -1366,7 +1366,7 @@ meters:
             unknown_messages = list(set(range(0, len(known_messages) + 1)) - known_messages)
             self.assertTrue(unknown_messages)
             self.assertFalse(self.valve.port_status_handler(
-                1, unknown_messages[0], 1).get(self.valve, []))
+                1, unknown_messages[0], 1, []).get(self.valve, []))
 
         def test_move_port(self):
             """Test host moves a port."""


### PR DESCRIPTION
* Add missing coverage for LACP flap/active/expiry
* Use ebtables, if present to suppress noise from test host interfaces when hardware testing (e.g. IPv6 link local) which was causing some hardware tests to be flakey (see PR for docker test base that provides ebtables)
* Ensure loop protect field always cleared on ingress.
