### PR TITLE
Fix LACP expiry case.

### DIFF
--- a/clib/mininet_test_base.py
+++ b/clib/mininet_test_base.py
@@ -845,12 +845,10 @@ dbs:
                                       actions=None, hard_timeout=0, cookie=None,
                                       ofa_match=True):
         """Return True if matching flow is present on a DPID."""
-        if self.get_matching_flow_on_dpid(
-                dpid, match, table_id, timeout=timeout,
-                actions=actions, hard_timeout=hard_timeout, cookie=cookie,
-                ofa_match=ofa_match):
-            return True
-        return False
+        return self.get_matching_flow_on_dpid(
+            dpid, match, table_id, timeout=timeout,
+            actions=actions, hard_timeout=hard_timeout, cookie=cookie,
+            ofa_match=ofa_match)
 
     def matching_flow_present(self, match, table_id, timeout=10,
                               actions=None, hard_timeout=0, cookie=None,
@@ -863,11 +861,13 @@ dbs:
 
     def wait_until_matching_flow(self, match, table_id, timeout=10,
                                  actions=None, hard_timeout=0, cookie=None,
-                                 ofa_match=True):
+                                 ofa_match=True, dpid=None):
         """Wait (require) for flow to be present on default DPID."""
+        if dpid is None:
+            dpid = self.dpid
         self.assertTrue(
-            self.matching_flow_present(
-                match, table_id, timeout=timeout,
+            self.matching_flow_present_on_dpid(
+                dpid, match, table_id, timeout=timeout,
                 actions=actions, hard_timeout=hard_timeout, cookie=cookie,
                 ofa_match=ofa_match),
             msg=('match: %s table_id: %u actions: %s' % (match, table_id, actions)))

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -830,6 +830,9 @@ class Valve:
         if port.dyn_lacp_up != 0:
             self.logger.info('LAG %u port %s down (previous state %s)' % (
                 port.lacp, port, port.dyn_lacp_up))
+        port.dyn_lacp_up = 0
+        port.dyn_last_lacp_pkt = None
+        port.dyn_lacp_updated_time = None
         if not cold_start:
             ofmsgs.extend(self._port_delete_flows_state(port))
             for vlan in port.vlans():
@@ -845,9 +848,6 @@ class Valve:
                 eth_dst=valve_packet.SLOW_PROTOCOL_MULTICAST),
             priority=self.dp.highest_priority,
             max_len=valve_packet.LACP_SIZE))
-        port.dyn_lacp_up = 0
-        port.dyn_last_lacp_pkt = None
-        port.dyn_lacp_updated_time = None
         self._reset_lacp_status(port)
         return ofmsgs
 


### PR DESCRIPTION
We did not handle the case of a LAG LACP expiry, while remaining op status up (we would continue to use the op up/LACP down link).
Found while fixing hardware tests of LACP in stacks.