### PR TITLE
Packaging unit test fix

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,6 +2,7 @@
 bitstring
 codecov
 concurrencytest
+python-debian==0.1.33
 deb_pkg_tools
 exabgp
 importlab>=0.3.1

--- a/tests/unit/packaging/test_packaging.py
+++ b/tests/unit/packaging/test_packaging.py
@@ -53,7 +53,7 @@ class CheckDebianPackageTestCase(unittest.TestCase): # pytype: disable=module-at
             elif faucet_dpkg:
                 if not line:
                     break
-                faucet_dpkg += "{}\n".format(line)
+                faucet_dpkg += "\n{}".format(line)
 
         faucet_dpkg = parse_control_fields(deb822_from_string(faucet_dpkg))
         self.faucet_dpkg_deps = {}


### PR DESCRIPTION
Fixes the following error:

```
======================================================================
ERROR: test_every_pip_requirement_has_matching_version_in_debian_package (__main__.CheckDebianPackageTestCase)
Test pip requirements versions match debian package dependencies.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/faucet-src/tests/unit/packaging/test_packaging.py", line 64, in setUp
    faucet_dpkg = parse_control_fields(deb822_from_string(faucet_dpkg))
  File "/usr/local/lib/python3.5/dist-packages/deb_pkg_tools/control.py", line 281, in parse_control_fields
    for name, unparsed_value in input_fields.items():
AttributeError: 'Deb822' object has no attribute 'items'
```

