### PR TITLE
Convert RST images to figures.

### DIFF
--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -28,9 +28,10 @@ will be provisioned.
 
 See also canonical pipeline definitions in faucet_pipeline.py
 
-
-.. image:: /_static/images/faucet-pipeline.png
-
+.. figure:: ./_static/images/faucet-pipeline.png
+    :alt: Faucet OpenFlow Packet Processing Pipeline
+    :align: center
+    :width: 80%
 
 Table 0: PORT_ACL
 ~~~~~~~~~~~~~~~~~
@@ -117,7 +118,7 @@ Table 9: FLOOD
 Faucet Architecture
 -------------------
 
-.. figure:: /_static/images/faucet-architecture.svg
+.. figure:: ./_static/images/faucet-architecture.svg
     :alt: Faucet architecture diagram
     :align: center
     :width: 80%

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -333,9 +333,10 @@ the others ignored.
 
 A basic network and configuration with two hosts may look like:
 
-.. image:: ./_static/images/8021X-conf-diagram.svg
+.. figure:: ./_static/images/8021X-conf-diagram.svg
     :alt: ACL network diagram
     :align: center
+    :width: 80%
 
 A brief overview of the current state of the implementation:
 

--- a/docs/vendors/ovs/faucet_testing_with_OVS_on_hardware.rst
+++ b/docs/vendors/ovs/faucet_testing_with_OVS_on_hardware.rst
@@ -4,9 +4,10 @@ Faucet Testing with OVS on Hardware
 Setup
 -----
 
-.. image:: faucet_ovs_test.png
-
-.. _example:
+.. figure:: faucet_ovs_test.png
+    :alt: Open vSwitch testing diagram
+    :align: center
+    :width: 80%
 
 Faucet configuration file
 -------------------------


### PR DESCRIPTION
Figures are more flexible than images and render better in readthedocs.