### PR TITLE
docs/developer_guide: more files to copy

### DIFF
--- a/docs/developer_guide.rst
+++ b/docs/developer_guide.rst
@@ -145,6 +145,17 @@ Copy the sample gauge configuration file from
 ``/Dev/faucet/etc/faucet/gauge.yaml`` to ``/Dev/faucet/venv/etc/faucet/`` and
 edit this configuration file as necessary.
 
+If you are using the sample configuration "as is" you will also need to copy
+``/Dev/faucet/etc/faucet/acls.yaml`` to ``/Dev/faucet/venv/etc/faucet/`` as
+that included by the sample ``faucet.yaml`` file, and without it the sample
+``faucet.yaml`` file cannot be loaded.
+
+You may also wish to copy
+``/Dev/faucet/etc/faucet/ryu.conf`` to ``/Dev/faucet/venv/etc/faucet/`` as
+well so everything can be referenced in one directory inside the Python
+virtual environment.
+
+
 Configure PyCharm to run faucet and gauge
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -223,6 +234,8 @@ Then create a Python ``venv`` environment within it:
 
 and activate that virtual environment for all following steps:
 
+    .. code:: console
+
        . venv/bin/activate
 
 Ensure that the faucet config is present within the virtual environment,
@@ -233,7 +246,7 @@ copying from the default config files if required:
        mkdir -p "${VIRTUAL_ENV}/var/log/faucet"
        mkdir -p "${VIRTUAL_ENV}/etc/faucet"
 
-       for FILE in {faucet,gauge}.yaml; do
+       for FILE in {acls,faucet,gauge}.yaml ryu.conf; do
          if [ -f "${VIRTUAL_ENV}/etc/faucet/${FILE}" ]; then
            echo "Preserving existing ${FILE}"
          else


### PR DESCRIPTION
Document additional files that need to be copied to run faucet in a `venv` using the files directly copied out of the git repo.  In particular with the current `faucet.yaml` example supplied, it is necessary to copy `acls.yaml` as well, because `faucet.yaml` includes `acls.yaml`, and without it the config will not load, which will lead to Faucet not starting completely -- with the only errors being in `faucet.log` (the terminal output in the Ryu terminal looks normal).

(It's possibly also worth documenting (a) how to stop the possibly installed `faucet` / `gauge` systemd services -- otherwise the ports are busy -- and the recommended command line for running `faucet` and `gauge` directly, as none of those are immediately obvious.)