### PR TITLE
valve: add next_tables label to config_table_names

### DIFF
--- a/faucet/faucet_metrics.py
+++ b/faucet/faucet_metrics.py
@@ -96,7 +96,7 @@ class FaucetMetrics(PromClient):
         self.faucet_config_table_names = self._gauge(
             'faucet_config_table_names',
             'number to names map of FAUCET pipeline tables',
-            self.REQUIRED_LABELS + ['table_name'])
+            self.REQUIRED_LABELS + ['table_name', 'next_tables'])
         self.faucet_packet_in_secs = self._histogram(
             'faucet_packet_in_secs',
             'FAUCET packet in processing time',

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -1165,12 +1165,19 @@ class Valve:
         """Update table names for configuration."""
         self.metrics.reset_dpid(self.dp.base_prom_labels())
         self._reset_dp_status()
-        for table in self.dp.tables.values():
+
+        # Map table ids to table names
+        tables = self.dp.tables.values()
+        table_id_to_name = { table.table_id: table.name for table in tables }
+
+        for table in tables:
             table_id = table.table_id
+            next_tables = [table_id_to_name[t] for t in table.next_tables]
             self._set_var(
                 'faucet_config_table_names',
                 table_id,
-                labels=dict(self.dp.base_prom_labels(), table_name=table.name))
+                labels=dict(self.dp.base_prom_labels(), table_name=table.name,
+                            next_tables=",".join(next_tables)))
 
     def update_metrics(self, now, updated_port=None, rate_limited=False):
         """Update Gauge/metrics."""

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -1173,6 +1173,13 @@ class Valve:
         for table in tables:
             table_id = table.table_id
             next_tables = [table_id_to_name[t] for t in table.next_tables]
+
+            # Also add table miss destination as possible next table, if set
+            if table.table_config.miss_goto:
+                miss_table = table.table_config.miss_goto
+                if miss_table not in next_tables:
+                    next_tables.append(miss_table)
+
             self._set_var(
                 'faucet_config_table_names',
                 table_id,


### PR DESCRIPTION
Extend the `faucet_config_table_names` metric to include a comma separated list of next table names in a "next_tables" label, as suggested by @byllyfish in https://github.com/faucetsdn/faucet/issues/2797#issuecomment-464518340.

The `next_tables` value coming off `self.dp.tables.values()` are table IDs, so these are translated to names as part of calculating the return value (and to make those "`next_tables`" values more portable amongst different Faucet runs).

As best I can tell there are no tests on retrieving `faucet_config_table_names` at present (neither `update_config_metrics` nor `aucet_config_table_names` seems mentioned in the tests), and I'm not familiar enough with the Faucet testing framework to know how to create one from scratch (`tests/unit/faucet/test_valve.py` is a 2500+ line Python module with minimal comments, and appears mostly to test Faucet/Ryu behaviour, not things like config retrieval).

As best I can tell `/etc/faucet/prometheus/prometheus.yml` does not need updating as a result of this change, but I believe the table changed is exported to promethesus primarily, so possibly something does need updating on the promethesus side.

Example code to query/output this:

```
#! /usr/bin/env python3
# 
# Example by @KitL from: https://github.com/faucetsdn/faucet/issues/2797

import faucet.fctl as fctl

samples = fctl.get_samples(['http://127.0.0.1:9302' ],
                           'faucet_config_table_names',
                           {'dp_id': '0x1' })

#print(samples)
table_id_to_name = {
    sample.value: sample.labels['table_name']
    for sample in samples
}
table_name_to_next_tables = {
    sample.labels['table_name']: sample.labels['next_tables'].split(',')
    for sample in samples
}
for table_id in sorted(table_id_to_name.keys()):
    table_name = table_id_to_name[table_id]
    next_tables = table_name_to_next_tables[table_name]

    print("{0:2.0f}: {1:20s} {2}".format(table_id, table_name, next_tables))
```