### PR TITLE
Enable LLDP always for stacking ports.

### DIFF
--- a/faucet/port.py
+++ b/faucet/port.py
@@ -202,6 +202,11 @@ class Port(Conf):
             for stack_config in list(self.stack_defaults_types.keys()):
                 test_config_condition(stack_config not in self.stack, (
                     'stack %s must be defined' % stack_config))
+            # LLDP always enabled for stack ports.
+            self.receive_lldp = True
+            if not self.lldp_beacon_enabled():
+                self.lldp_beacon.update({'enable': True})
+
         if self.lldp_beacon:
             self._check_conf_types(
                 self.lldp_beacon, self.lldp_beacon_defaults_types)

--- a/tests/integration/mininet_tests.py
+++ b/tests/integration/mininet_tests.py
@@ -5768,9 +5768,6 @@ class FaucetStringOfDPTest(FaucetTest):
                             # make this a stacking link.
                             interfaces_config[port].update(
                                 {
-                                    'lldp_beacon': {
-                                        'enable': True},
-                                    'receive_lldp': True,
                                     'stack': {
                                         'dp': dp_name(peer_dp),
                                         'port': peer_port}


### PR DESCRIPTION
Fixes https://github.com/faucetsdn/faucet/issues/2726