### PR TITLE
Remove unnecessary double call to _configure_tables(), reduce unnecessary L2_LEARN events.

### DIFF
--- a/faucet/dp.py
+++ b/faucet/dp.py
@@ -771,7 +771,7 @@ configuration.
 
     def is_stack_root(self):
         """Return True if this DP is the root of the stack."""
-        return 'priority' in self.stack
+        return self.stack and 'priority' in self.stack
 
     def is_stack_edge(self):
         """Return True if this DP is a stack edge."""
@@ -1080,8 +1080,6 @@ configuration.
         resolve_override_output_ports()
         resolve_vlan_names_in_routers()
         resolve_acls()
-
-        self._configure_tables()
 
         bgp_vlans = self.bgp_vlans()
         if bgp_vlans:

--- a/faucet/valve_host.py
+++ b/faucet/valve_host.py
@@ -266,7 +266,7 @@ class ValveHostManager(ValveManagerBase):
         if cache_port == port or same_lag:
             # if we very very recently learned this host, don't do anything.
             if cache_age < self.cache_update_guard_time:
-                return (ofmsgs, cache_port)
+                return (ofmsgs, cache_port, False)
             # skip delete if host didn't change ports or on same LAG.
             delete_existing = False
             refresh_rules = True
@@ -295,7 +295,7 @@ class ValveHostManager(ValveManagerBase):
                 port.dyn_last_ban_time = now
                 ofmsgs.append(self._temp_ban_host_learning(
                     self.eth_src_table.match(in_port=port.number)))
-                return (ofmsgs, cache_port)
+                return (ofmsgs, cache_port, False)
 
         (src_rule_idle_timeout,
          src_rule_hard_timeout,
@@ -306,8 +306,7 @@ class ValveHostManager(ValveManagerBase):
             src_rule_idle_timeout, src_rule_hard_timeout,
             dst_rule_idle_timeout))
 
-        vlan.add_cache_host(eth_src, port, now)
-        return (ofmsgs, cache_port)
+        return (ofmsgs, cache_port, True)
 
     def flow_timeout(self, _now, _table_id, _match):
         """Handle a flow timed out message from dataplane."""

--- a/faucet/valve_host.py
+++ b/faucet/valve_host.py
@@ -255,7 +255,7 @@ class ValveHostManager(ValveManagerBase):
             if entry.port != port:
                 ofmsgs.extend(self.pipeline.filter_packets(
                     {'eth_src': eth_src, 'in_port': port.number}))
-            return (ofmsgs, entry.port)
+            return (ofmsgs, entry.port, False)
         else:
             cache_age = now - entry.cache_time
             cache_port = entry.port


### PR DESCRIPTION
Return flag for cache update needed when learning, to remove unnecessary duplicate L2_LEARN events.