### PR TITLE
Correct formatting/missing fields for BGP.

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -623,7 +623,7 @@ be configured:
       - See below for BGP configuration.
 
 BGP
-===
+###
 
 Routers config to enable BGP routing.
 
@@ -640,17 +640,25 @@ Routers config to enable BGP routing.
       - "passive"
       - Must be "passive"
     * - neighbor_addresses
-      - list of strings (IP Addresses)
+      - list of strings (IP addresses)
       - None
       - The list of BGP neighbours
     * - neighbor_as
       - integer
       - None
       - The AS Number for the BGP neighbours
+    * - routerid
+      - string (IP address)
+      - None
+      - BGP router ID.
+    * - server_addresses
+      - list of strings (IP addresses)
+      - None
+      - IP addresses for FAUCET to listen for incoming BGP addresses.
     * - port
       - integer
       - 9179
-      - Port to use for bgp sessions
+      - Port to use for BGP sessions
     * - vlan
       - string
       - None

--- a/faucet/router.py
+++ b/faucet/router.py
@@ -89,16 +89,21 @@ class Router(Conf):
 
     def check_config(self):
         super(Router, self).check_config()
-        test_config_condition(not self.vlans, 'at least one VLAN must be specified')
-        for ipv in self.bgp_ipvs():
+        if self.bgp_as():
+            for ipv in self.bgp_ipvs():
+                test_config_condition(
+                    len(self.bgp_server_addresses_by_ipv(ipv)) != 1,
+                    'Only one BGP server address per IP version supported')
+            if not self.bgp_vlan():
+                test_config_condition(
+                    len(self.vlans) != 1,
+                    'If routing more than one VLAN, must specify BGP VLAN')
+                self.set_bgp_vlan(self.vlans[0])
+            if not self.vlans:
+                self.vlans = [self.bgp_vlan()]
+        else:
             test_config_condition(
-                len(self.bgp_server_addresses_by_ipv(ipv)) != 1,
-                'Only one BGP server address per IP version supported')
-        if self.bgp_as() and not self.bgp_vlan():
-            test_config_condition(
-                len(self.vlans) != 1,
-                'If routing more than one VLAN, must specify BGP VLAN')
-            self.set_bgp_vlan(self.vlans[0])
+                not self.vlans, 'A router must have least one VLAN specified at top level')
 
     def vip_map(self, ipa):
         """Return VIP for IP address, if any."""

--- a/tests/integration/mininet_tests.py
+++ b/tests/integration/mininet_tests.py
@@ -2435,7 +2435,6 @@ vlans:
         faucet_vips: ["10.0.0.254/24", "fc00::1:254/112"]
 routers:
     router1:
-        vlans: [100]
         bgp:
             as: 1
             connect_mode: "passive"
@@ -2443,6 +2442,7 @@ routers:
             routerid: "1.1.1.1"
             server_addresses: ["127.0.0.1", "::1"]
             neighbor_addresses: ["127.0.0.1", "::1"]
+            vlan: 100
 """ + """
             neighbor_as: %u
 """ % PEER_BGP_AS
@@ -2499,7 +2499,6 @@ vlans:
         faucet_vips: ["10.0.0.254/24"]
 routers:
     router1:
-        vlans: [100]
         bgp:
             as: 1
             connect_mode: "passive"
@@ -2507,6 +2506,7 @@ routers:
             routerid: "1.1.1.1"
             server_addresses: ["127.0.0.1"]
             neighbor_addresses: ["127.0.0.1"]
+            vlan: 100
 """ + """
             neighbor_as: %u
 """ % PEER_BGP_AS
@@ -2566,7 +2566,6 @@ vlans:
                 ip_gw: 10.0.0.1
 routers:
     router1:
-        vlans: [100]
         bgp:
             as: 1
             connect_mode: "passive"
@@ -2574,6 +2573,7 @@ routers:
             routerid: "1.1.1.1"
             server_addresses: ["127.0.0.1"]
             neighbor_addresses: ["127.0.0.1"]
+            vlan: 100
 """ + """
             neighbor_as: %u
 """ % PEER_BGP_AS
@@ -2646,7 +2646,6 @@ vlans:
                 ip_gw: "10.0.0.2"
 routers:
     router1:
-        vlans: [100]
         bgp:
             as: 1
             connect_mode: "passive"
@@ -2654,6 +2653,7 @@ routers:
             routerid: "1.1.1.1"
             server_addresses: ["127.0.0.1"]
             neighbor_addresses: ["127.0.0.1"]
+            vlan: 100
 """ + """
             neighbor_as: %u
 """ % PEER_BGP_AS
@@ -5399,7 +5399,6 @@ vlans:
         faucet_vips: ["fc00::1:254/112"]
 routers:
     router1:
-        vlans: [100]
         bgp:
             as: 1
             connect_mode: "passive"
@@ -5407,6 +5406,7 @@ routers:
             routerid: "1.1.1.1"
             server_addresses: ["::1"]
             neighbor_addresses: ["::1"]
+            vlan: 100
 """ + """
             neighbor_as: %u
 """ % PEER_BGP_AS
@@ -5461,7 +5461,6 @@ vlans:
         faucet_vips: ["fc00::1:254/112"]
 routers:
     router1:
-        vlans: [100]
         bgp:
             as: 1
             connect_mode: "passive"
@@ -5469,6 +5468,7 @@ routers:
             routerid: "1.1.1.1"
             server_addresses: ["::1"]
             neighbor_addresses: ["::1"]
+            vlan: 100
 """ + """
             neighbor_as: %u
 """ % PEER_BGP_AS
@@ -5575,7 +5575,6 @@ vlans:
                 ip_gw: "fc00::1:2"
 routers:
     router1:
-        vlans: [100]
         bgp:
             as: 1
             connect_mode: "passive"
@@ -5583,6 +5582,7 @@ routers:
             routerid: "1.1.1.1"
             server_addresses: ["::1"]
             neighbor_addresses: ["::1"]
+            vlan: 100
 """ + """
             neighbor_as: %u
 """ % PEER_BGP_AS

--- a/tests/unit/faucet/test_config.py
+++ b/tests/unit/faucet/test_config.py
@@ -2764,14 +2764,16 @@ dps:
     def test_share_bgp_routing_VLAN(self):
         """Test cannot share VLAN with BGP across DPs."""
         config = """
+routers:
+    router1:
+        as: 1
+        routerid: "1.1.1.1"
+        neighbor_as: 2
+        server_addresses: ["127.0.0.1"]
+        neighbor_addresses: ["127.0.0.1"]
+        vlan: 100
 vlans:
     routing:
-        bgp_as: 1
-        bgp_routerid: "1.1.1.1"
-        bgp_neighbor_as: 2
-        bgp_server_addresses: ["127.0.0.1"]
-        bgp_neighbor_addresses: ["127.0.0.1"]
-        bgp_vlan: 100
         vid: 100
         faucet_vips: ["10.0.0.254/24"]
 dps:
@@ -2791,15 +2793,18 @@ dps:
     def test_bgp_server_invalid(self):
         """Test invalid BGP server address."""
         bgp_config = """
+routers:
+    router1:
+        as: 1
+        port: 9179
+        server_address: ["256.0.0.1"]
+        neighbor_addresses: ["127.0.0.1"]
+        routerid: "1.1.1.1"
+        neighbor_as: 2
+        vlan: 100
 vlans:
     100:
         description: "100"
-        bgp_port: 9179
-        bgp_server_addresses: ['256.0.0.1']
-        bgp_as: 1
-        bgp_routerid: '1.1.1.1'
-        bgp_neighbor_addresses: ['127.0.0.1']
-        bgp_neighbor_as: 2
 dps:
     switch1:
         dp_id: 0xcafef00d
@@ -2813,15 +2818,18 @@ dps:
     def test_bgp_neighbor_invalid(self):
         """Test invalid BGP server address."""
         bgp_config = """
+routers:
+    router1:
+        as: 1
+        port: 9179
+        server_addresses: ["127.0.0.1"]
+        neighbor_addresses: ["256.0.0.1"]
+        neighbor_as: 2
+        routerid: "1.1.1.1"
+        vlan: 100
 vlans:
     100:
         description: "100"
-        bgp_port: 9179
-        bgp_server_addresses: ['127.0.0.1']
-        bgp_as: 1
-        bgp_routerid: '1.1.1.1'
-        bgp_neighbor_addresses: ['256.0.0.1']
-        bgp_neighbor_as: 2
 dps:
     switch1:
         dp_id: 0xcafef00d

--- a/tests/unit/faucet/test_valve.py
+++ b/tests/unit/faucet/test_valve.py
@@ -2772,7 +2772,7 @@ routers:
             routerid: '1.1.1.1'
             server_addresses: ['127.0.0.1']
             neighbor_addresses: ['127.0.0.1']
-            vlan: 100
+            vlan: v100
 """ % DP1_CONFIG
 
     def setUp(self):

--- a/tests/unit/faucet/test_valve.py
+++ b/tests/unit/faucet/test_valve.py
@@ -2772,7 +2772,7 @@ routers:
             routerid: '1.1.1.1'
             server_addresses: ['127.0.0.1']
             neighbor_addresses: ['127.0.0.1']
-        vlans: [v100]
+            vlan: 100
 """ % DP1_CONFIG
 
     def setUp(self):


### PR DESCRIPTION
Allow a router to be configured without top-level VLANs (BGP only).