### PR TITLE
packets on stacking ports are marked as external_loop_protect (vlan_pcp=0) even when they're not.

### DIFF
--- a/faucet/valve_flood.py
+++ b/faucet/valve_flood.py
@@ -71,16 +71,20 @@ class ValveFloodManager(ValveManagerBase):
         return list(vlan.flood_ports(vlan.get_ports(), exclude_unicast))
 
     @staticmethod
-    def _build_flood_local_rule_actions(vlan, exclude_unicast, in_port, exclude_all_external):
+    def _build_flood_local_rule_actions(vlan, exclude_unicast, in_port, exclude_all_external, logger):
         """Return a list of flood actions to flood packets from a port."""
-        external_ports = vlan.loop_protect_external_ports_up()
+        external_ports = vlan.loop_protect_external_ports()
         exclude_ports = vlan.exclude_same_lag_member_ports(in_port)
+        if in_port and in_port.number == 1:
+            logger.info('lag_ports ' + str(exclude_ports))
+            logger.info('external_ports ' + str(external_ports))
+            logger.info('loop_protect ' + str(in_port.loop_protect_external))
         if external_ports:
             if (exclude_all_external or
                     in_port is not None and in_port.loop_protect_external):
                 exclude_ports |= set(external_ports)
-            else:
-                exclude_ports |= set(external_ports[1:])
+        if in_port and in_port.number == 1:
+            logger.info('exclude_ports ' + str(exclude_ports))
         return valve_of.flood_port_outputs(
             vlan.tagged_flood_ports(exclude_unicast),
             vlan.untagged_flood_ports(exclude_unicast),
@@ -89,7 +93,7 @@ class ValveFloodManager(ValveManagerBase):
 
     def _build_flood_rule_actions(self, vlan, exclude_unicast, in_port, exclude_all_external=False):
         return self._build_flood_local_rule_actions(
-            vlan, exclude_unicast, in_port, exclude_all_external)
+            vlan, exclude_unicast, in_port, exclude_all_external, self.logger)
 
     def _build_flood_rule(self, match, command, flood_acts, flood_priority):
         return self.flood_table.flowmod(
@@ -360,6 +364,7 @@ class ValveFloodStackManager(ValveFloodManager):
                 elif external_ports:
                     flood_actions = (
                         flood_prefix + toward_flood_actions + local_flood_actions)
+        self.logger.info('flood_actions_size2 %s' % str(flood_actions))
 
         return flood_actions
 
@@ -478,19 +483,25 @@ class ValveFloodStackManager(ValveFloodManager):
         5: 1 2 3 4
         """
         exclude_ports = []
-        external_ports = vlan.loop_protect_external_ports_up()
-
+        external_ports = vlan.loop_protect_external_ports()
         if in_port and in_port in self.stack_ports:
             in_port_peer_dp = in_port.stack['dp']
             exclude_ports = [
                 port for port in self.stack_ports
                 if port.stack['dp'] == in_port_peer_dp]
         local_flood_actions = self._build_flood_local_rule_actions(
-            vlan, exclude_unicast, in_port, exclude_all_external)
+            vlan, exclude_unicast, in_port, exclude_all_external, self.logger)
         away_flood_actions = valve_of.flood_tagged_port_outputs(
             self.away_from_root_stack_ports, in_port, exclude_ports=exclude_ports)
         toward_flood_actions = valve_of.flood_tagged_port_outputs(
             self.towards_root_stack_ports, in_port)
+        if in_port and in_port.number == 1:
+            self.logger.info('exclude_all_external ' + str(exclude_all_external))
+            self.logger.info('external_ports ' + str(external_ports))
+            self.logger.info('exclude_ports ' + str(exclude_ports))
+            self.logger.info('local_flood ' + str(local_flood_actions))
+            self.logger.info('away_flood ' + str(away_flood_actions))
+            self.logger.info('towards_flood ' + str(toward_flood_actions))
         flood_acts = self._flood_actions_func(
             in_port, external_ports, away_flood_actions,
             toward_flood_actions, local_flood_actions)
@@ -501,7 +512,8 @@ class ValveFloodStackManager(ValveFloodManager):
         # Stack ports aren't in VLANs, so need special rules to cause flooding from them.
         ofmsgs = super(ValveFloodStackManager, self)._build_mask_flood_rules(
             vlan, eth_dst, eth_dst_mask, exclude_unicast, command)
-        external_ports = vlan.loop_protect_external_ports_up()
+        external_ports = vlan.loop_protect_external_ports()
+        self.logger.info('External ports B for %s is %s' % (str(vlan), str(external_ports)))
         for port in self.stack_ports:
             if self.externals and external_ports:
                 # If external flag is set, flood to external ports, otherwise exclude them.

--- a/faucet/valve_flood.py
+++ b/faucet/valve_flood.py
@@ -326,9 +326,16 @@ class ValveFloodStackManager(ValveFloodManager):
 
     def _flood_actions_size2(self, in_port, external_ports,
                              away_flood_actions, toward_flood_actions, local_flood_actions):
+        if not in_port:
+            return ([])
+        if in_port and in_port in self.stack_ports:
+            flood_prefix = []
+        else:
+            flood_prefix = self.ext_flood_not_needed if in_port.loop_protect_external else self.ext_flood_needed
+
         # Special case for stack with maximum distance 2 - we don't need to reflect off of the root.
         flood_actions = (
-            self.ext_flood_needed + away_flood_actions + local_flood_actions)
+            flood_prefix + away_flood_actions + local_flood_actions)
 
         if self._dp_is_root():
             # Default strategy is flood locally and to non-roots.
@@ -337,22 +344,22 @@ class ValveFloodStackManager(ValveFloodManager):
                 # externally, locally.
                 if external_ports:
                     flood_actions = (
-                        self.ext_flood_not_needed + away_flood_actions + local_flood_actions)
+                        flood_prefix + away_flood_actions + local_flood_actions)
         else:
             # Default strategy is flood locally and then to the root.
             flood_actions = (
-                self.ext_flood_needed + toward_flood_actions + local_flood_actions)
+                flood_prefix + toward_flood_actions + local_flood_actions)
 
             if in_port:
                 # If packet came from the root, flood it locally.
                 if in_port in self.towards_root_stack_ports:
                     flood_actions = (
-                        self.ext_flood_not_needed + local_flood_actions)
+                        flood_prefix + local_flood_actions)
                 # If we have external ports on this switch, then let the root know
                 # we have already flooded externally, locally.
                 elif external_ports:
                     flood_actions = (
-                        self.ext_flood_not_needed + toward_flood_actions + local_flood_actions)
+                        flood_prefix + toward_flood_actions + local_flood_actions)
 
         return flood_actions
 

--- a/tests/integration/mininet_tests.py
+++ b/tests/integration/mininet_tests.py
@@ -5680,7 +5680,7 @@ class FaucetStringOfDPTest(FaucetTest):
                   include=None, include_optional=None,
                   acls=None, acl_in_dp=None,
                   switch_to_switch_links=1, hw_dpid=None,
-                  stack_ring=False, lacp=False, first_external=False):
+                  stack_ring=False, lacp=False, use_external=False):
         """Set up Mininet and Faucet for the given topology."""
         if include is None:
             include = []
@@ -5721,13 +5721,13 @@ class FaucetStringOfDPTest(FaucetTest):
             acl_in_dp,
             stack_ring,
             lacp,
-            first_external,
+            use_external,
         )
 
     def get_config(self, dpids=None, hw_dpid=None, stack=False, hardware=None, ofchannel_log=None,
                    n_tagged=0, tagged_vid=0, n_untagged=0, untagged_vid=0,
                    include=None, include_optional=None, acls=None, acl_in_dp=None, stack_ring=False,
-                   lacp=False, first_external=False):
+                   lacp=False, use_external=False):
         """Build a complete Faucet configuration for each datapath, using the given topology."""
         if dpids is None:
             dpids = []
@@ -5833,7 +5833,7 @@ class FaucetStringOfDPTest(FaucetTest):
 
         def add_dp(name, dpid, hw_dpid, i, dpid_count, stack,
                    n_tagged, tagged_vid, n_untagged, untagged_vid,
-                   dpname_to_dpkey, first_external):
+                   dpname_to_dpkey, use_external):
             dpid_ofchannel_log = None
             if ofchannel_log is not None:
                 dpid_ofchannel_log = ofchannel_log + str(i)
@@ -5855,7 +5855,7 @@ class FaucetStringOfDPTest(FaucetTest):
             for _ in range(n_tagged):
                 interfaces_config[port] = {
                     'tagged_vlans': [tagged_vid],
-                    'loop_protect_external': (first_external and port < n_tagged),
+                    'loop_protect_external': (use_external and port < n_tagged),
                 }
                 add_acl_to_port(name, port, interfaces_config)
                 port += 1
@@ -5863,7 +5863,7 @@ class FaucetStringOfDPTest(FaucetTest):
             for _ in range(n_untagged):
                 interfaces_config[port] = {
                     'native_vlan': untagged_vid,
-                    'loop_protect_external': (first_external and port < n_untagged),
+                    'loop_protect_external': (use_external and port < n_untagged),
                 }
                 add_acl_to_port(name, port, interfaces_config)
                 port += 1
@@ -5919,7 +5919,7 @@ class FaucetStringOfDPTest(FaucetTest):
             config['dps'][name] = add_dp(
                 name, dpid, hw_dpid, i, dpid_count, stack,
                 n_tagged, tagged_vid, n_untagged, untagged_vid,
-                dpname_to_dpkey, first_external)
+                dpname_to_dpkey, use_external)
 
         return yaml.dump(config, default_flow_style=False)
 
@@ -6167,7 +6167,7 @@ class FaucetStackStringOfDPExtLoopProtUntaggedTest(FaucetStringOfDPTest):
             untagged_vid=self.VID,
             switch_to_switch_links=2,
             hw_dpid=self.hw_dpid,
-            first_external=True)
+            use_external=True)
         self.start_net()
 
     def test_untagged(self):

--- a/tests/integration/mininet_tests.py
+++ b/tests/integration/mininet_tests.py
@@ -6188,9 +6188,9 @@ class FaucetStackStringOfDPExtLoopProtUntaggedTest(FaucetStringOfDPTest):
 
         self.verify_broadcast(hosts=(ext_port1, alt_port2), broadcast_expected=False)
         self.verify_broadcast(hosts=(alt_port1, ext_port2), broadcast_expected=False)
+        self.verify_broadcast(hosts=(int_port1, alt_port1), broadcast_expected=True)
         self.verify_broadcast(hosts=(int_port1, alt_port2), broadcast_expected=True)
         self.verify_broadcast(hosts=(alt_port1, int_port2), broadcast_expected=True)
-        self.verify_broadcast(hosts=(int_port1, alt_port1), broadcast_expected=True)
 
 
 class FaucetGroupStackStringOfDPUntaggedTest(FaucetStackStringOfDPUntaggedTest):

--- a/tests/integration/mininet_tests.py
+++ b/tests/integration/mininet_tests.py
@@ -5855,7 +5855,7 @@ class FaucetStringOfDPTest(FaucetTest):
             for _ in range(n_tagged):
                 interfaces_config[port] = {
                     'tagged_vlans': [tagged_vid],
-                    'loop_protect_external': (first_external and port == 1),
+                    'loop_protect_external': (first_external and port < n_tagged),
                 }
                 add_acl_to_port(name, port, interfaces_config)
                 port += 1
@@ -5863,7 +5863,7 @@ class FaucetStringOfDPTest(FaucetTest):
             for _ in range(n_untagged):
                 interfaces_config[port] = {
                     'native_vlan': untagged_vid,
-                    'loop_protect_external': (first_external and port == 1),
+                    'loop_protect_external': (first_external and port < n_untagged),
                 }
                 add_acl_to_port(name, port, interfaces_config)
                 port += 1
@@ -6156,7 +6156,7 @@ class FaucetStackStringOfDPExtLoopProtUntaggedTest(FaucetStringOfDPTest):
     """Test topology of stacked datapaths with untagged hosts."""
 
     NUM_DPS = 2
-    NUM_HOSTS = 2
+    NUM_HOSTS = 3
 
     def setUp(self): # pylint: disable=invalid-name
         super(FaucetStackStringOfDPExtLoopProtUntaggedTest, self).setUp()
@@ -6172,7 +6172,7 @@ class FaucetStackStringOfDPExtLoopProtUntaggedTest(FaucetStringOfDPTest):
 
     def test_untagged(self):
         """Host can reach eachother, unless both marked loop_protect_external"""
-        ext_port1, int_port1, ext_port2, int_port2 = self.net.hosts
+        ext_port1, alt_port1, int_port1, ext_port2, alt_port2, int_port2 = self.net.hosts
         self.verify_broadcast(hosts=(ext_port1, ext_port2), broadcast_expected=False)
         self.verify_broadcast(hosts=(ext_port1, int_port1), broadcast_expected=True)
         self.verify_broadcast(hosts=(ext_port1, int_port2), broadcast_expected=True)
@@ -6185,6 +6185,12 @@ class FaucetStackStringOfDPExtLoopProtUntaggedTest(FaucetStringOfDPTest):
         self.verify_broadcast(hosts=(int_port2, int_port1), broadcast_expected=True)
         self.verify_broadcast(hosts=(int_port2, ext_port1), broadcast_expected=True)
         self.verify_broadcast(hosts=(int_port2, ext_port2), broadcast_expected=True)
+
+        self.verify_broadcast(hosts=(ext_port1, alt_port2), broadcast_expected=False)
+        self.verify_broadcast(hosts=(alt_port1, ext_port2), broadcast_expected=False)
+        self.verify_broadcast(hosts=(int_port1, alt_port2), broadcast_expected=True)
+        self.verify_broadcast(hosts=(alt_port1, int_port2), broadcast_expected=True)
+        self.verify_broadcast(hosts=(int_port1, alt_port1), broadcast_expected=True)
 
 
 class FaucetGroupStackStringOfDPUntaggedTest(FaucetStackStringOfDPUntaggedTest):

--- a/tests/integration/mininet_tests.py
+++ b/tests/integration/mininet_tests.py
@@ -5919,7 +5919,7 @@ class FaucetStringOfDPTest(FaucetTest):
             config['dps'][name] = add_dp(
                 name, dpid, hw_dpid, i, dpid_count, stack,
                 n_tagged, tagged_vid, n_untagged, untagged_vid,
-                dpname_to_dpkey, (first_external and i == 0))
+                dpname_to_dpkey, first_external)
 
         return yaml.dump(config, default_flow_style=False)
 
@@ -6171,8 +6171,20 @@ class FaucetStackStringOfDPExtLoopProtUntaggedTest(FaucetStringOfDPTest):
         self.start_net()
 
     def test_untagged(self):
-        """All untagged hosts in stack topology can reach each other."""
-        self.verify_all_stack_hosts()
+        """Host can reach eachother, unless both marked loop_protect_external"""
+        ext_port1, int_port1, ext_port2, int_port2 = self.net.hosts
+        self.verify_broadcast(hosts=(ext_port1, ext_port2), broadcast_expected=False)
+        self.verify_broadcast(hosts=(ext_port1, int_port1), broadcast_expected=True)
+        self.verify_broadcast(hosts=(ext_port1, int_port2), broadcast_expected=True)
+        self.verify_broadcast(hosts=(int_port1, int_port2), broadcast_expected=True)
+        self.verify_broadcast(hosts=(int_port1, ext_port1), broadcast_expected=True)
+        self.verify_broadcast(hosts=(int_port1, ext_port2), broadcast_expected=True)
+        self.verify_broadcast(hosts=(ext_port2, int_port1), broadcast_expected=True)
+        self.verify_broadcast(hosts=(ext_port2, int_port2), broadcast_expected=True)
+        self.verify_broadcast(hosts=(ext_port2, ext_port1), broadcast_expected=False)
+        self.verify_broadcast(hosts=(int_port2, int_port1), broadcast_expected=True)
+        self.verify_broadcast(hosts=(int_port2, ext_port1), broadcast_expected=True)
+        self.verify_broadcast(hosts=(int_port2, ext_port2), broadcast_expected=True)
 
 
 class FaucetGroupStackStringOfDPUntaggedTest(FaucetStackStringOfDPUntaggedTest):


### PR DESCRIPTION
One half of a problem I've been tracking down. I have it distilled down to a test, but haven't identified the solution yet. The problem is that the actions generated for stacking ports on a switch set the vlan_pcp=0, which implicitly makes them considered "external" by the receiving switch. It breaks, then, internal --> external communication across the stack.

If you can point me roughly at where in the code this happens, I'd be most appreciative and can fix it up. Otherwise I'll keep on looking... I just haven't found where the rule actions are constructed yet...