### PR TITLE
faucet_config_applied: report the fraction of datapaths that we have tried to apply the config to

### DIFF
--- a/faucet/faucet.py
+++ b/faucet/faucet.py
@@ -282,6 +282,7 @@ class Faucet(RyuAppBase):
             if (valve_of.port_status_from_state(port.state) and
                 not valve_of.ignore_port(port.port_no))}
         self._send_flow_msgs(valve, valve.datapath_connect(now, discovered_up_ports))
+        self.valves_manager.update_config_applied({valve.dp.dp_id: True})
 
     @kill_on_exception(exc_logname)
     def _datapath_disconnect(self, ryu_event):

--- a/faucet/faucet_metrics.py
+++ b/faucet/faucet_metrics.py
@@ -53,6 +53,9 @@ class FaucetMetrics(PromClient):
         self.faucet_config_hash_func = self._gauge(
             'faucet_config_hash_func',
             'algorithm used to compute config hashes', ['algorithm'])
+        self.faucet_config_applied = self._gauge(
+            'faucet_config_applied',
+            'fraction of DPs that we have tried to apply config to', [])
         self.faucet_event_id = self._gauge(
             'faucet_event_id',
             'highest/most recent event ID to be sent', [])


### PR DESCRIPTION
The `faucet_config_errors` and `faucet_config_reload_requests` prometheus statistics can be used to indicate whether FAUCET has received a reload request and whether the last configuration was loaded correctly. This is what the prototype [FAUCET config agent](/lantz/faucetagent) does. (The plan is also to report and use a config hash such as `faucet_config_sha256`.)

However, this only indicates that the FAUCET state has been updated – what about the datapath state? Prior to version 1.5, OpenFlow provided no guarantees, but OpenFlow 1.5+ actually mandates that state must be committed to the datapath before a barrier reply.

So, in theory, we could keep track of barrier replies, but:

1. FAUCET doesn't use barriers with all switches (maybe it should?)
2. FAUCET is intended to work with OpenFlow 1.3 rather than 1.5
3. Few switches implement the OpenFlow 1.5 barrier semantics. For some switches, the forwarding state is propagated to hardware in an eventually consistent manner, and there may not be an easy or practical way to determine when the hardware has actually been programmed.
4. Ryu doesn't currently report barrier replies.

So if FAUCET doesn't use barriers and barriers wouldn't actually work anyway, what should we do? We could possibly (?) make things slightly better by signaling `faucet_config_applied` after we have "sent" (i.e. queued via Ryu) all of the OpenFlow messages required by the configuration to all switches. We keep track of which switches we have queued a set of OF messages for, at least once, in response to either a warm start (connected switch is updated during config load) or a cold start (switch is updated when it reconnects after a config load).

Caveats:

1. Ryu doesn't inform us whether OpenFlow messages have actually been sent, and FAUCET/Ryu doesn't seem to use transactions or keep track of replies/errors.

2. In practice, it doesn't seem to help with OVS - we still have to wait for it to take effect (and barriers might not even help?) As noted above, we only know what the messages have been queued, not sent. As in the FAUCET end-to-end tests, an end-to-end agent test using OVS can simply query OVS for flows – a somewhat brittle signal but a good sign that OVS has gotten some flows that we might care about.

3. Ultimately the hardware state is unknowable – a switch may die, or reboot, or forget all of its
flows, or equivocate about whether it has applied state, etc.. So this may not add a lot of value
since we're kind of relying on eventual consistency anyway.

4. FAUCET seems like it could evolve to enable one `Valve` to handle multiple datapaths. However, this implementation assumes a single datapath per `Valve`.

5. It's possible we should record config state using `Valve.update_config_metrics()` instead of
`ValvesManager.update_config_applied()`. The agent could aggregate the state itself if it wanted to.

6. It is possibly useful for the agent to optionally wait for the state to be applied (for some definition of applied) in small networks or networks where consistency/reliability/security is important, but it should probably not be mandatory for large networks, or you could end up waiting a very long time. (A corollary of this idea is that large networks might not be secure or reliable.) Currently the signal reports the fraction of datapaths that FAUCET has tried to program, which might be nice to know.

7. It's hard to test datapath connection because 1) it's code in `faucet.py` that isn't tested and 2) `test_valve.py` doesn't currently have code to simulate connection of multiple datapaths. So the current test checks a single datapath being configured out of the gate, and being reconfigured.
