### PR TITLE
Add faucet_config_hash_info

### DIFF
--- a/faucet/config_parser_util.py
+++ b/faucet/config_parser_util.py
@@ -29,6 +29,9 @@ try:
 except ImportError:
     from yaml import Loader
 
+CONFIG_HASH_FUNC = 'sha256'
+CONFIG_HASH = getattr(hashlib, CONFIG_HASH_FUNC)
+
 
 class UniqueKeyLoader(Loader):
 
@@ -81,7 +84,7 @@ def read_config(config_file, logname):
 def config_file_hash(config_file_name):
     """Return hash of YAML config file contents."""
     with open(config_file_name) as config_file:
-        return hashlib.sha256(config_file.read().encode('utf-8')).hexdigest()
+        return CONFIG_HASH(config_file.read().encode('utf-8')).hexdigest()
 
 
 def dp_config_path(config_file, parent_file=None):

--- a/faucet/faucet_metrics.py
+++ b/faucet/faucet_metrics.py
@@ -18,7 +18,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from prometheus_client import Gauge as PromGauge
+from prometheus_client import Gauge as PromGauge, Info
 from prometheus_client import Counter, Histogram
 
 from faucet.prom_client import PromClient
@@ -41,6 +41,12 @@ class FaucetMetrics(PromClient):
         self.faucet_config_load_error = self._gauge(
             'faucet_config_load_error',
             '1 if last attempt to re/load config failed', [])
+        self.faucet_config_hash = self._info(
+            'faucet_config_hash',
+            'file hashes for last successful config')
+        self.faucet_config_hash_func = self._gauge(
+            'faucet_config_hash_func',
+            'algorithm used to compute config hashes', ['algorithm'])
         self.faucet_event_id = self._gauge(
             'faucet_event_id',
             'highest/most recent event ID to be sent', [])
@@ -176,6 +182,9 @@ class FaucetMetrics(PromClient):
 
     def _gauge(self, var, var_help, labels):
         return PromGauge(var, var_help, labels, registry=self._reg) # pylint: disable=unexpected-keyword-arg
+
+    def _info(self, var, var_help):
+        return Info(var, var_help, registry=self._reg) # pylint: disable=unexpected-keyword-arg
 
     def _histogram(self, var, var_help, labels, buckets):
         return Histogram(var, var_help, labels, buckets=buckets, registry=self._reg) # pylint: disable=unexpected-keyword-arg

--- a/faucet/valves_manager.py
+++ b/faucet/valves_manager.py
@@ -20,7 +20,7 @@
 from collections import defaultdict
 
 from faucet.conf import InvalidConfigError
-from faucet.config_parser_util import config_changed
+from faucet.config_parser_util import config_changed, CONFIG_HASH_FUNC
 from faucet.config_parser import dp_parser
 from faucet.valve import valve_factory, SUPPORTED_HARDWARE
 from faucet.valve_util import dpid_log, stat_config_files
@@ -89,9 +89,11 @@ class ValvesManager:
 
     def parse_configs(self, new_config_file):
         """Return parsed configs for Valves, or None."""
+        self.metrics.faucet_config_hash_func.labels(algorithm=CONFIG_HASH_FUNC)
         try:
             new_config_hashes, new_dps = dp_parser(new_config_file, self.logname)
             self.config_watcher.update(new_config_file, new_config_hashes)
+            self.metrics.faucet_config_hash.info(new_config_hashes)
             self.metrics.faucet_config_load_error.set(0)
         except InvalidConfigError as err:
             self.logger.error('New config bad (%s) - rejecting', err)

--- a/tests/unit/faucet/test_valve.py
+++ b/tests/unit/faucet/test_valve.py
@@ -21,6 +21,7 @@ from collections import namedtuple
 from functools import partial
 
 import cProfile
+import hashlib
 import io
 import ipaddress
 import logging
@@ -47,6 +48,7 @@ from beka.ip import IPAddress, IPPrefix
 
 from faucet import faucet
 from faucet import faucet_bgp
+from faucet import config_parser_util
 from faucet import faucet_dot1x
 from faucet import faucet_experimental_api
 from faucet import faucet_experimental_event
@@ -2252,6 +2254,96 @@ dps:
         total_tt_prop = pstats_out.total_tt / self.baseline_total_tt # pytype: disable=attribute-error
         # must not be 50x slower, to ingest config for 100 interfaces than 1.
         self.assertTrue(total_tt_prop < 50, msg=pstats_text)
+
+
+
+class ValveTestConfigHash(ValveTestBases.ValveTestSmall):
+    """Verify faucet_config_hash_info update after config change"""
+
+    CONFIG = """
+dps:
+    s1:
+%s
+        interfaces:
+            p1:
+                number: 1
+                native_vlan: 0x100
+""" % DP1_CONFIG
+
+    def setUp(self):
+        self.setup_valve(self.CONFIG)
+
+    def _get_info(self, metric, name):
+        """"Return (single) info dict for metric"""
+        # There doesn't seem to be a nice API for this,
+        # so we use the prometheus client internal API
+        metrics = list(metric.collect())
+        self.assertEqual(len(metrics), 1)
+        samples = metrics[0].samples
+        self.assertEqual(len(samples), 1)
+        sample = samples[0]
+        self.assertEqual(sample.name, name)
+        return sample.labels
+
+    def _get_hashes(self):
+        """Return and verify hashes"""
+        hashes = self._get_info(metric=self.metrics.faucet_config_hash,
+                                name='faucet_config_hash_info')
+        self._verify_hashes(hashes)
+        return hashes
+
+    def _verify_hashes(self, hashes):
+        """Verify hashes dict"""
+        self.assertEqual(len(hashes), 1, 'too many hashes')
+        hash_value = tuple(hashes.values())[0]
+        goal = config_parser_util.config_file_hash(self.config_file)
+        self.assertEqual(hash_value, goal, 'hash validation failed')
+
+    def _change_config(self):
+        "Change self.CONFIG"
+        if '0x100' in self.CONFIG:
+            self.CONFIG = self.CONFIG.replace('0x100', '0x200')
+        else:
+            self.CONFIG = self.CONFIG.replace('0x200', '0x100')
+        self.update_config(self.CONFIG, reload_expected=True)
+        return self.CONFIG
+
+    def test_config_hash_func(self):
+        """Verify that faucet_config_hash_func is set correctly"""
+        labels = self._get_info(metric=self.metrics.faucet_config_hash_func,
+                                name='faucet_config_hash_func')
+        hash_funcs = list(labels.values())
+        self.assertEqual(len(hash_funcs), 1, "found multiple hash functions")
+        hash_func = hash_funcs[0]
+        # Make sure that it matches and is supported in hashlib
+        self.assertEqual(hash_func, config_parser_util.CONFIG_HASH_FUNC)
+        self.assertTrue(hash_func in hashlib.algorithms_guaranteed)
+
+    def test_config_hash_update(self):
+        """Verify faucet_config_hash_info is properly updated after config"""
+        # Verify that hashes change after config is changed
+        old_config = self.CONFIG
+        old_hashes = self._get_hashes()
+        starting_hashes = old_hashes
+        self._change_config()
+        new_config = self.CONFIG
+        self.assertNotEqual(old_config, new_config, 'config not changed')
+        new_hashes = self._get_hashes()
+        self._verify_hashes(new_hashes)
+        self.assertNotEqual(old_hashes, new_hashes,
+                            'hashes not changed after config change')
+        # Verify that hashes don't change after config isn't changed
+        old_hashes = new_hashes
+        self.update_config(self.CONFIG, reload_expected=False)
+        new_hashes = self._get_hashes()
+        self.assertEqual(old_hashes, new_hashes,
+                         "hashes changed when config didn't")
+        # Verify that hash is restored when config is restored
+        self._change_config()
+        new_hashes = self._get_hashes()
+        self.assertEqual(new_hashes, starting_hashes,
+                         'hashes should be restored to starting values')
+
 
 
 class ValveTestTunnel(ValveTestBases.ValveTestSmall):


### PR DESCRIPTION
Report the following information via prometheus stats:

config file hashes as `faucet_config_hash_info{filename="hash",…} 1.0`
config file hash function as `faucet_config_hash_func{algorithm="sha256"} 1.0`

This is intended to make it easier for the [faucet config agent](/faucetsdn/faucetagent) to verify that a config has been accepted, by comparing the hash of a transmitted config file with its hash from `faucet_config_hash_info`. An appropriate hash function implementation may be imported directly from Python's `hashlib` or instantiated using `hashlib.new(algorithm)`.

The `1.0` values are meaningless, but seem to be a prometheus requirement.

I would prefer that the hashes were called `faucet_config_hashes` but the `Info()` class appends `_info` on the name, so `faucet_config_hash_info` seemed better than `faucet_config_hashes_info`.

I was considering `faucet_config_hash_alg{name="sha256"}` but that didn't seem to be any clearer.
