### PR TITLE
Refactor faucet_dot1x.py

### DIFF
--- a/faucet/faucet_dot1x.py
+++ b/faucet/faucet_dot1x.py
@@ -44,15 +44,15 @@ class FaucetDot1x:
     def __init__(self, logger, metrics, send_flow_msgs):
         self.logger = logger
         self.metrics = metrics
-        self._send_flow_msgs = send_flow_msgs
-        self._valves = None
-        self.dot1x_speaker = None
-        self.dot1x_intf = None
         self.mac_to_port = {}  # {"00:00:00:00:00:02" : (valve_0, port_1)}
         self.dp_id_to_valve_index = {}
         self.thread = None
-        self.auth_acl_name = None
-        self.noauth_acl_name = None
+
+        self._send_flow_msgs = send_flow_msgs
+        self._valves = None
+        self._dot1x_speaker = None
+        self._auth_acl_name = None
+        self._noauth_acl_name = None
 
     def _create_dot1x_speaker(self, dot1x_intf, chewie_id, radius_ip, radius_port, radius_secret):
         """
@@ -75,40 +75,45 @@ class FaucetDot1x:
         self.thread.name = 'chewie'
         return _chewie
 
-    def get_valve_and_port(self, port_id):
+    def _get_valve_and_port(self, port_id):
         """Finds the valve and port that this address corresponds to
         Args:
             port_id: is a macaddress string"""
         valve, port = self.mac_to_port[port_id]
         return (valve, port)
 
+    def _get_acls(self, dp):
+        """Returns tuple of acl values"""
+        auth_acl = dp.acls.get(self._auth_acl_name)
+        noauth_acl = dp.acls.get(self._noauth_acl_name)
+        return (auth_acl, noauth_acl)
+
+    # Loggin Methods
+    def log_auth_event(self, valve, port_num, mac_str, status):
+        """Log an authentication attempt event"""
+        self.metrics.inc_var('dp_dot1x_{}'.format(status), valve.dp.base_prom_labels())
+        self.metrics.inc_var('port_dot1x_{}'.format(status), valve.dp.port_labels(port_num))
+        self.logger.info(
+            '{} from MAC {} on {}'.format(status.capitalize(), mac_str, port_num))
+        valve.dot1x_event({'AUTHENTICATION': {'dp_id': valve.dp.dp_id,
+                                              'port': port_num,
+                                              'eth_src': mac_str,
+                                              'status': status}})
+
+    def log_port_event(self, event_type, port_type, valve, port_num):
+        """Log a dot1x port event"""
+        valve.dot1x_event({event_type: {'dp_id': valve.dp.dp_id,
+                                        'port': port_num,
+                                        'port_type': port_type}})
+
     def auth_handler(self, address, port_id, vlan_name, filter_id):
         """Callback for when a successful auth happens."""
         address_str = str(address)
-        valve, dot1x_port = self.get_valve_and_port(port_id)
-        self.logger.info(
-            'Successful auth from MAC %s on %s' % (address_str, dot1x_port))
-        self.metrics.inc_var('dp_dot1x_success', valve.dp.base_prom_labels())
-        self.metrics.inc_var('port_dot1x_success', valve.dp.port_labels(dot1x_port.number))
-        valve.dot1x_event({'AUTHENTICATION': {'dp_id': valve.dp.dp_id,
-                                              'port': dot1x_port.number,
-                                              'eth_src': address_str,
-                                              'status': 'success'}})
+        valve, dot1x_port = self._get_valve_and_port(port_id)
+        port_num = dot1x_port.number
 
-        # Call acl manager for flowmods of ACL
-        acl_manager = valve.acl_manager
-        flowmods = []
-
-        if dot1x_port.dot1x_acl:
-            auth_acl = valve.dp.acls.get(self.auth_acl_name)
-            noauth_acl = valve.dp.acls.get(self.noauth_acl_name)
-            flowmods.extend(acl_manager.add_port_acl(auth_acl, dot1x_port, address_str))
-            flowmods.extend(acl_manager.del_port_acl(noauth_acl, dot1x_port))
-        else:
-            flowmods.extend(acl_manager.add_authed_mac(dot1x_port.number, address_str))
-
-        if vlan_name:
-            flowmods.extend(valve.add_dot1x_native_vlan(dot1x_port.number, str(address), vlan_name))
+        self.log_auth_event(valve, port_num, address_str, 'success')
+        flowmods = self._get_login_flowmod(dot1x_port, valve, address_str, vlan_name)
 
         if flowmods:
             self._send_flow_msgs(valve, flowmods)
@@ -116,28 +121,12 @@ class FaucetDot1x:
     def logoff_handler(self, address, port_id):
         """Callback for when an EAP logoff happens."""
         address_str = str(address)
-        valve, dot1x_port = self.get_valve_and_port(port_id)
-        self.logger.info(
-            'Logoff from MAC %s on %s', address_str, dot1x_port)
-        self.metrics.inc_var('dp_dot1x_logoff', valve.dp.base_prom_labels())
-        self.metrics.inc_var('port_dot1x_logoff', valve.dp.port_labels(dot1x_port.number))
-        valve.dot1x_event({'AUTHENTICATION': {'dp_id': valve.dp.dp_id,
-                                              'port': dot1x_port.number,
-                                              'eth_src': address_str,
-                                              'status': 'logoff'}})
+        valve, dot1x_port = self._get_valve_and_port(port_id)
+        port_num = dot1x_port.number
 
-        acl_manager = valve.acl_manager
-        flowmods = []
+        self.log_auth_event(valve, port_num, address_str, 'logoff')
 
-        if dot1x_port.dot1x_acl:
-            auth_acl = valve.dp.acls.get(self.auth_acl_name)
-            noauth_acl = valve.dp.acls.get(self.noauth_acl_name)
-
-            flowmods.extend(acl_manager.del_port_acl(auth_acl, dot1x_port, address_str))
-            flowmods.extend(acl_manager.add_port_acl(noauth_acl, dot1x_port))
-        else:
-            flowmods.extend(valve.del_authed_mac(dot1x_port.number, address_str))
-        flowmods.extend(valve.del_dot1x_native_vlan(dot1x_port.number, address_str))
+        flowmods = self._get_logoff_flowmod(dot1x_port, valve, address_str)
 
         if flowmods:
             self._send_flow_msgs(valve, flowmods)
@@ -145,28 +134,12 @@ class FaucetDot1x:
     def failure_handler(self, address, port_id):
         """Callback for when a EAP failure happens."""
         address_str = str(address)
-        valve, dot1x_port = self.get_valve_and_port(port_id)
-        self.logger.info(
-            'Failure from MAC %s on %s, removing access', address_str, dot1x_port)
-        self.metrics.inc_var('dp_dot1x_failure', valve.dp.base_prom_labels())
-        self.metrics.inc_var('port_dot1x_failure', valve.dp.port_labels(dot1x_port.number))
-        valve.dot1x_event({'AUTHENTICATION': {'dp_id': valve.dp.dp_id,
-                                              'port': dot1x_port.number,
-                                              'eth_src': address_str,
-                                              'status': 'failure'}})
 
-        acl_manager = valve.acl_manager
-        flowmods = []
+        valve, dot1x_port = self._get_valve_and_port(port_id)
+        port_num = dot1x_port.number
 
-        if dot1x_port.dot1x_acl:
-            auth_acl = valve.dp.acls.get(self.auth_acl_name)
-            noauth_acl = valve.dp.acls.get(self.noauth_acl_name)
-
-            flowmods.extend(acl_manager.del_port_acl(auth_acl, dot1x_port, address_str))
-            flowmods.extend(acl_manager.add_port_acl(noauth_acl, dot1x_port))
-        else:
-            flowmods.extend(valve.del_authed_mac(dot1x_port.number, address_str))
-        flowmods.extend(valve.del_dot1x_native_vlan(dot1x_port.number, address_str))
+        self.log_auth_event(valve, port_num, address_str, 'failure')
+        flowmods = self._get_logoff_flowmod(dot1x_port, valve, address_str)
 
         if flowmods:
             self._send_flow_msgs(valve, flowmods)
@@ -186,63 +159,57 @@ class FaucetDot1x:
         self.mac_to_port[mac_str] = (valve, port)
         return mac_str
 
-    def nfv_sw_port_up(self, dp_id, dot1x_ports, nfv_sw_port, acl_manager):
+    def nfv_sw_port_up(self, dp_id, dot1x_ports, nfv_sw_port):
         """Setup the dot1x forward port acls when the nfv_sw_port comes up.
         Args:
             dp_id (int):
             dot1x_ports (Iterable of Port objects):
             nfv_sw_port (Port):
-            acl_manager (ValveAclManager):
 
         Returns:
             list of flowmods
         """
-        self.dot1x_speaker.port_down(
+        #TODO Come back to. Should this be down?
+        self._dot1x_speaker.port_down(
             get_mac_str(self.dp_id_to_valve_index[dp_id], nfv_sw_port.number))
         valve = self._valves[dp_id]
-        valve.dot1x_event({'PORT_UP': {'dp_id': valve.dp.dp_id,
-                                       'port': nfv_sw_port.number,
-                                       'port_type': 'nfv'}})
+
+        self.log_port_event("PORT_UP", 'nfv', valve, nfv_sw_port.number)
+
         ret = []
         for port in dot1x_ports:
             ret.extend(self.create_flow_pair(
-                dp_id, port, nfv_sw_port, acl_manager))
+                dp_id, port, nfv_sw_port, valve))
         return ret
 
-    def port_up(self, dp_id, dot1x_port, nfv_sw_port, acl_manager):
+    def port_up(self, dp_id, dot1x_port, nfv_sw_port):
         """Setup the dot1x forward port acls.
         Args:
             dp_id (int):
             dot1x_port (Port):
             nfv_sw_port (Port):
-            acl_manager (ValveAclManager):
 
         Returns:
             list of flowmods
         """
-        mac_str = get_mac_str(self.dp_id_to_valve_index[dp_id], dot1x_port.number)
+        port_num = dot1x_port.number
 
-        self.dot1x_speaker.port_up(mac_str)
-
+        mac_str = get_mac_str(self.dp_id_to_valve_index[dp_id], port_num)
+        self._dot1x_speaker.port_up(mac_str)
         valve = self._valves[dp_id]
-        valve.dot1x_event({'PORT_UP': {'dp_id': valve.dp.dp_id,
-                                       'port': dot1x_port.number,
-                                       'port_type': 'supplicant'}})
+
+        self.log_port_event("PORT_UP", 'supplicant', valve, port_num)
 
         # Dealing with ACLs
         flowmods = []
         flowmods.extend(self.create_flow_pair(
-            dp_id, dot1x_port, nfv_sw_port, acl_manager))
+            dp_id, dot1x_port, nfv_sw_port, valve))
 
-        if dot1x_port.dot1x_acl:
-            noauth_acl = self._valves[dp_id].dp.acls.get(self.noauth_acl_name)
-            flowmods.extend(
-                acl_manager.add_port_acl(noauth_acl, dot1x_port)
-            )
+        flowmods.extend(self._add_unauthenticated_flowmod(dot1x_port, valve))
 
         return flowmods
 
-    def create_flow_pair(self, dp_id, dot1x_port, nfv_sw_port, acl_manager):
+    def create_flow_pair(self, dp_id, dot1x_port, nfv_sw_port, valve):
         """Creates the pair of flows that redirects the eapol packets to/from
         the supplicant and nfv port
 
@@ -250,7 +217,7 @@ class FaucetDot1x:
             dp_id (int):
             dot1x_port (Port):
             nfv_sw_port (Port):
-            acl_manager (ValveAclManager):
+            valve (Valve):
 
         Returns:
             list
@@ -258,59 +225,35 @@ class FaucetDot1x:
         if dot1x_port.running():
             valve_index = self.dp_id_to_valve_index[dp_id]
             mac = get_mac_str(valve_index, dot1x_port.number)
-            return acl_manager.create_dot1x_flow_pair(
-                dot1x_port, nfv_sw_port, mac)
+            return valve.create_dot1x_flow_pair(
+                dot1x_port.number, nfv_sw_port.number, mac)
         return []
 
-    def _clean_up_acls(self, dp_id, dot1x_port, acl_manager, mac):
-        '''Remove ACL flows from a port'''
-        # Remove ACLS for Port
-        flowmods = []
-
-        if dot1x_port.dot1x_acl:
-            auth_acl = self._valves[dp_id].dp.acls.get(self.auth_acl_name)
-            noauth_acl = self._valves[dp_id].dp.acls.get(self.noauth_acl_name)
-
-            if auth_acl:
-                flowmods.extend(
-                    acl_manager.del_port_acl(auth_acl, dot1x_port, mac)
-                )
-
-            if noauth_acl:
-                flowmods.extend(
-                    acl_manager.del_port_acl(noauth_acl, dot1x_port)
-                )
-
-        return flowmods
-
-    def port_down(self, dp_id, dot1x_port, nfv_sw_port, acl_manager):
+    def port_down(self, dp_id, dot1x_port, nfv_sw_port):
         """
         Remove the acls added by FaucetDot1x.get_port_acls
         Args:
             dp_id (int):
             dot1x_port (Port):
             nfv_sw_port (Port):
-            acl_manager (ValveAclManager):
 
         Returns:
             list of flowmods
         """
         valve_index = self.dp_id_to_valve_index[dp_id]
-        mac = get_mac_str(valve_index, dot1x_port.number)
-        self.dot1x_speaker.port_down(get_mac_str(valve_index, dot1x_port.number))
+        port_num = dot1x_port.number
+
+        mac = get_mac_str(valve_index, port_num)
+        self._dot1x_speaker.port_down(mac)
+
         valve = self._valves[dp_id]
-        valve.dot1x_event({'PORT_DOWN': {'dp_id': valve.dp.dp_id,
-                                         'port': dot1x_port.number,
-                                         'port_type': 'supplicant'}})
+        self.log_port_event("PORT_DOWN", 'supplicant', valve, port_num)
 
         flowmods = []
-        flowmods.extend(self._clean_up_acls(dp_id, dot1x_port, acl_manager, mac))
-
-        # Clear auth_mac
-        flowmods.extend(acl_manager.del_authed_mac(dot1x_port.number))
-        flowmods.extend(acl_manager.del_dot1x_flow_pair(dot1x_port, nfv_sw_port, mac))
-        valve = self._valves[dp_id]
-        flowmods.extend(valve.del_dot1x_native_vlan(dot1x_port.number, None))
+        flowmods.extend(self._del_authenticated_flowmod(dot1x_port, valve, mac))
+        flowmods.extend(self._del_unauthenticated_flowmod(dot1x_port, valve))
+        # NOTE: The flow_pair are not included in unauthed flowmod
+        flowmods.extend(valve.del_dot1x_flow_pair(dot1x_port.number, nfv_sw_port.number, mac))
         return flowmods
 
     def reset(self, valves):
@@ -328,10 +271,10 @@ class FaucetDot1x:
         radius_port = first_valve.dp.dot1x['radius_port']
         radius_secret = first_valve.dp.dot1x['radius_secret']
 
-        self.auth_acl_name = first_valve.dp.dot1x.get('auth_acl')
-        self.noauth_acl_name = first_valve.dp.dot1x.get('noauth_acl')
+        self._auth_acl_name = first_valve.dp.dot1x.get('auth_acl')
+        self._noauth_acl_name = first_valve.dp.dot1x.get('noauth_acl')
 
-        self.dot1x_speaker = self._create_dot1x_speaker(
+        self._dot1x_speaker = self._create_dot1x_speaker(
             dot1x_intf, first_valve.dp.faucet_dp_mac,
             radius_ip, radius_port, radius_secret)
 
@@ -344,3 +287,70 @@ class FaucetDot1x:
                         valve.dp, valve_index, dot1x_port, dot1x_intf))
 
             valve.dot1x_event({'ENABLED': {'dp_id': valve.dp.dp_id}})
+
+    def _get_logoff_flowmod(self, dot1x_port, valve, mac_str):
+        """Return flowmods required to logoff port"""
+        flowmods = []
+        flowmods.extend(
+            self._del_authenticated_flowmod(dot1x_port, valve, mac_str))
+        flowmods.extend(
+            self._add_unauthenticated_flowmod(dot1x_port, valve))
+        return flowmods
+
+    def _get_login_flowmod(self, dot1x_port, valve, mac_str, vlan_name):
+        """Return flowmods required to login port"""
+        flowmods = []
+        flowmods.extend(
+            self._del_unauthenticated_flowmod(dot1x_port, valve))
+        flowmods.extend(
+            self._add_authenticated_flowmod(dot1x_port, valve, mac_str, vlan_name))
+
+        return flowmods
+
+    def _add_authenticated_flowmod(self, dot1x_port, valve, mac_str, vlan_name):
+        """Return flowmods for successful authentication on port"""
+        port_num = dot1x_port.number
+        flowmods = []
+
+        if dot1x_port.dot1x_acl:
+            auth_acl, _ = self._get_acls(valve.dp)
+            flowmods.extend(valve.add_port_acl(auth_acl, port_num, mac_str))
+        else:
+            flowmods.extend(valve.add_authed_mac(port_num, mac_str))
+
+        if vlan_name:
+            flowmods.extend(valve.add_dot1x_native_vlan(port_num, mac_str, vlan_name))
+
+        return flowmods
+
+    def _del_authenticated_flowmod(self, dot1x_port, valve, mac_str):
+        """Return flowmods for deleting authentication flows from a port"""
+        flowmods = []
+        port_num = dot1x_port.number
+        if dot1x_port.dot1x_acl:
+            auth_acl, _ = self._get_acls(valve.dp)
+            flowmods.extend(valve.del_port_acl(auth_acl, port_num, mac_str))
+        else:
+            flowmods.extend(valve.del_authed_mac(port_num, mac_str))
+
+        flowmods.extend(valve.del_dot1x_native_vlan(port_num, mac_str))
+
+        return flowmods
+
+    def _add_unauthenticated_flowmod(self, dot1x_port, valve, mac_str=None):
+        """Return flowmods default on a port"""
+        flowmods = []
+        if dot1x_port.dot1x_acl:
+            _, noauth_acl = self._get_acls(valve.dp)
+            flowmods.extend(valve.add_port_acl(noauth_acl, dot1x_port.number, mac_str))
+
+        return flowmods
+
+    def _del_unauthenticated_flowmod(self, dot1x_port, valve, mac_str=None):
+        """Return flowmods for deleting default / unauthenticated flows from a port"""
+        flowmods = []
+        if dot1x_port.dot1x_acl:
+            _, noauth_acl = self._get_acls(valve.dp)
+            flowmods.extend(valve.del_port_acl(noauth_acl, dot1x_port.number, mac_str))
+
+        return flowmods

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -738,11 +738,10 @@ class Valve:
                 nfv_sw_port = self.dp.ports[self.dp.dot1x['nfv_sw_port']]
                 if port == nfv_sw_port:
                     ofmsgs.extend(self.dot1x.nfv_sw_port_up(
-                        self.dp.dp_id, self.dp.dot1x_ports(), nfv_sw_port,
-                        self.acl_manager))
+                        self.dp.dp_id, self.dp.dot1x_ports(), nfv_sw_port))
                 elif port.dot1x:
                     ofmsgs.extend(self.dot1x.port_up(
-                        self.dp.dp_id, port, nfv_sw_port, self.acl_manager))
+                        self.dp.dp_id, port, nfv_sw_port))
 
             port_vlans = port.vlans()
 
@@ -809,8 +808,7 @@ class Valve:
                 ofmsgs.extend(self.dot1x.port_down(
                     self.dp.dp_id,
                     port,
-                    self.dp.ports[self.dp.dot1x['nfv_sw_port']],
-                    self.acl_manager
+                    self.dp.ports[self.dp.dot1x['nfv_sw_port']]
                     ))
             if port.lacp:
                 ofmsgs.extend(self.lacp_down(port))
@@ -1499,6 +1497,22 @@ class Valve:
 
     def del_authed_mac(self, port_num, mac=None):
         return self.acl_manager.del_authed_mac(port_num, mac)
+
+    def del_port_acl(self, acl, port_num, mac=None):
+        """Return ACL openflow rules for removing port with acl"""
+        return self.acl_manager.del_port_acl(acl, port_num, mac)
+
+    def add_port_acl(self, acl, port_num, mac=None):
+        """Return ACL openflow rules for port with acl"""
+        return self.acl_manager.add_port_acl(acl, port_num, mac)
+
+    def create_dot1x_flow_pair(self, port_num, nfv_sw_port_num, mac):
+        """Return flowmods for creating dot1x flow pair"""
+        return self.acl_manager.create_dot1x_flow_pair(port_num, nfv_sw_port_num, mac)
+
+    def del_dot1x_flow_pair(self, port_num, nfv_sw_port_num, mac):
+        """Return flowmods for deleting dot1x flow pair"""
+        return self.acl_manager.del_dot1x_flow_pair(port_num, nfv_sw_port_num, mac)
 
     def add_dot1x_native_vlan(self, port_num, eth_src, vlan_name):
         port = self.dp.ports[port_num]

--- a/tests/integration/mininet_tests.py
+++ b/tests/integration/mininet_tests.py
@@ -856,13 +856,17 @@ vlans:
 acls:
     auth_acl:
         - rule:
-            dl_type: 0x800      # Deny ICMP / IPv4
+            dl_type: 0x800      # Allow ICMP / IPv4
             ip_proto: 1
+            actions:
+                allow: True
+        - rule:
+            dl_type: 0x0806     # ARP Packets 
             actions:
                 allow: True
     noauth_acl:
         - rule:
-            dl_type: 0x800      # Allow ICMP / IPv4
+            dl_type: 0x800      # Deny ICMP / IPv4
             ip_proto: 1
             actions:
                 allow: False


### PR DESCRIPTION
BUGFIX: Remove Default ACL when Authenticated Correctly
Simplify the logging of events inside the dot1x module.
Remove acl_manager dependency from faucet_dot1x.py module
Enforce valve dot1x functions only require port numbers not 'dot1x_port' type.
Remove flow building from handler functions and split into reusable components.
Rename internal variables to conform to Python standard.