### PR TITLE
Update faucet_config_hash_info label format for compatibility with faucetagent

### DIFF
--- a/faucet/faucet_metrics.py
+++ b/faucet/faucet_metrics.py
@@ -18,16 +18,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import re
 from prometheus_client import Gauge as PromGauge, Info
 from prometheus_client import Counter, Histogram
 
 from faucet.prom_client import PromClient
-
-
-def quote_label(label):
-    """Return a Prometheus-safe version of a label."""
-    return re.sub(r'[^a-zA-Z0-9_]', '_', label)
 
 
 class FaucetMetrics(PromClient):

--- a/faucet/valves_manager.py
+++ b/faucet/valves_manager.py
@@ -22,7 +22,6 @@ from collections import defaultdict
 from faucet.conf import InvalidConfigError
 from faucet.config_parser_util import config_changed, CONFIG_HASH_FUNC
 from faucet.config_parser import dp_parser
-from faucet.faucet_metrics import quote_label
 from faucet.valve import valve_factory, SUPPORTED_HARDWARE
 from faucet.valve_util import dpid_log, stat_config_files
 
@@ -93,11 +92,12 @@ class ValvesManager:
         self.metrics.faucet_config_hash_func.labels(algorithm=CONFIG_HASH_FUNC)
         try:
             new_config_hashes, new_dps = dp_parser(new_config_file, self.logname)
-            quoted_new_config_hashes = {
-                quote_label(filename): filehash
-                for filename, filehash in new_config_hashes.items()}
             self.config_watcher.update(new_config_file, new_config_hashes)
-            self.metrics.faucet_config_hash.info(quoted_new_config_hashes)
+            config_files = sorted(new_config_hashes.keys())
+            hashes = [new_config_hashes[config] for config in config_files]
+            self.metrics.faucet_config_hash.info(
+                dict(config_files=','.join(config_files),
+                     hashes=','.join(hashes)))
             self.metrics.faucet_config_load_error.set(0)
         except InvalidConfigError as err:
             self.logger.error('New config bad (%s) - rejecting', err)


### PR DESCRIPTION
The new format is:

`faucet_config_hash_info{config_files='file1,file2,file3', hashes='hash1,hash2,hash3'} 1.0`

This should enable us to fix faucetsdn/faucetagent#12 using faucetsdn/faucetagent#13