### PR TITLE
Fix two broken switch vendor URLs in the docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ FAUCET has been tested against the following switches (see also SUPPORTED_HARDWA
 - `Lagopus Openflow Switch <https://lagopus.github.io>`_
 - Allied Telesis `x510 <https://www.alliedtelesis.com/products/x510-series>`_ and `x930 <https://www.alliedtelesis.com/products/x930-series>`_ series
 - `NoviFlow 1248 <http://noviflow.com/products/noviswitch>`_
-- Northbound Networks - `Zodiac FX <http://northboundnetworks.com/collections/zodiac-fx>`_ and `Zodiac GX <http://northboundnetworks.com/collections/zodiac-gx>`_
+- Northbound Networks - `Zodiac FX <http://northboundnetworks.com/collections/zodiac-fx>`_ and `Zodiac GX <http://northboundnetworks.com/products/zodiac-gx>`_
 - Hewlett Packard Enterprise - `Aruba 5400R, 3810 and 2930F <http://www.arubanetworks.com/products/networking/switches/>`_
 - Netronome produces PCIe adaptors, via OVS - `Agilio CX 2x10GbE card <https://www.netronome.com/products/agilio-cx/>`_
 - Cisco Systems - `Catalyst 9000 Family Switches <http://www.cisco.com/c/en/us/products/switches/catalyst-9000.html>`_

--- a/docs/vendors/cisco/README_Cisco.rst
+++ b/docs/vendors/cisco/README_Cisco.rst
@@ -7,7 +7,7 @@ Cisco supports Openflow with FAUCET pipeline on the Catalyst 9000 Series switche
 
 The solution support is currently in beta on the following models:
 
-- `C9300-48P-A <https://www.cisco.com/c/en/us/products/collateral/switches/catalyst-9300-series-switches/datasheet-c78-738977.html>`_
+- `C9300-48P-A <https://www.cisco.com/c/en/us/products/collateral/switches/catalyst-9300-series-switches/data_sheet-c78-738977.html>`_
 - `C9410R with SUP1 <https://www.cisco.com/c/en/us/products/collateral/switches/catalyst-9400-series-switches/datasheet-c78-739053.html>`_
 - `C9500-48X-A <https://www.cisco.com/c/en/us/products/collateral/switches/catalyst-9500-series-switches/datasheet-c78-738978.html>`_
 


### PR DESCRIPTION
Fix broken Zodiac GX product page and Cisco C9300-48P-A datasheet links.