### PR TITLE
Add a new option to the hw_switch_config.yaml to be able to use the IPv6 of the CPN interface

### DIFF
--- a/clib/mininet_test_base.py
+++ b/clib/mininet_test_base.py
@@ -110,6 +110,7 @@ class FaucetTestBase(unittest.TestCase):
     net = None
     topo = None
     cpn_intf = None
+    cpn_ipv6 = False
     config_ports = {}
     env = collections.defaultdict(dict)
     rand_dpids = set()
@@ -169,6 +170,8 @@ class FaucetTestBase(unittest.TestCase):
             if self.hw_switch:
                 self.dpid = self.config['dpid']
                 self.cpn_intf = self.config['cpn_intf']
+                if 'cpn_ipv6' in self.config:
+                    self.cpn_ipv6 = self.config['cpn_ipv6']
                 self.hardware = self.config['hardware']
                 if 'ctl_privkey' in self.config:
                     self.ctl_privkey = self.config['ctl_privkey']
@@ -425,9 +428,11 @@ class FaucetTestBase(unittest.TestCase):
     def start_net(self):
         """Start Mininet network."""
         controller_intf = 'lo'
+        controller_ipv6 = False
         if self.hw_switch:
             controller_intf = self.cpn_intf
-        self._start_faucet(controller_intf)
+            controller_ipv6 = self.cpn_ipv6
+        self._start_faucet(controller_intf, controller_ipv6)
         self.pre_start_net()
         if self.hw_switch:
             self._attach_physical_switch()
@@ -464,7 +469,7 @@ class FaucetTestBase(unittest.TestCase):
                             port, port_name)
         return self._start_gauge_check()
 
-    def _start_faucet(self, controller_intf):
+    def _start_faucet(self, controller_intf, controller_ipv6):
         last_error_txt = ''
         assert self.net is None # _start_faucet() can't be multiply called
         for _ in range(3):
@@ -481,6 +486,7 @@ class FaucetTestBase(unittest.TestCase):
                 controller=self.CONTROLLER_CLASS(
                     name='faucet', tmpdir=self.tmpdir,
                     controller_intf=controller_intf,
+                    controller_ipv6=controller_ipv6,
                     env=self.env['faucet'],
                     ctl_privkey=self.ctl_privkey,
                     ctl_cert=self.ctl_cert,
@@ -496,6 +502,7 @@ class FaucetTestBase(unittest.TestCase):
                     name='gauge', tmpdir=self.tmpdir,
                     env=self.env['gauge'],
                     controller_intf=controller_intf,
+                    controller_ipv6=controller_ipv6,
                     ctl_privkey=self.ctl_privkey,
                     ctl_cert=self.ctl_cert,
                     ca_certs=self.ca_certs,

--- a/clib/mininet_test_topo.py
+++ b/clib/mininet_test_topo.py
@@ -263,6 +263,7 @@ class BaseFAUCET(Controller):
     # Set to True to have cProfile output to controller log.
     CPROFILE = False
     controller_intf = None
+    controller_ipv6 = False
     controller_ip = None
     pid_file = None
     tmpdir = None
@@ -282,18 +283,22 @@ maximum_unreplied_echo_requests=5
 socket_timeout=15
 """
 
-    def __init__(self, name, tmpdir, controller_intf=None, cargs='', **kwargs):
+    def __init__(self, name, tmpdir, controller_intf=None, controller_ipv6=False, cargs='', **kwargs):
         name = '%s-%u' % (name, os.getpid())
         self.tmpdir = tmpdir
         self.controller_intf = controller_intf
+        self.controller_ipv6 = controller_ipv6
         super(BaseFAUCET, self).__init__(
             name, cargs=self._add_cargs(cargs, name), **kwargs)
 
     def _add_cargs(self, cargs, name):
         ofp_listen_host_arg = ''
         if self.controller_intf is not None:
+            socket_type = socket.AF_INET
+            if self.controller_ipv6:
+                socket_type = socket.AF_INET6
             self.controller_ip = netifaces.ifaddresses( # pylint: disable=c-extension-no-member
-                self.controller_intf)[socket.AF_INET][0]['addr']
+                self.controller_intf)[socket_type][0]['addr']
             ofp_listen_host_arg = '--ryu-ofp-listen-host=%s' % self.controller_ip
         self.pid_file = os.path.join(self.tmpdir, name + '.pid')
         pid_file_arg = '--ryu-pid-file=%s' % self.pid_file
@@ -463,7 +468,7 @@ class FAUCET(BaseFAUCET):
 
     START_ARGS = ['--ryu-app=ryu.app.ofctl_rest']
 
-    def __init__(self, name, tmpdir, controller_intf, env,
+    def __init__(self, name, tmpdir, controller_intf, controller_ipv6, env,
                  ctl_privkey, ctl_cert, ca_certs,
                  ports_sock, prom_port, port, test_name, **kwargs):
         self.prom_port = prom_port
@@ -477,6 +482,7 @@ class FAUCET(BaseFAUCET):
             name,
             tmpdir,
             controller_intf,
+            controller_ipv6,
             cargs=cargs,
             command=self._command(env, tmpdir, name, ' '.join(self.START_ARGS)),
             port=port,
@@ -492,13 +498,13 @@ class FAUCET(BaseFAUCET):
 class Gauge(BaseFAUCET):
     """Start a Gauge controller."""
 
-    def __init__(self, name, tmpdir, controller_intf, env,
+    def __init__(self, name, tmpdir, controller_intf, controller_ipv6, env,
                  ctl_privkey, ctl_cert, ca_certs,
                  port, **kwargs):
         super(Gauge, self).__init__(
             name,
             tmpdir,
-            controller_intf,
+            controller_intf, controller_ipv6,
             cargs=self._tls_cargs(port, ctl_privkey, ctl_cert, ca_certs),
             command=self._command(env, tmpdir, name, '--gauge'),
             port=port,

--- a/hw_switch_config.yaml
+++ b/hw_switch_config.yaml
@@ -12,7 +12,9 @@ dp_ports:
 dpid: 0xeccd6d9936ed
 # Port on this machine that connects to hardware switch's CPN port.
 # Hardware switch must use IP address of this port as controller IP.
+# To use IPv6 address of the CPN port, set cpn_ipv6 to True
 cpn_intf: enp5s0
+cpn_ipv6: False
 # There must be two controllers configured on the hardware switch,
 # with same IP (see cpn_intf), but different ports - one for FAUCET,
 # one for Gauge.


### PR DESCRIPTION
By default, when the faucet test suite is running, it will use the IPv4 address of the CPN interface to start
the Faucet and the Gauge controllers.
By adding a new field to the hw_switch_config.yaml, the test code could use the IPv6 address of
the CPU interface instead of the IPv4 address.
The changes should be backward compatible. The field is optional and if not present, this means use the IPv4 address of the CPN interface.

A new member "controller_ipv6" is added to the class BaseFAUCET (along with the member "controller_intf"). This member will be initialized with the value set in the configuration file hw_switch_config.yaml
