### PR TITLE
Support for port remapping/randomization

### DIFF
--- a/clib/clib_mininet_tests.py
+++ b/clib/clib_mininet_tests.py
@@ -49,6 +49,7 @@ vlans:
             n_extended=self.N_EXTENDED, e_cls=self.EXTENDED_CLS,
             tmpdir=self.tmpdir, links_per_host=self.LINKS_PER_HOST,
             hw_dpid=self.hw_dpid)
+        self.port_map = self.create_port_map(self.dpid)
         self.start_net()
 
     def test_ping_all(self):


### PR DESCRIPTION
Add an option (`-p`) to the integration tests to specify OvS port numbers, either explicitly or randomly, defaulting to `random`.

We generate a list of random port numbers (`port_base`) which is extended as needed and used for allocating OvS port numbers in `FaucetSwitchTopo` and its subclass `FaucetStringOfDPSwitchTopo`.

The test classes call `FaucetTestBase.create_port_map(dpid)` which reads `self.topo` to create `port_maps[dpid]` and `port_map`, which is a shortcut for `port_maps[self.dpid]`.

Each port map (e.g. `port_maps[dpid]['port_1']`) tells you the actual OvS/OpenFlow port number for `port_n` on `dpid`, allowing tests to use virtual port identifiers (`port_1`...) rather than fixed numbers.

At the moment I am restarting the allocation for each switch, and the switch-to-switch ports are allocated sequentially after the host ports, but probably every port should be allocated from `port_base`.
