### PR TITLE
Clone dyn_ port state on reconfigure

### DIFF
--- a/faucet/dp.py
+++ b/faucet/dp.py
@@ -338,7 +338,7 @@ configuration.
         logger.info('Clone ports %s to %s' % (prev_dp.ports.keys(), self.ports.keys()))
         for port in prev_dp.ports:
             if port in self.ports:
-                self.ports[port].clone_dyn_state(prev_dp.ports[port])
+                self.ports[port].clone_dyn_state(prev_dp.ports[port], logger)
 
     def check_config(self):
         super(DP, self).check_config()

--- a/faucet/dp.py
+++ b/faucet/dp.py
@@ -331,14 +331,13 @@ configuration.
     def __str__(self):
         return self.name
 
-    def clone_dyn_state(self, prev_dp, logger):
+    def clone_dyn_state(self, prev_dp):
         self.dyn_running = prev_dp.dyn_running
         self.dyn_up_port_nos = set(prev_dp.dyn_up_port_nos)
         self.dyn_last_coldstart_time = prev_dp.dyn_last_coldstart_time
-        logger.info('Clone ports %s to %s' % (prev_dp.ports.keys(), self.ports.keys()))
         for port in prev_dp.ports:
             if port in self.ports:
-                self.ports[port].clone_dyn_state(prev_dp.ports[port], logger)
+                self.ports[port].clone_dyn_state(prev_dp.ports[port])
 
     def check_config(self):
         super(DP, self).check_config()

--- a/faucet/dp.py
+++ b/faucet/dp.py
@@ -331,6 +331,11 @@ configuration.
     def __str__(self):
         return self.name
 
+    def clone_dyn_state(self, prev_dp):
+        self.dyn_running = prev_dp.dyn_running
+        self.dyn_up_port_nos = set(prev_dp.dyn_up_port_nos)
+        self.dyn_last_coldstart_time = prev_dp.dyn_last_coldstart_time
+
     def check_config(self):
         super(DP, self).check_config()
         test_config_condition(not isinstance(self.dp_id, int), (

--- a/faucet/dp.py
+++ b/faucet/dp.py
@@ -331,10 +331,14 @@ configuration.
     def __str__(self):
         return self.name
 
-    def clone_dyn_state(self, prev_dp):
+    def clone_dyn_state(self, prev_dp, logger):
         self.dyn_running = prev_dp.dyn_running
         self.dyn_up_port_nos = set(prev_dp.dyn_up_port_nos)
         self.dyn_last_coldstart_time = prev_dp.dyn_last_coldstart_time
+        logger.info('Clone ports %s to %s' % (prev_dp.ports.keys(), self.ports.keys()))
+        for port in prev_dp.ports:
+            if port in self.ports:
+                self.ports[port].clone_dyn_state(prev_dp.ports[port])
 
     def check_config(self):
         super(DP, self).check_config()

--- a/faucet/port.py
+++ b/faucet/port.py
@@ -189,8 +189,18 @@ class Port(Conf):
         self._set_default('description', self.name)
         self._set_default('tagged_vlans', [])
 
-    def clone_dyn_state(self, old_port):
-        pass
+    def clone_dyn_state(self, old_port, logger):
+        self.dyn_dot1x_native_vlan = old_port.dyn_dot1x_native_vlan
+        self.dyn_lacp_up = old_port.dyn_lacp_up
+        self.dyn_lacp_updated_time = old_port.dyn_lacp_updated_time
+        self.dyn_last_ban_time = old_port.dyn_last_ban_time
+        self.dyn_last_lacp_pkt = old_port.dyn_last_lacp_pkt
+        self.dyn_last_lldp_beacon_time = old_port.dyn_last_lldp_beacon_time
+        self.dyn_learn_ban_count = old_port.dyn_learn_ban_count
+        self.dyn_phys_up = old_port.dyn_phys_up
+        self.dyn_stack_current_state = old_port.dyn_stack_current_state
+        self.dyn_stack_probe_info = old_port.dyn_stack_probe_info.copy()
+        logger.info('Port %s dyn_lacp_up %s' % (self.number, self.dyn_lacp_up))
 
     def check_config(self):
         super(Port, self).check_config()

--- a/faucet/port.py
+++ b/faucet/port.py
@@ -189,6 +189,9 @@ class Port(Conf):
         self._set_default('description', self.name)
         self._set_default('tagged_vlans', [])
 
+    def clone_dyn_state(self, old_port):
+        pass
+
     def check_config(self):
         super(Port, self).check_config()
         test_config_condition(not (isinstance(self.number, int) and self.number > 0 and (

--- a/faucet/port.py
+++ b/faucet/port.py
@@ -189,7 +189,7 @@ class Port(Conf):
         self._set_default('description', self.name)
         self._set_default('tagged_vlans', [])
 
-    def clone_dyn_state(self, old_port, logger):
+    def clone_dyn_state(self, old_port):
         self.dyn_dot1x_native_vlan = old_port.dyn_dot1x_native_vlan
         self.dyn_lacp_up = old_port.dyn_lacp_up
         self.dyn_lacp_updated_time = old_port.dyn_lacp_updated_time
@@ -200,7 +200,6 @@ class Port(Conf):
         self.dyn_phys_up = old_port.dyn_phys_up
         self.dyn_stack_current_state = old_port.dyn_stack_current_state
         self.dyn_stack_probe_info = old_port.dyn_stack_probe_info.copy()
-        logger.info('Port %s dyn_lacp_up %s' % (self.number, self.dyn_lacp_up))
 
     def check_config(self):
         super(Port, self).check_config()

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -142,10 +142,6 @@ class Valve:
 
     def dp_init(self, new_dp=None):
         """Initialize datapath state at connection/re/config time."""
-        if new_dp:
-            self.logger('TAP clone_dyn_state %s' % self.dp.dp_id)
-            new_dp.clone_dyn_state(self.dp, self.logger)
-            self.dp = new_dp
         self.close_logs()
         self.logger = ValveLogger(
             logging.getLogger(self.logname + '.valve'), self.dp.dp_id, self.dp.name)
@@ -157,6 +153,11 @@ class Valve:
         self._route_manager_by_ipv = {}
         self._route_manager_by_eth_type = {}
         self._port_highwater = {}
+
+        if new_dp:
+            self.logger.info('TAP clone_dyn_state %s' % self.dp.dp_id)
+            new_dp.clone_dyn_state(self.dp, self.logger)
+            self.dp = new_dp
 
         self.dp.reset_refs()
 

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -142,6 +142,10 @@ class Valve:
 
     def dp_init(self, new_dp=None):
         """Initialize datapath state at connection/re/config time."""
+        if new_dp:
+            new_dp.clone_dyn_state(self.dp)
+            self.dp = new_dp
+
         self.close_logs()
         self.logger = ValveLogger(
             logging.getLogger(self.logname + '.valve'), self.dp.dp_id, self.dp.name)
@@ -153,11 +157,6 @@ class Valve:
         self._route_manager_by_ipv = {}
         self._route_manager_by_eth_type = {}
         self._port_highwater = {}
-
-        if new_dp:
-            self.logger.info('TAP clone_dyn_state %s' % self.dp.dp_id)
-            new_dp.clone_dyn_state(self.dp, self.logger)
-            self.dp = new_dp
 
         self.dp.reset_refs()
 
@@ -1471,7 +1470,6 @@ class Valve:
         Returns:
             ofmsgs (list): OpenFlow messages.
         """
-        self.logger.info('TAP reload_config %s' % self.dp.dp_id)
         cold_start, ofmsgs = self._apply_config_changes(
             new_dp, self.dp.get_config_changes(self.logger, new_dp))
         restart_type = None

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -143,7 +143,7 @@ class Valve:
     def dp_init(self, new_dp=None):
         """Initialize datapath state at connection/re/config time."""
         if new_dp:
-            self.logger('TAP clone_dyn_state' % self.dp.dp_id)
+            self.logger('TAP clone_dyn_state %s' % self.dp.dp_id)
             new_dp.clone_dyn_state(self.dp, self.logger)
             self.dp = new_dp
         self.close_logs()

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -144,7 +144,7 @@ class Valve:
         """Initialize datapath state at connection/re/config time."""
         if new_dp:
             self.logger('TAP clone_dyn_state' % self.dp.dp_id)
-            new_dp.clone_dyn_state(self.dp)
+            new_dp.clone_dyn_state(self.dp, self.logger)
             self.dp = new_dp
         self.close_logs()
         self.logger = ValveLogger(

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -140,8 +140,12 @@ class Valve:
             valve_util.close_logger(self.logger.logger)
         valve_util.close_logger(self.ofchannel_logger)
 
-    def dp_init(self):
+    def dp_init(self, new_dp=None):
         """Initialize datapath state at connection/re/config time."""
+        if new_dp:
+            self.logger('TAP clone_dyn_state' % self.dp.dp_id)
+            new_dp.clone_dyn_state(self.dp)
+            self.dp = new_dp
         self.close_logs()
         self.logger = ValveLogger(
             logging.getLogger(self.logname + '.valve'), self.dp.dp_id, self.dp.name)
@@ -1406,14 +1410,12 @@ class Valve:
 
         if self._pipeline_change():
             self.logger.info('pipeline change')
-            self.dp = new_dp
-            self.dp_init()
+            self.dp_init(new_dp)
             return True, []
 
         if all_ports_changed:
             self.logger.info('all ports changed')
-            self.dp = new_dp
-            self.dp_init()
+            self.dp_init(new_dp)
             return True, []
 
         all_up_port_nos = [
@@ -1434,8 +1436,7 @@ class Valve:
             self.logger.info('ports changed/added: %s' % changed_ports)
             ofmsgs.extend(self.ports_delete(changed_ports))
 
-        self.dp = new_dp
-        self.dp_init()
+        self.dp_init(new_dp)
 
         if changed_vlans:
             self.logger.info('VLANs changed/added: %s' % changed_vlans)
@@ -1469,14 +1470,9 @@ class Valve:
         Returns:
             ofmsgs (list): OpenFlow messages.
         """
-        dp_running = self.dp.dyn_running
-        up_ports = self.dp.dyn_up_port_nos
-        coldstart_time = self.dp.dyn_last_coldstart_time
+        self.logger.info('TAP reload_config %s' % self.dp.dp_id)
         cold_start, ofmsgs = self._apply_config_changes(
             new_dp, self.dp.get_config_changes(self.logger, new_dp))
-        self.dp.dyn_running = dp_running
-        self.dp.dyn_up_port_nos = up_ports
-        self.dp.dyn_last_coldstart_time = coldstart_time
         restart_type = None
         if cold_start:
             restart_type = 'cold'

--- a/tests/integration/mininet_tests.py
+++ b/tests/integration/mininet_tests.py
@@ -6876,8 +6876,10 @@ class FaucetStringOfDPLACPUntaggedTest(FaucetStringOfDPTest):
         self.reload_conf(conf, self.faucet_config_path,
                          restart=True, cold_start=False, change_expected=False)
 
-        self.wait_for_lacp_port_down(src_port, self.dpids[0], 'faucet-1')
+        self.faucet_log('waiting for port %d up' % dst_port)
         self.wait_for_lacp_port_up(dst_port, self.dpids[0], 'faucet-1')
+        self.faucet_log('waiting for port %d down' % src_port)
+        self.wait_for_lacp_port_down(src_port, self.dpids[0], 'faucet-1')
 
 
 class FaucetStackStringOfDPUntaggedTest(FaucetStringOfDPTest):

--- a/tests/integration/mininet_tests.py
+++ b/tests/integration/mininet_tests.py
@@ -6830,7 +6830,7 @@ class FaucetStringOfDPLACPUntaggedTest(FaucetStringOfDPTest):
             self.match_bcast, self._FLOOD_TABLE, actions=[self.action_str % remote_first_lacp_port],
             dpid=self.dpids[1])
 
-    def Xtest_lacp_port_down(self):
+    def test_lacp_port_down(self):
         """LACP to switch to a working port when the primary port fails."""
         first_lacp_port, second_lacp_port = self.non_host_ports(self.dpid)
         remote_first_lacp_port, remote_second_lacp_port = self.non_host_ports(self.dpids[1])
@@ -6847,39 +6847,31 @@ class FaucetStringOfDPLACPUntaggedTest(FaucetStringOfDPTest):
         self.retry_net_ping()
         self.set_port_up(first_lacp_port)
 
-    def Xtest_untagged(self):
+    def test_untagged(self):
         """All untagged hosts in stack topology can reach each other."""
         for _ in range(3):
             self.wait_for_all_lacp_up()
             self.verify_stack_hosts()
             self.flap_all_switch_ports()
 
-    def faucet_log(self, message):
-        faucet_log = os.path.join(self.tmpdir, 'faucet.log')
-        with open(faucet_log, 'a+') as input_stream:
-            input_stream.write(message + '\n')
-
-    def test_passthrough(self):
-        """Test lacp passthrough on port fail."""
+    def test_dyn_fail(self):
+        """Test lacp fail on reload with dynamic lacp status."""
 
         conf = self._get_faucet_conf()
         src_port = self.non_host_ports(self.dpids[0])[0]
         dst_port = self.non_host_ports(self.dpids[0])[1]
         fail_port = self.non_host_ports(self.dpids[1])[0]
-        end_port = self.non_host_ports(self.dpids[1])[1]
 
-        self.wait_for_all_lacp_up()
-        self.verify_stack_hosts()
+        self.wait_for_lacp_port_up(src_port, self.dpids[0], 'faucet-1')
+        self.wait_for_lacp_port_up(dst_port, self.dpids[0], 'faucet-1')
 
         conf['dps']['faucet-2']['interfaces'][fail_port]['lacp'] = 0
         conf['dps']['faucet-2']['interfaces'][fail_port]['lacp_active'] = False
-        self.reload_conf(conf, self.faucet_config_path,
-                         restart=True, cold_start=False, change_expected=False)
+        self.reload_conf(conf, self.faucet_config_path, restart=True,
+                         cold_start=False, change_expected=False)
 
-        self.faucet_log('waiting for port %d up' % dst_port)
-        self.wait_for_lacp_port_up(dst_port, self.dpids[0], 'faucet-1')
-        self.faucet_log('waiting for port %d down' % src_port)
         self.wait_for_lacp_port_down(src_port, self.dpids[0], 'faucet-1')
+        self.wait_for_lacp_port_up(dst_port, self.dpids[0], 'faucet-1')
 
 
 class FaucetStackStringOfDPUntaggedTest(FaucetStringOfDPTest):


### PR DESCRIPTION
Fixes problem where the dyn_ state of ports is not maintained on reconfiguration. This manifests itself as part of lacp state management, which is where the triggering test resides.