### PR TITLE
Smoke tests for hardware tests

### DIFF
--- a/clib/clib_mininet_test_main.py
+++ b/clib/clib_mininet_test_main.py
@@ -125,8 +125,8 @@ def import_hw_config():
         }
         unknown_keys = set(config.keys()) - set(required_config.keys())
         if unknown_keys:
-            print('unknown config %s in %s' % (unknown_keys, config_file_name)
-            sys.exit(-1)
+            print('unknown config %s in %s' % (unknown_keys, config_file_name))
+            sys.exit(1)
         for required_key, required_key_types in required_config.items():
             if required_key not in config:
                 print('%s must be specified in %s to use HW switch.' % (

--- a/clib/clib_mininet_test_main.py
+++ b/clib/clib_mininet_test_main.py
@@ -113,25 +113,25 @@ def import_hw_config():
     except IOError:
         print('Could not load YAML config data from %s' % config_file_name)
         sys.exit(-1)
-    if 'hw_switch' in config:
-        hw_switch = config['hw_switch']
-        if not isinstance(hw_switch, bool):
-            print('hw_switch must be a bool: ' % hw_switch)
-            sys.exit(-1)
-        if not hw_switch:
-            return None
+    if config.get('hw_switch', False):
         required_config = {
             'dp_ports': (dict,),
             'cpn_intf': (str,),
             'dpid': (int,),
+            'hardware': (str,),
+            'hw_switch': (bool,),
             'of_port': (int,),
             'gauge_of_port': (int,),
         }
+        unknown_keys = set(config.keys()) - set(required_config.keys())
+        if unknown_keys:
+            print('unknown config %s in %s' % (unknown_keys, config_file_name)
+            sys.exit(-1)
         for required_key, required_key_types in required_config.items():
             if required_key not in config:
                 print('%s must be specified in %s to use HW switch.' % (
                     required_key, config_file_name))
-                sys.exit(-1)
+                sys.exit(1)
             required_value = config[required_key]
             key_type_ok = False
             for key_type in required_key_types:
@@ -148,6 +148,7 @@ def import_hw_config():
             print('Exactly %u dataplane ports are required, '
                   '%d are provided in %s.' %
                   (REQUIRED_TEST_PORTS, len(dp_ports), config_file_name))
+            sys.exit(1)
         return config
     return None
 

--- a/clib/mininet_test_base.py
+++ b/clib/mininet_test_base.py
@@ -467,7 +467,8 @@ class FaucetTestBase(unittest.TestCase):
     def _start_faucet(self, controller_intf, controller_ipv6):
         last_error_txt = ''
         assert self.net is None # _start_faucet() can't be multiply called
-        for _ in range(3):
+        # TODO: restore retries
+        for _ in range(1):
             mininet_test_util.return_free_ports(
                 self.ports_sock, self._test_name())
             self._allocate_config_ports()

--- a/clib/mininet_test_base.py
+++ b/clib/mininet_test_base.py
@@ -467,8 +467,7 @@ class FaucetTestBase(unittest.TestCase):
     def _start_faucet(self, controller_intf, controller_ipv6):
         last_error_txt = ''
         assert self.net is None # _start_faucet() can't be multiply called
-        # TODO: restore retries
-        for _ in range(1):
+        for _ in range(3):
             mininet_test_util.return_free_ports(
                 self.ports_sock, self._test_name())
             self._allocate_config_ports()

--- a/docker/runtests.sh
+++ b/docker/runtests.sh
@@ -106,7 +106,9 @@ if [ "$HWTESTS" == 1 ] ; then
   for p in `seq 2 5` ; do
     HWP="hwp$p"
     PHWP="p$HWP"
-    sudo ip link add dev $HWP type veth peer name $PHWP && ifconfig $PHWP up && sudo ovs-vsctl add-port hwbr $PHWP || exit 1
+    sudo ip link add dev $HWP type veth peer name $PHWP && \
+      ifconfig $PHWP up && \ 
+      sudo ovs-vsctl add-port hwbr $PHWP -- set interface $PHWP ofport_request=${p} || exit 1
     DP_PORTS="  ${p}: ${HWP}${N}${DP_PORTS}"
   done
   cat > /tmp/hw_switch_config.yaml << EOL

--- a/docker/runtests.sh
+++ b/docker/runtests.sh
@@ -106,9 +106,7 @@ if [ "$HWTESTS" == 1 ] ; then
   for p in `seq 2 5` ; do
     HWP="hwp$p"
     PHWP="p$HWP"
-    sudo ip link add dev $HWP type veth peer name $PHWP && \
-      ifconfig $PHWP up && \ 
-      sudo ovs-vsctl add-port hwbr $PHWP -- set interface $PHWP ofport_request=${p} || exit 1
+    ip link add dev $HWP type veth peer name $PHWP && ifconfig $PHWP up && ovs-vsctl add-port hwbr $PHWP -- set interface $PHWP ofport_request=$p || exit 1
     DP_PORTS="  ${p}: ${HWP}${N}${DP_PORTS}"
   done
   cat > /tmp/hw_switch_config.yaml << EOL

--- a/docker/runtests.sh
+++ b/docker/runtests.sh
@@ -102,8 +102,8 @@ if [ "$HWTESTS" == 1 ] ; then
   DPID='0x'`sudo ovs-vsctl get bridge hwbr datapath-id|sed 's/"//g'`
   DP_PORTS=""
   N=$'\n'
-  # TODO: randomize OF port range
-  for p in `seq 2 6` ; do
+  # TODO: randomize OF port range (offset from 1 for basic test)
+  for p in `seq 2 5` ; do
     HWP="hwp$p"
     PHWP="p$HWP"
     sudo ip link add dev $HWP type veth peer name $PHWP && ifconfig $PHWP up && sudo ovs-vsctl add-port hwbr $PHWP || exit 1

--- a/travis/runtests.sh
+++ b/travis/runtests.sh
@@ -68,8 +68,7 @@ fi
 if [[ "$FILES_CHANGED" != "" ]] ; then
   if [[ "$PY_FILES_CHANGED" == "" && "$RQ_FILES_CHANGED" == "" ]] ; then
     echo Not running docker tests because only non-python/requirements changes: $FILES_CHANGED
-    # TODO: Re-enable.
-    # exit 0
+    exit 0
   else
     echo python/requirements changes: $PY_FILES_CHANGED $RQ_FILES_CHANGED
   fi
@@ -93,7 +92,7 @@ sudo modprobe ebtables
 if [ "${MATRIX_SHARD}" == "sanity" ] ; then
   # Simulate hardware test switch
   # TODO: run a standalone DP and also a stacked DP test to test hardware linkages.
-  sudo docker run $SHARDARGS -e FAUCET_TESTS="-ni FaucetUntaggedTest FaucetStackStringOfDPUntaggedTest" -e HWTESTS="1" -t ${FAUCET_TEST_IMG} || exit 1
+  sudo docker run $SHARDARGS -e FAUCET_TESTS="-ni FaucetSanityTest FaucetStackStringOfDPUntaggedTest" -e HWTESTS="1" -t ${FAUCET_TEST_IMG} || exit 1
 fi
 
 sudo docker run $SHARDARGS -e PY_FILES_CHANGED="${PY_FILES_CHANGED}" -e FAUCET_TESTS="${FAUCET_TESTS}" -t ${FAUCET_TEST_IMG} || exit 1

--- a/travis/runtests.sh
+++ b/travis/runtests.sh
@@ -68,7 +68,8 @@ fi
 if [[ "$FILES_CHANGED" != "" ]] ; then
   if [[ "$PY_FILES_CHANGED" == "" && "$RQ_FILES_CHANGED" == "" ]] ; then
     echo Not running docker tests because only non-python/requirements changes: $FILES_CHANGED
-    exit 0
+    # TODO: Re-enable.
+    # exit 0
   else
     echo python/requirements changes: $PY_FILES_CHANGED $RQ_FILES_CHANGED
   fi
@@ -92,7 +93,7 @@ sudo modprobe ebtables
 if [ "${MATRIX_SHARD}" == "sanity" ] ; then
   # Simulate hardware test switch
   # TODO: run a standalone DP and also a stacked DP test to test hardware linkages.
-  sudo docker run $SHARDARGS -e FAUCET_TESTS="-ni FaucetSanityTest FaucetStackStringOfDPUntaggedTest" -e HWTESTS="1" -t ${FAUCET_TEST_IMG} || exit 1
+  sudo docker run $SHARDARGS -e FAUCET_TESTS="-ni FaucetUntaggedTest FaucetStackStringOfDPUntaggedTest" -e HWTESTS="1" -t ${FAUCET_TEST_IMG} || exit 1
 fi
 
 sudo docker run $SHARDARGS -e PY_FILES_CHANGED="${PY_FILES_CHANGED}" -e FAUCET_TESTS="${FAUCET_TESTS}" -t ${FAUCET_TEST_IMG} || exit 1

--- a/travis/runtests.sh
+++ b/travis/runtests.sh
@@ -68,8 +68,7 @@ fi
 if [[ "$FILES_CHANGED" != "" ]] ; then
   if [[ "$PY_FILES_CHANGED" == "" && "$RQ_FILES_CHANGED" == "" ]] ; then
     echo Not running docker tests because only non-python/requirements changes: $FILES_CHANGED
-    # TODO: re-enable for python.
-    # exit 0
+    exit 0
   else
     echo python/requirements changes: $PY_FILES_CHANGED $RQ_FILES_CHANGED
   fi

--- a/travis/runtests.sh
+++ b/travis/runtests.sh
@@ -68,8 +68,7 @@ fi
 if [[ "$FILES_CHANGED" != "" ]] ; then
   if [[ "$PY_FILES_CHANGED" == "" && "$RQ_FILES_CHANGED" == "" ]] ; then
     echo Not running docker tests because only non-python/requirements changes: $FILES_CHANGED
-    # TODO: always run tests for dev.
-    # exit 0
+    exit 0
   else
     echo python/requirements changes: $PY_FILES_CHANGED $RQ_FILES_CHANGED
   fi
@@ -92,10 +91,10 @@ sudo modprobe openvswitch
 sudo modprobe ebtables
 
 if [ "${MATRIX_SHARD}" == "sanity" ] ; then
-  sudo docker run $SHARDARGS -e FAUCET_TESTS="-ni FaucetUntaggedTest" -e HWTESTS="1" -t ${FAUCET_TEST_IMG}
+  # Simulate hardware test switch
+  # TODO: run a standalone DP and also a stacked DP test to test hardware linkages.
+  sudo docker run $SHARDARGS -e FAUCET_TESTS="-ni FaucetSanityTest FaucetStackStringOfDPUntaggedTest" -e HWTESTS="1" -t ${FAUCET_TEST_IMG}
 fi
-
-exit 0
 
 sudo docker run $SHARDARGS -e FAUCET_TESTS="${FAUCET_TESTS}" -t ${FAUCET_TEST_IMG} || exit 1
 

--- a/travis/runtests.sh
+++ b/travis/runtests.sh
@@ -82,8 +82,10 @@ docker images
 SHARDARGS="--privileged --sysctl net.ipv6.conf.all.disable_ipv6=0 \
   --ulimit core=99999999999:99999999999 \
   -v /var/local/lib/docker:/var/lib/docker \
-  -v $HOME/.cache/pip:/var/tmp/pip-cache \
-  -e PY_FILES_CHANGED=\"${PY_FILES_CHANGED}\""
+  -v $HOME/.cache/pip:/var/tmp/pip-cache
+
+# TODO: re-add changed files.
+# -e PY_FILES_CHANGED=\"${PY_FILES_CHANGED}\""
 echo Shard $MATRIX_SHARD: $FAUCETTESTS: $SHARDARGS
 
 ulimit -c unlimited && sudo echo '/var/tmp/core.%h.%e.%t' > /proc/sys/kernel/core_pattern


### PR DESCRIPTION
We need tests, for hardware tests.

Apart from stronger hardware test config checks, this implements CI-friendly tests for the hardware tests (simulating the hardware test switch with an OVS switch).

We only test that the hardware linkages basically work with a standalone DP test and one stacking test. This should catch catastrophic hardware testing bugs.

However it is possible to select simulated hardware switches with HWTESTS=1, enabling a full run locally.
