### PR TITLE
Move test_topo.py into tests/integration

### DIFF
--- a/docker/runtests.sh
+++ b/docker/runtests.sh
@@ -92,6 +92,7 @@ export FAUCET_DIR=/faucet-src/faucet
 export http_proxy=
 
 cd /faucet-src/tests/integration
+./test_topo.py
 ./mininet_main.py -c
 
 

--- a/tests/integration/test_topo.py
+++ b/tests/integration/test_topo.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 """Unit tests for Mininet Topologies in mininet_test_topo"""
 
 from unittest import TestCase, main

--- a/tests/run_integration_tests.sh
+++ b/tests/run_integration_tests.sh
@@ -7,4 +7,5 @@ export FAUCET_DIR=$PWD/../faucet
 export PYTHONPATH=$PWD/..:$PWD/../clib
 
 cd integration
+./test_topo.py
 rm -rf /tmp/faucet*log /tmp/gauge*log /tmp/faucet-tests* /var/tmp/faucet-tests* $OVS_LOGDIR/* ; killall ryu-manager ; ./mininet_main.py -c ; /usr/local/share/openvswitch/scripts/ovs-ctl stop ; /usr/local/share/openvswitch/scripts/ovs-ctl start ; ./mininet_main.py $*


### PR DESCRIPTION
`test_topo.py` is a `clib` unit test, but we don't yet have a home for those.

This puts it into `tests/integration` but runs it before the actual integration tests.