### PR TITLE
Stack flooding fixes

### DIFF
--- a/faucet/valve_flood.py
+++ b/faucet/valve_flood.py
@@ -191,7 +191,7 @@ class ValveFloodManager(ValveManagerBase):
                      vlan, exclude_unicast, port)
                 if not port_output_ports:
                     continue
-                if (vlan_output_ports - set(port.number) == port_output_ports
+                if (vlan_output_ports - set([port.number]) == port_output_ports
                         and vlan_non_output_acts == port_non_output_acts):
                     # Delete a potentially existing port specific flow
                     # TODO: optimize, avoid generating delete for port if no existing flow.


### PR DESCRIPTION
* Broadcast loop check added to all stacking test cases.
* Ensure a possibly stale port-specific rule will be deleted when combinatorial port flood mode is not in use
* Sure traffic on a down stack link is explicitly blocked to remove the possibility of a brief loop between the port coming up and flows hitting the default rule, and FAUCET reacting to the port up message and sending the right flows.

Fixes https://github.com/faucetsdn/faucet/issues/3013