### PR TITLE
If we don't specify an explict version PBR will calculate from git tags.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,5 @@
 [metadata]
 name = faucet
-version = 1.9.10
 summary = Faucet is an OpenFlow controller that implements a layer 2 and layer 3 switch.
 license = Apache-2
 author = Faucet development team


### PR DESCRIPTION
This PR removes the need for preversioning after each release.