### PR TITLE
table manager API cleanup for flooding and 8021X

### DIFF
--- a/faucet/faucet_dot1x.py
+++ b/faucet/faucet_dot1x.py
@@ -324,7 +324,7 @@ class FaucetDot1x:
             flowmods.extend(acl_manager.add_authed_mac(port_num, mac_str))
 
         if vlan_name:
-            flowmods.extend(valve.add_dot1x_native_vlan(port_num, mac_str, vlan_name))
+            flowmods.extend(valve.add_dot1x_native_vlan(port_num, vlan_name))
 
         return flowmods
 
@@ -340,7 +340,7 @@ class FaucetDot1x:
         else:
             flowmods.extend(acl_manager.del_authed_mac(port_num, mac_str))
 
-        flowmods.extend(valve.del_dot1x_native_vlan(port_num, mac_str))
+        flowmods.extend(valve.del_dot1x_native_vlan(port_num))
 
         return flowmods
 

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -1476,6 +1476,7 @@ class Valve:
         if changed_vids:
             self.logger.info('VLANs changed/added: %s' % changed_vids)
             changed_vlans = [self.dp.vlans[vid] for vid in changed_vids]
+            # TODO: handle change versus add separately so can avoid delete first.
             ofmsgs.extend(self._del_vlans(changed_vlans))
             ofmsgs.extend(self._add_vlans(changed_vlans))
         if changed_ports:

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -1531,7 +1531,6 @@ class Valve:
         return [ofmsg]
 
     def _reset_dot1x_port_flood(self, port, vlans):
-        flood_table = self.dp.tables['flood']
         ofmsgs = []
         mirror_act = port.mirror_actions()
         ofmsgs.extend(self._port_add_vlans(port, mirror_act))

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -864,7 +864,7 @@ class Valve:
         if not cold_start:
             ofmsgs.extend(self.host_manager.del_port(port))
             for vlan in port.vlans():
-                ofmsgs.extend(self.flood_manager.update_vlan(vlan))
+                ofmsgs.extend(self.flood_manager.add_vlan(vlan))
         vlan_table = self.dp.tables['vlan']
         ofmsgs.append(vlan_table.flowdrop(
             match=vlan_table.match(in_port=port.number),
@@ -891,7 +891,7 @@ class Valve:
                 port.lacp, port, port.dyn_lacp_up))
         port.dyn_lacp_up = 1
         for vlan in port.vlans():
-            ofmsgs.extend(self.flood_manager.update_vlan(vlan))
+            ofmsgs.extend(self.flood_manager.add_vlan(vlan))
         self._reset_lacp_status(port)
         return ofmsgs
 

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -862,7 +862,9 @@ class Valve:
         port.dyn_lacp_updated_time = None
         port.dyn_lacp_last_resp_time = None
         if not cold_start:
-            ofmsgs.extend(self._warm_reconfig_port_vlans(port, port.vlans()))
+            ofmsgs.extend(self.host_manager.del_port(port))
+            for vlan in port.vlans():
+                ofmsgs.extend(self.flood_manager.update_vlan(vlan))
         vlan_table = self.dp.tables['vlan']
         ofmsgs.append(vlan_table.flowdrop(
             match=vlan_table.match(in_port=port.number),
@@ -888,7 +890,8 @@ class Valve:
             self.logger.info('LAG %u Port %s up (previous state %s)' % (
                 port.lacp, port, port.dyn_lacp_up))
         port.dyn_lacp_up = 1
-        self._warm_reconfig_port_vlans(port, port.vlans())
+        for vlan in port.vlans():
+            ofmsgs.extend(self.flood_manager.update_vlan(vlan))
         self._reset_lacp_status(port)
         return ofmsgs
 

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -866,7 +866,7 @@ class Valve:
             # Expire all hosts on this port.
             ofmsgs.extend(self.host_manager.del_port(port))
             for vlan in port.vlans():
-                ofmsgs.extend(self.flood_manager.add_vlan(vlan))
+                ofmsgs.extend(self.flood_manager.update_vlan(vlan))
         vlan_table = self.dp.tables['vlan']
         ofmsgs.append(vlan_table.flowdrop(
             match=vlan_table.match(in_port=port.number),
@@ -893,7 +893,7 @@ class Valve:
                 port.lacp, port, port.dyn_lacp_up))
         port.dyn_lacp_up = 1
         for vlan in port.vlans():
-            ofmsgs.extend(self.flood_manager.add_vlan(vlan))
+            ofmsgs.extend(self.flood_manager.update_vlan(vlan))
         self._reset_lacp_status(port)
         return ofmsgs
 
@@ -1535,8 +1535,7 @@ class Valve:
         mirror_act = port.mirror_actions()
         ofmsgs.extend(self._port_add_vlans(port, mirror_act))
         for vlan in vlans:
-            ofmsgs.extend(self.flood_manager.del_vlan(vlan))
-            ofmsgs.extend(self.flood_manager.add_vlan(vlan))
+            ofmsgs.extend(self.flood_manager.update_vlan(vlan))
         return ofmsgs
 
     def add_dot1x_native_vlan(self, port_num, eth_src, vlan_name):

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -1547,14 +1547,7 @@ class Valve:
             vlan = vlans[0]
             port.dyn_dot1x_native_vlan = vlan
             vlan.reset_ports(self.dp.ports.values())
-
-            eth_src_table = self.dp.tables['eth_src']
-            eth_dst_table = self.dp.tables['eth_dst']
-            ofmsgs.append(
-                eth_src_table.flowdel(eth_src_table.match(in_port=port_num, eth_src=eth_src)))
-            ofmsgs.append(
-                eth_dst_table.flowdel(eth_dst_table.match(eth_dst=eth_src), out_port=port_num))
-
+            ofmsgs.extend(self.host_manager.del_port(port))
             ofmsgs.extend(self._del_native_vlan(port))
             ofmsgs.extend(self._reset_dot1x_port_flood(
                 port, (port.dyn_dot1x_native_vlan, port.native_vlan)))

--- a/faucet/valve_flood.py
+++ b/faucet/valve_flood.py
@@ -265,6 +265,12 @@ class ValveFloodManager(ValveManagerBase):
     def add_vlan(self, vlan):
         return self.build_flood_rules(vlan)
 
+    def del_vlan(self, vlan):
+        return [self.flood_table.flowdel(self.flood_table.match(vlan=vlan.vid))]
+
+    def update_vlan(self, vlan):
+        return self.build_flood_rules(vlan, modify=True)
+
     def build_flood_rules(self, vlan, modify=False):
         """Add flows to flood packets to unknown destinations on a VLAN."""
         command = valve_of.ofp.OFPFC_ADD

--- a/faucet/valve_manager_base.py
+++ b/faucet/valve_manager_base.py
@@ -17,11 +17,15 @@ class ValveManagerBase: # pylint: disable=too-few-public-methods
     _FILTER_PRIORITY = 0x5000
 
     def initialise_tables(self):
-        '''initialise tables controlled by this manager'''
+        """initialise tables controlled by this manager."""
         return []
 
     def add_vlan(self, vlan):
-        """install flows in response to a new vlan"""
+        """install flows in response to a new VLAN"""
+        return []
+
+    def update_vlan(self, vlan):
+        """flows in response to updating an existing VLAN."""
         return []
 
     def add_port(self, port):
@@ -29,7 +33,7 @@ class ValveManagerBase: # pylint: disable=too-few-public-methods
         return []
 
     def del_vlan(self, vlan):
-        """delete flows in response to a vlan removal"""
+        """delete flows in response to a VLAN removal"""
         return []
 
     def del_port(self, port):


### PR DESCRIPTION
* Most knowledge about how the flood table is updated moved to the flood manager (introduced warm reconfig call update_vlan() to allow future further optimization)
* Host state handling (was incomplete anyway) moved from 8021X to host manager.
* pylint cleanup of unused LACP args
