### PR TITLE
- Fix some tests to avoid some failures on Cisco C9K

### DIFF
--- a/tests/integration/mininet_tests.py
+++ b/tests/integration/mininet_tests.py
@@ -4139,6 +4139,7 @@ acls:
 
 class FaucetUntaggedEgressACLTest(FaucetUntaggedTest):
 
+    REQUIRES_METADATA = True
     CONFIG_GLOBAL = """
 vlans:
     100:
@@ -6615,6 +6616,7 @@ class FaucetStringOfDPTest(FaucetTest):
             dp_config = {
                 'dp_id': int(dpid),
                 'hardware': hardware if dpid == hw_dpid else 'Open vSwitch',
+                'table_sizes': {'flood': 64},
                 'ofchannel_log': ofchannel_log + str(i) if ofchannel_log else None,
                 'interfaces': {},
                 'lldp_beacon': {'send_interval': 5, 'max_per_interval': 5},


### PR DESCRIPTION
The first part of the fix will indicate that the test "FaucetUntaggedEgressACLTest" is using metadata. As metadata is not supported on Cisco C9K switch, this test will not get executed for this platform.

The second part of the fix is increasing the flood table size to 64 flows. This will allow the tests "FaucetTunnelSameDpTest" and "FaucetTunnelTest" to run successfully. Indeed those two tests needs to install 34 flows in the flood table but by default the flood table is accepting as most 32 flows. 