### PR TITLE
Testing kill on exception

### DIFF
--- a/faucet/dp.py
+++ b/faucet/dp.py
@@ -414,6 +414,12 @@ configuration.
                     all_acls.setdefault('port_acl', [])
                     all_acls['port_acl'].extend(port.acls_in)
 
+                if self.dot1x and port.number == self.dot1x['nfv_sw_port']:
+                    test_config_condition(not port.output_only, (
+                        'NFV Ports must have output_only set to True.'
+                    ))
+
+
         table_config = {}
         for table_name, acls in all_acls.items():
             matches = {}

--- a/faucet/faucet.py
+++ b/faucet/faucet.py
@@ -110,7 +110,7 @@ class Faucet(RyuAppBase):
         self.bgp = faucet_bgp.FaucetBgp(
             self.logger, self.exc_logname, self.metrics, self._send_flow_msgs)
         self.dot1x = faucet_dot1x.FaucetDot1x(
-            self.logger, self.metrics, self._send_flow_msgs)
+            self.logger, self.exc_logname, self.metrics, self._send_flow_msgs)
         self.notifier = faucet_event.FaucetEventNotifier(
             self.get_setting('EVENT_SOCK'), self.metrics, self.logger)
         self.valves_manager = valves_manager.ValvesManager(

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -737,6 +737,15 @@ class Valve:
             for manager in self._get_managers():
                 ofmsgs.extend(manager.add_port(port))
 
+            if self.dp.dot1x:
+                nfv_sw_port = self.dp.ports[self.dp.dot1x['nfv_sw_port']]
+                if port == nfv_sw_port:
+                    ofmsgs.extend(self.dot1x.nfv_sw_port_up(
+                        self.dp.dp_id, self.dp.dot1x_ports(), nfv_sw_port))
+                elif port.dot1x:
+                    ofmsgs.extend(self.dot1x.port_up(
+                        self.dp.dp_id, port, nfv_sw_port))
+
             if port.output_only:
                 ofmsgs.append(vlan_table.flowdrop(
                     match=vlan_table.match(in_port=port_num),
@@ -757,15 +766,6 @@ class Valve:
                 ofmsgs.extend(self.lacp_down(port, cold_start=cold_start))
                 if port.lacp_active:
                     ofmsgs.extend(self._lacp_actions(port.dyn_last_lacp_pkt, port))
-
-            if self.dp.dot1x:
-                nfv_sw_port = self.dp.ports[self.dp.dot1x['nfv_sw_port']]
-                if port == nfv_sw_port:
-                    ofmsgs.extend(self.dot1x.nfv_sw_port_up(
-                        self.dp.dp_id, self.dp.dot1x_ports(), nfv_sw_port))
-                elif port.dot1x:
-                    ofmsgs.extend(self.dot1x.port_up(
-                        self.dp.dp_id, port, nfv_sw_port))
 
             port_vlans = port.vlans()
 

--- a/tests/integration/mininet_tests.py
+++ b/tests/integration/mininet_tests.py
@@ -748,7 +748,7 @@ class Faucet8021XPortFlapTest(Faucet8021XBaseTest):
             self.try_8021x(
                 self.eapol1_host, port_no1, self.wpasupplicant_conf_1, and_logoff=False)
             self.one_ipv4_ping(
-                self.eapol1_host, self.nfv_host.IP(),
+                self.eapol1_host, self.ping_host.IP(),
                 require_host_learned=False, expected_result=False)
             wpa_status = self.get_wpa_status(self.eapol1_host, self.get_wpa_ctrl_path(self.eapol1_host))
             self.assertNotEqual('SUCCESS', wpa_status)
@@ -1126,18 +1126,15 @@ class Faucet8021XVLANTest(Faucet8021XSuccessTest):
         self.wait_until_matching_flow(
             {'vlan_vid': vid},
             table_id=self._FLOOD_TABLE,
-            actions=['POP_VLAN', 'OUTPUT:%s' % port_no2, 'OUTPUT:%s' % port_no4])
+            actions=['POP_VLAN', 'OUTPUT:%s' % port_no2])
         self.wait_until_no_matching_flow(
             {'vlan_vid': radius_vid2},
             table_id=self._FLOOD_TABLE,
-            actions=['POP_VLAN', 'OUTPUT:%s' % port_no1, 'OUTPUT:%s' % port_no2, 'OUTPUT:%s' % port_no4])
+            actions=['POP_VLAN', 'OUTPUT:%s' % port_no1, 'OUTPUT:%s' % port_no2])
 
         self.one_ipv4_ping(
             self.eapol1_host, self.ping_host.IP(),
             require_host_learned=False, expected_result=True)
-
-        self.one_ipv4_ping(self.eapol1_host, self.nfv_host.IP(),
-                           require_host_learned=False, expected_result=False)
 
         tcpdump_txt = self.try_8021x(
             self.eapol1_host, port_no1, self.wpasupplicant_conf_1, and_logoff=True)
@@ -1146,9 +1143,6 @@ class Faucet8021XVLANTest(Faucet8021XSuccessTest):
         self.one_ipv4_ping(
             self.eapol1_host, self.ping_host.IP(),
             require_host_learned=False, expected_result=False)
-
-        self.one_ipv4_ping(self.eapol1_host, self.nfv_host.IP(),
-                           require_host_learned=False, expected_result=False)
 
         # check ports are back in the right vlans.
         self.wait_until_no_matching_flow(
@@ -1169,7 +1163,7 @@ class Faucet8021XVLANTest(Faucet8021XSuccessTest):
         self.wait_until_matching_flow(
             {'vlan_vid': vid},
             table_id=self._FLOOD_TABLE,
-            actions=['POP_VLAN', 'OUTPUT:%s' % port_no1, 'OUTPUT:%s' % port_no2, 'OUTPUT:%s' % port_no4])
+            actions=['POP_VLAN', 'OUTPUT:%s' % port_no1, 'OUTPUT:%s' % port_no2])
 
         # check two 1x hosts play nicely. (same dyn vlan)
         tcpdump_txt = self.try_8021x(
@@ -1279,7 +1273,7 @@ class Faucet8021XVLANTest(Faucet8021XSuccessTest):
         self.wait_until_matching_flow(
             {'vlan_vid': vid},
             table_id=self._FLOOD_TABLE,
-            actions=['POP_VLAN', 'OUTPUT:%s' % port_no2, 'OUTPUT:%s' % port_no4])
+            actions=['POP_VLAN', 'OUTPUT:%s' % port_no2])
 
 
 class FaucetUntaggedRandomVidTest(FaucetUntaggedTest):

--- a/tests/integration/mininet_tests.py
+++ b/tests/integration/mininet_tests.py
@@ -209,7 +209,7 @@ vlans:
                 native_vlan: 100
                 # ping host.
             %(port_4)d:
-                native_vlan: 100
+                output_only: True
                 # "NFV host - interface used by controller."
 """
 
@@ -911,8 +911,7 @@ acls:
             %(port_4)d:
                 name: b4
                 description: "b4"
-
-                native_vlan: 100
+                output_only: True
                 # "NFV host - interface used by controller."
     """
 
@@ -981,7 +980,7 @@ class Faucet8021XMABTest(Faucet8021XSuccessTest):
                 native_vlan: 100
                 # ping host.
             %(port_4)d:
-                native_vlan: 100
+                output_only: True
                 # "NFV host - interface used by controller."
     """
 
@@ -1056,7 +1055,7 @@ class Faucet8021XVLANTest(Faucet8021XSuccessTest):
                 native_vlan: radiusassignedvlan1
                 # ping host.
             %(port_4)d:
-                native_vlan: 100
+                output_only: True
                 # "NFV host - interface used by controller."
     """
 

--- a/tests/unit/faucet/test_config.py
+++ b/tests/unit/faucet/test_config.py
@@ -3080,6 +3080,31 @@ dps:
 """
         self.check_config_success(config, cp.dp_parser)
 
+    def test_dot1x_nfv_port_config_invalid(self):
+        """Test valid dot1x."""
+        config = """
+vlans:
+    office:
+        vid: 100
+dps:
+    sw1:
+        dp_id: 0x1
+        dot1x:
+            nfv_intf: lo
+            nfv_sw_port: 2
+            radius_ip: ::1
+            radius_port: 123
+            radius_secret: SECRET
+        interfaces:
+            1:
+                native_vlan: office
+                dot1x: True
+            2:
+                output_only: False
+    """
+        self.check_config_failure(config, cp.dp_parser)
+
+
     def test_rule_acl_parse(self):
         """Test simple allow ACL."""
         config = """

--- a/tests/unit/faucet/test_valve.py
+++ b/tests/unit/faucet/test_valve.py
@@ -387,7 +387,7 @@ class ValveTestBases:
             self.bgp = faucet_bgp.FaucetBgp(
                 self.logger, logfile, self.metrics, self.send_flows_to_dp_by_id)
             self.dot1x = faucet_dot1x.FaucetDot1x(
-                self.logger, self.metrics, self.send_flows_to_dp_by_id)
+                self.logger, logfile, self.metrics, self.send_flows_to_dp_by_id)
             self.valves_manager = valves_manager.ValvesManager(
                 self.LOGNAME, self.logger, self.metrics, self.notifier,
                 self.bgp, self.dot1x, self.send_flows_to_dp_by_id)

--- a/tests/unit/faucet/test_valve.py
+++ b/tests/unit/faucet/test_valve.py
@@ -1631,9 +1631,6 @@ dps:
 vlans:
     v100:
         vid: 0x100
-    student:
-        vid: 0x200
-        dot1x_assigned: True
 """.format(DOT1X_CONFIG)
 
 


### PR DESCRIPTION
Add Kill On Exception flag to API for Chewie
BUGFIX: Enforce output_only restraint on nfv_sw_port
Add tests for restraint
Change Mininet dot1x tests to use restraint
Remove Invalid Usage of NFV Port from 8021XPortFlapTest and 8021XVLANTest