### PR TITLE
Latest exabgp strictly verifies routes can't be hosts.

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,7 +3,7 @@ bitstring
 codecov
 concurrencytest
 deb_pkg_tools
-exabgp==4.0.10
+exabgp==4.1.2
 importlab>=0.3.1
 netifaces
 packaging

--- a/tests/integration/mininet_tests.py
+++ b/tests/integration/mininet_tests.py
@@ -6463,11 +6463,11 @@ routers:
 
     exabgp_peer_conf = """
     static {
-      route fc00::10:1/112 next-hop fc00::1:1 local-preference 100;
-      route fc00::20:1/112 next-hop fc00::1:2 local-preference 100;
-      route fc00::30:1/112 next-hop fc00::1:2 local-preference 100;
-      route fc00::40:1/112 next-hop fc00::1:254;
-      route fc00::50:1/112 next-hop fc00::2:2;
+      route fc00::10:0/112 next-hop fc00::1:1 local-preference 100;
+      route fc00::20:0/112 next-hop fc00::1:2 local-preference 100;
+      route fc00::30:0/112 next-hop fc00::1:2 local-preference 100;
+      route fc00::40:0/112 next-hop fc00::1:254;
+      route fc00::50:0/112 next-hop fc00::2:2;
     }
 """
     exabgp_log = None


### PR DESCRIPTION
Allows us to use the latest exabgp again.