### PR TITLE
Later pytype has its own parallel run capability. 

### DIFF
--- a/tests/codecheck/pytype.sh
+++ b/tests/codecheck/pytype.sh
@@ -3,12 +3,11 @@
 FAUCETHOME=`dirname $0`"/../.."
 TMPDIR=`mktemp -d -p /var/tmp`
 CONFIG="$FAUCETHOME/setup.cfg"
-PARARGS="parallel --delay 1 --bar --halt now,fail=1 -j 2"
 PYTYPE=`which pytype`
-PYTYPEARGS="python3 $PYTYPE --config $CONFIG -o $TMPDIR/{/} {}"
 PYHEADER=`head -1 $PYTYPE`
 SRCFILES="$FAUCETHOME/tests/codecheck/src_files.sh $*"
+echo
 echo "Using $PYTYPE (header $PYHEADER)"
 
-$SRCFILES | shuf | $PARARGS $PYTYPEARGS || exit 1
+python3 $PYTYPE --config $CONFIG -o $TMPDIR/{/} `$SRCFILES | shuf`
 rm -rf $TMPDIR


### PR DESCRIPTION
Use that rather that rather than GNU parallel - much faster since running under GNU parallel can have a run time of 30m!

Reduces run time to about 7m.
