### PR TITLE
Lock scapy to 2.4.2.

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -11,4 +11,4 @@ pylint
 pytest-cov
 pytype==2019.7.11
 requests
-scapy
+scapy==2.4.2


### PR DESCRIPTION
Lock scapy to 2.4.2 so @renovatebot will tell us when 2.4.3 gets released