### PR TITLE
Verify that switch works after several disconnections

### DIFF
--- a/clib/mininet_test_base.py
+++ b/clib/mininet_test_base.py
@@ -2308,16 +2308,16 @@ dbs:
         exp_re = re.compile(exp)
         with open(log_name) as log_file:
             return [log_line for log_line in log_file if exp_re.match(log_line)]
-        return []
 
-    def wait_until_matching_lines_from_file(self, exp, log_name, timeout=30):
-        """Require matching lines to be present in file."""
+    def wait_until_matching_lines_from_file(self, exp, log_name, timeout=30, count=1):
+        """Require (count) matching lines to be present in file."""
+        assert timeout >= 1
         for _ in range(timeout):
             lines = self.matching_lines_from_file(exp, log_name)
-            if lines:
+            if len(lines) >= count:
                 return lines
             time.sleep(1)
-        self.fail('%s not found in %s' % (exp, log_name))
+        self.fail('%s not found in %s (%d/%d)' % (exp, log_name, len(lines), count))
 
     def exabgp_updates(self, exabgp_log, timeout=60):
         """Verify that exabgp process has received BGP updates."""


### PR DESCRIPTION
First we change the DPID to something incorrect and then wait for FAUCET to disconnect from the switch several times.

Then we restore the correct DPID, reload the config, and verify that `untagged_test()` still works.

Notes: 

Initially I was dissatisfied with this approach for a couple of reasons, but now I think maybe it isn't so bad. Most of the delay seems to be from waiting for the switch to reconnect and for performing the connectivity test. Even if we did this in another way, we would still have to wait for the switch to reconnect, which is a switch configuration, and we would still want to run the connectivity test. We could try a simpler/faster test however (e.g. just do the ping test.)