### PR TITLE
Enable inter-VLAN routing with stacking

### DIFF
--- a/clib/mininet_test_base.py
+++ b/clib/mininet_test_base.py
@@ -2076,15 +2076,17 @@ dbs:
             ip_dst.version, ip_dst.network.with_prefixlen, ip_gw)
         self.quiet_commands(host, (add_cmd,))
 
-    def _one_ip_ping(self, host, ping_cmd, retries, require_host_learned, expected_result=True):
+    def _ip_ping(self, host, ping_cmd, retries, require_host_learned, expected_result=True, count=1):
+        """Ping a destination from a host"""
+        good_ping = '%u packets transmitted, %u received, 0%% packet loss' % (count, count)
         if require_host_learned:
             self.require_host_learned(host)
         for _ in range(retries):
             ping_result = host.cmd(ping_cmd)
-            if re.search(self.ONE_GOOD_PING, ping_result):
+            if re.search(good_ping, ping_result):
                 break
         self.assertTrue(
-            bool(re.search(self.ONE_GOOD_PING, ping_result)) ^ (not expected_result),
+            bool(re.search(good_ping, ping_result)) ^ (not expected_result),
             msg='%s: %s' % (ping_cmd, ping_result))
 
     def one_ipv4_ping(self, host, dst, retries=3, require_host_learned=True, intf=None,
@@ -2097,7 +2099,7 @@ dbs:
         else:
             timeout = '-W%u' % timeout
         ping_cmd = 'ping -c1 %s -I%s %s' % (timeout, intf, dst)
-        return self._one_ip_ping(host, ping_cmd, retries, require_host_learned, expected_result)
+        return self._ip_ping(host, ping_cmd, retries, require_host_learned, expected_result, 1)
 
     def one_ipv4_controller_ping(self, host):
         """Ping the controller from a host with IPv4."""
@@ -2115,7 +2117,7 @@ dbs:
         else:
             timeout = '-W%u' % timeout
         ping_cmd = 'ping6 -c1 %s -I%s %s' % (timeout, intf, dst)
-        return self._one_ip_ping(host, ping_cmd, retries, require_host_learned, expected_result)
+        return self._ip_ping(host, ping_cmd, retries, require_host_learned, expected_result, 1)
 
     def one_ipv6_controller_ping(self, host):
         """Ping the controller from a host with IPv6."""

--- a/clib/mininet_test_topo.py
+++ b/clib/mininet_test_topo.py
@@ -262,7 +262,7 @@ class FaucetStringOfDPSwitchTopo(FaucetSwitchTopo):
         return links
 
     def build(self, ovs_type, ports_sock, test_name, dpids,
-              n_tagged=0, tagged_vid=100, n_untagged=0,
+              n_tagged=0, tagged_vid=100, untagged_hosts=None,
               links_per_host=0, switch_to_switch_links=1,
               hw_dpid=None, switch_map=None,
               stack_ring=False, start_port=SWITCH_START_PORT,
@@ -311,11 +311,12 @@ class FaucetStringOfDPSwitchTopo(FaucetSwitchTopo):
                 next_index[src] += 1
                 next_index[dst] += 1
 
+        num_untagged_hosts = sum(untagged_hosts.values()) if untagged_hosts else 0
         self.hw_dpid = hw_dpid
         self.hw_ports = sorted(switch_map) if switch_map else []
         self.start_port = start_port
         self.switch_to_switch_links = switch_to_switch_links
-        max_ports = (n_tagged + n_untagged) * links_per_host + 2*switch_to_switch_links
+        max_ports = (n_tagged + num_untagged_hosts) * links_per_host + 2*switch_to_switch_links
         self.port_order = self.extend_port_order(port_order, max_ports)
         self.switch_peer_links = {}
 
@@ -326,7 +327,7 @@ class FaucetStringOfDPSwitchTopo(FaucetSwitchTopo):
             tagged = [self._add_tagged_host(sid_prefix, tagged_vid, host_n)
                       for host_n in range(n_tagged)]
             untagged = [self._add_untagged_host(sid_prefix, host_n)
-                        for host_n in range(n_untagged)]
+                for host_n in range(num_untagged_hosts)]
             switch = self._add_faucet_switch(sid_prefix, dpid, hw_dpid, ovs_type)
             next_index[switch] = self._add_links(switch, tagged + untagged, links_per_host)
             if first_switch is None:

--- a/faucet/dp.py
+++ b/faucet/dp.py
@@ -717,9 +717,6 @@ configuration.
                         'stack priority must be > 0'))
                     test_config_condition(root_dp is not None, 'cannot have multiple stack roots')
                     root_dp = dp
-                    for vlan in dp.vlans.values():
-                        test_config_condition(vlan.faucet_vips, (
-                            'routing + stacking not supported'))
 
         if root_dp is None:
             test_config_condition(stack_dps, 'stacking enabled but no root_dp')

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -1110,12 +1110,10 @@ class Valve:
         """
         if pkt_meta.eth_src == pkt_meta.vlan.faucet_mac:
             return self.host_manager.learn_host_intervlan_routing_flows(
-                now, pkt_meta.port, pkt_meta.vlan, pkt_meta.eth_src, pkt_meta.eth_dst,
-                last_dp_coldstart_time=self.dp.dyn_last_coldstart_time)
+                now, pkt_meta.port, pkt_meta.vlan, pkt_meta.eth_src, pkt_meta.eth_dst)
         elif pkt_meta.eth_dst == pkt_meta.vlan.faucet_mac:
             return self.host_manager.learn_host_intervlan_routing_flows(
-                now, pkt_meta.port, pkt_meta.vlan, pkt_meta.eth_dst, pkt_meta.eth_src,
-                last_dp_coldstart_time=self.dp.dyn_last_coldstart_time)
+                now, pkt_meta.port, pkt_meta.vlan, pkt_meta.eth_dst, pkt_meta.eth_src)
         return []
 
     def _learn_host(self, now, other_valves, pkt_meta):

--- a/faucet/valve_flood.py
+++ b/faucet/valve_flood.py
@@ -596,9 +596,6 @@ class ValveFloodStackManager(ValveFloodManager):
         # We find just one port that is the shortest unicast path to
         # the destination. We could use other factors (eg we could
         # load balance over multiple ports based on destination MAC).
-        # TODO: each DP learns independently. An edge DP could
-        # call other valves so they learn immediately without waiting
-        # for packet in.
         # TODO: edge DPs could use a different forwarding algorithm
         # (for example, just default switch to a neighbor).
         # Find port that forwards closer to destination DP that
@@ -655,7 +652,8 @@ class ValveFloodStackManager(ValveFloodManager):
         self._reset_peer_distances()
 
     def edge_learn_port(self, other_valves, pkt_meta):
-        """Possibly learn a host on a port.
+        """
+        Find a port towards the edge DP where the packet originated from
 
         Args:
             other_valves (list): All Valves other than this one.

--- a/faucet/valve_host.py
+++ b/faucet/valve_host.py
@@ -173,8 +173,7 @@ class ValveHostManager(ValveManagerBase):
             has_externals = has_externals | bool(vlan.loop_protect_external_ports())
         return has_externals
 
-    def learn_host_intervlan_routing_flows(self, now, port, vlan,
-                                           eth_src, eth_dst, last_dp_coldstart_time=None):
+    def learn_host_intervlan_routing_flows(self, now, port, vlan, eth_src, eth_dst):
         """
         Returns flows for the eth_src_table that enable packets that have been routed to be
             accepted from an adjacent DP and then switched to the destination

--- a/faucet/valve_host.py
+++ b/faucet/valve_host.py
@@ -173,8 +173,9 @@ class ValveHostManager(ValveManagerBase):
             has_externals = has_externals | bool(vlan.loop_protect_external_ports())
         return has_externals
 
-    def learn_host_intervlan_routing_flows(self, now, port, vlan, eth_src, eth_dst, last_dp_coldstart_time=None):
-        """ 
+    def learn_host_intervlan_routing_flows(self, now, port, vlan,
+                                           eth_src, eth_dst, last_dp_coldstart_time=None):
+        """
         Returns flows for the eth_src_table that enable packets that have been routed to be
             accepted from an adjacent DP and then switched to the destination
         Eth_src_table flow rule to match on port, eth_src, eth_dst and vlan
@@ -188,8 +189,9 @@ class ValveHostManager(ValveManagerBase):
          src_rule_hard_timeout,
          _) = self.learn_host_timeouts(port)
         ofmsgs = []
-        ofmsgs.append(self.eth_src_table.flowdel(self.eth_src_table.match(vlan=vlan,eth_src=eth_src,eth_dst=eth_dst)))
-        src_match = self.eth_src_table.match(vlan=vlan,eth_src=eth_src,eth_dst=eth_dst)
+        ofmsgs.append(self.eth_src_table.flowdel(
+            self.eth_src_table.match(vlan=vlan, eth_src=eth_src, eth_dst=eth_dst)))
+        src_match = self.eth_src_table.match(vlan=vlan, eth_src=eth_src, eth_dst=eth_dst)
         src_priority = self.host_priority - 1
         inst = []
         inst.append(self.eth_src_table.goto(self.output_table))
@@ -198,7 +200,7 @@ class ValveHostManager(ValveManagerBase):
             priority=src_priority,
             inst=inst,
             hard_timeout=src_rule_hard_timeout,
-            idle_timeout=src_rule_idle_timeout)]) 
+            idle_timeout=src_rule_idle_timeout)])
         return ofmsgs
 
     def learn_host_on_vlan_port_flows(self, port, vlan, eth_src,

--- a/faucet/valve_host.py
+++ b/faucet/valve_host.py
@@ -173,6 +173,34 @@ class ValveHostManager(ValveManagerBase):
             has_externals = has_externals | bool(vlan.loop_protect_external_ports())
         return has_externals
 
+    def learn_host_intervlan_routing_flows(self, now, port, vlan, eth_src, eth_dst, last_dp_coldstart_time=None):
+        """ 
+        Returns flows for the eth_src_table that enable packets that have been routed to be
+            accepted from an adjacent DP and then switched to the destination
+        Eth_src_table flow rule to match on port, eth_src, eth_dst and vlan
+
+        Args:
+            vlan (VLAN): The VLAN to match on
+            eth_src: The source MAC address (should be the router MAC)
+            eth_dst: The destination MAC address
+        """
+        (src_rule_idle_timeout,
+         src_rule_hard_timeout,
+         _) = self.learn_host_timeouts(port)
+        ofmsgs = []
+        ofmsgs.append(self.eth_src_table.flowdel(self.eth_src_table.match(vlan=vlan,eth_src=eth_src,eth_dst=eth_dst)))
+        src_match = self.eth_src_table.match(vlan=vlan,eth_src=eth_src,eth_dst=eth_dst)
+        src_priority = self.host_priority - 1
+        inst = []
+        inst.append(self.eth_src_table.goto(self.output_table))
+        ofmsgs.extend([self.eth_src_table.flowmod(
+            match=src_match,
+            priority=src_priority,
+            inst=inst,
+            hard_timeout=src_rule_hard_timeout,
+            idle_timeout=src_rule_idle_timeout)]) 
+        return ofmsgs
+
     def learn_host_on_vlan_port_flows(self, port, vlan, eth_src,
                                       delete_existing, refresh_rules,
                                       src_rule_idle_timeout,

--- a/faucet/valve_route.py
+++ b/faucet/valve_route.py
@@ -773,20 +773,6 @@ class ValveRouteManager(ValveManagerBase):
     def control_plane_handler(self, now, pkt_meta):
         return self._proactive_resolve_neighbor(now, pkt_meta)
 
-    def __str__(self):
-        s = ''
-        for router in self.routers.values():
-            s += '%s:[' % router
-            for vlan in router.vlans:
-                s += '%s:' % vlan.vid
-                s += '%s' % self._vlan_nexthop_cache(vlan)
-                s += ' '
-            s += ']'
-        return s
-
-    def __repr__(self):
-        return self.__str__()
-
 
 class ValveIPv4RouteManager(ValveRouteManager):
     """Implement IPv4 RIB/FIB."""

--- a/faucet/valve_route.py
+++ b/faucet/valve_route.py
@@ -82,6 +82,12 @@ class NextHop:
             return True
         return False
 
+    def __str__(self):
+        return '%s' % [self.eth_src, self.port]
+
+    def __repr__(self):
+        return self.__str__()
+
 
 class ValveRouteManager(ValveManagerBase):
     """Base class to implement RIB/FIB."""
@@ -137,10 +143,13 @@ class ValveRouteManager(ValveManagerBase):
             self.logger.info('global routing enabled')
 
     def nexthop_dead(self, nexthop_cache_entry):
+        """Returns true if the nexthop_cache_entry is considered dead"""
         return nexthop_cache_entry.dead(self.max_host_fib_retry_count)
 
     @staticmethod
     def _unicast_to_vip(pkt_meta):
+        """Return true if packet is from a src in the connected network and dst ip is
+            a faucet vip. I.e: Packet is traffic bound for a VIP"""
         return (pkt_meta.eth_dst == pkt_meta.vlan.faucet_mac and
                 pkt_meta.vlan.from_connected_to_vip(pkt_meta.l3_src, pkt_meta.l3_dst))
 
@@ -153,20 +162,24 @@ class ValveRouteManager(ValveManagerBase):
         return None
 
     def _resolve_gw_on_vlan(self, vlan, faucet_vip, ip_gw):
+        """Return flood packet-out actions for gw resolving"""
         return vlan.flood_pkt(
             self._gw_resolve_pkt(), self.multi_out,
             vlan.faucet_mac, valve_of.mac.BROADCAST_STR, faucet_vip.ip, ip_gw)
 
     def _resolve_gw_on_port(self, vlan, port, faucet_vip, ip_gw, eth_dst):
+        """Return packet-out actions for outputting to a specific port"""
         return vlan.pkt_out_port(
             self._gw_resolve_pkt(),
             port, vlan.faucet_mac, eth_dst, faucet_vip.ip, ip_gw)
 
     def _controller_and_flood(self):
+        """Return instructions to forward packet to l2-forwarding"""
         return self.pipeline.accept_to_l2_forwarding(
             actions=[valve_of.output_controller(max_len=self.ICMP_SIZE)])
 
     def _resolve_vip_response(self, pkt_meta, solicited_ip, now):
+        """Learn host requesting for router, and return packet-out ofmsgs router response"""
         ofmsgs = []
         vlan = pkt_meta.vlan
         if (pkt_meta.vlan.is_faucet_vip(solicited_ip) and
@@ -191,6 +204,7 @@ class ValveRouteManager(ValveManagerBase):
         return ofmsgs
 
     def _gw_advert(self, pkt_meta, target_ip, now):
+        """Receive an advert, so update nexthop information"""
         ofmsgs = []
         vlan = pkt_meta.vlan
         if vlan.ip_in_vip_subnet(target_ip):
@@ -204,13 +218,15 @@ class ValveRouteManager(ValveManagerBase):
         return ofmsgs
 
     def _vlan_routes(self, vlan):
+        """Return vlan routes"""
         return vlan.routes_by_ipv(self.IPV)
 
     def _vlan_nexthop_cache(self, vlan):
+        """Return vlan neighbour cache"""
         return vlan.neigh_cache_by_ipv(self.IPV)
 
     def expire_port_nexthops(self, port):
-        """Expire all hosts on a port."""
+        """Expire all hosts on a port"""
         ofmsgs = []
         now = time.time()
         for vlan in port.vlans():
@@ -225,6 +241,7 @@ class ValveRouteManager(ValveManagerBase):
         return ofmsgs
 
     def _vlan_nexthop_cache_entry(self, vlan, ip_gw):
+        """Return nexthop cache entry"""
         nexthop_cache = self._vlan_nexthop_cache(vlan)
         return nexthop_cache.get(ip_gw, None)
 
@@ -233,6 +250,7 @@ class ValveRouteManager(ValveManagerBase):
         del nexthop_cache[ip_gw]
 
     def _nexthop_actions(self, eth_dst, vlan):
+        """Return flowrule actions for fib entry"""
         actions = []
         if self.routers:
             actions.append(self.fib_table.set_vlan_vid(vlan.vid))
@@ -244,13 +262,16 @@ class ValveRouteManager(ValveManagerBase):
         return actions
 
     def _route_match(self, vlan, ip_dst):
+        """Return vid, dst, eth_type flowrule match for fib entry"""
         return self.fib_table.match(vlan=vlan, eth_type=self.ETH_TYPE, nw_dst=ip_dst)
 
     def _route_priority(self, ip_dst):
+        """Return ip dst priority"""
         prefixlen = ipaddress.ip_network(ip_dst).prefixlen
         return self.route_priority + prefixlen
 
     def _router_for_vlan(self, vlan):
+        """Return vlan router if any"""
         if self.routers:
             for router in self.routers.values():
                 if vlan in router.vlans:
@@ -258,6 +279,7 @@ class ValveRouteManager(ValveManagerBase):
         return None
 
     def _routed_vlans(self, vlan):
+        """Return vlans that have routers"""
         if self.global_routing:
             return set([self.global_vlan])
         vlans = set([vlan])
@@ -272,9 +294,11 @@ class ValveRouteManager(ValveManagerBase):
         return not dst_ip.is_link_local or vlan.ip_dsts_for_ip_gw(dst_ip)
 
     def _global_routing(self):
+        """Return true if global routing is enabled"""
         return self.global_vlan.vid and self.routers and len(self.routers) == 1
 
     def _add_faucet_fib_to_vip(self, vlan, priority, faucet_vip, faucet_vip_host):
+        """Router flowmods"""
         ofmsgs = []
         learn_connected_priority = self.route_priority + faucet_vip.network.prefixlen
         faucet_mac = vlan.faucet_mac
@@ -354,6 +378,7 @@ class ValveRouteManager(ValveManagerBase):
         return ofmsgs
 
     def _add_resolved_route(self, vlan, ip_gw, ip_dst, eth_dst, is_updated):
+        """Return flowmods for enabling routing of a resolved nexthop"""
         ofmsgs = []
         if is_updated:
             self.logger.info(
@@ -374,6 +399,7 @@ class ValveRouteManager(ValveManagerBase):
         return ofmsgs
 
     def _update_nexthop_cache(self, now, vlan, eth_src, port, ip_gw):
+        """Add information to the nexthop cache and return the new object"""
         nexthop = NextHop(eth_src, port, now)
         nexthop_cache = self._vlan_nexthop_cache(vlan)
         nexthop_cache[ip_gw] = nexthop
@@ -434,6 +460,7 @@ class ValveRouteManager(ValveManagerBase):
         raise NotImplementedError # pragma: no cover
 
     def _resolve_gateway_flows(self, ip_gw, nexthop_cache_entry, vlan, now):
+        """Return packet-out ofmsgs using ARP/ND to resolve for nexthop"""
         faucet_vip = vlan.vip_map(ip_gw)
         if not faucet_vip:
             self.logger.info('Not resolving %s (not in connected network)' % ip_gw)
@@ -464,6 +491,7 @@ class ValveRouteManager(ValveManagerBase):
         return resolve_flows
 
     def _expire_gateway_flows(self, ip_gw, nexthop_cache_entry, vlan, now):
+        """Return ofmsgs deleting the expired nexthop information"""
         expire_flows = []
         self.logger.info(
             'expiring dead route %s (age %us) on %s' % (
@@ -477,12 +505,17 @@ class ValveRouteManager(ValveManagerBase):
         return expire_flows
 
     def _resolve_expire_gateway_flows(self, ip_gw, nexthop_cache_entry, vlan, now):
+        """If cache entry is dead then delete related flows
+        otherwise return packet-out ofmsgs to resolve nexthops"""
         if self.nexthop_dead(nexthop_cache_entry):
             return self._expire_gateway_flows(ip_gw, nexthop_cache_entry, vlan, now)
         return self._resolve_gateway_flows(ip_gw, nexthop_cache_entry, vlan, now)
 
     def _resolve_gateways_flows(self, resolve_handler, vlan, now,
                                 unresolved_nexthops, remaining_attempts):
+        """Resolve for nexthops using the resolve_handler
+        Return packet-out ofmsgs using V4 ARP/V6 ND to resolve nexthops
+        """
         ofmsgs = []
         for ip_gw in unresolved_nexthops:
             if remaining_attempts == 0:
@@ -543,6 +576,7 @@ class ValveRouteManager(ValveManagerBase):
             unresolved_gateways, self.max_hosts_per_resolve_cycle)
 
     def _cached_nexthop_eth_dst(self, vlan, ip_gw):
+        """Return nexthop cache entry eth_dst for the ip_gw"""
         entry = self._vlan_nexthop_cache_entry(vlan, ip_gw)
         if entry is not None and entry.eth_src is not None:
             return entry.eth_src
@@ -559,6 +593,7 @@ class ValveRouteManager(ValveManagerBase):
         raise NotImplementedError # pragma: no cover
 
     def _proactive_resolve_neighbor(self, now, pkt_meta):
+        """Packet not directly destined for router but we can learn from the packet anyway"""
         vlan = pkt_meta.vlan
         dst_ip = pkt_meta.l3_dst
         ofmsgs = []
@@ -706,6 +741,7 @@ class ValveRouteManager(ValveManagerBase):
         return ofmsgs
 
     def _del_route_flows(self, vlan, ip_dst):
+        """Delete all flows matching the vlan and ip_dst"""
         ofmsgs = []
         routed_vlans = self._routed_vlans(vlan)
         for routed_vlan in routed_vlans:
@@ -736,6 +772,20 @@ class ValveRouteManager(ValveManagerBase):
 
     def control_plane_handler(self, now, pkt_meta):
         return self._proactive_resolve_neighbor(now, pkt_meta)
+
+    def __str__(self):
+        s = ''
+        for router in self.routers.values():
+            s += '%s:[' % router
+            for vlan in router.vlans:
+                s += '%s:' % vlan.vid
+                s += '%s' % self._vlan_nexthop_cache(vlan)
+                s += ' '
+            s += ']'
+        return s
+
+    def __repr__(self):
+        return self.__str__()
 
 
 class ValveIPv4RouteManager(ValveRouteManager):
@@ -795,6 +845,7 @@ class ValveIPv4RouteManager(ValveRouteManager):
         return ofmsgs
 
     def _control_plane_arp_handler(self, now, pkt_meta):
+        """Handle ARP packets destined for the router"""
         ofmsgs = []
         if not pkt_meta.eth_type == valve_of.ether.ETH_TYPE_ARP:
             return ofmsgs
@@ -811,6 +862,7 @@ class ValveIPv4RouteManager(ValveRouteManager):
         return ofmsgs
 
     def _control_plane_icmp_handler(self, pkt_meta, ipv4_pkt):
+        """Handle ICMP packets destined for the router"""
         ofmsgs = []
         if ipv4_pkt.proto != valve_of.inet.IPPROTO_ICMP:
             return ofmsgs
@@ -829,6 +881,7 @@ class ValveIPv4RouteManager(ValveRouteManager):
         return ofmsgs
 
     def control_plane_handler(self, now, pkt_meta):
+        """Handle packets destined for router otherwise proactively learn host information"""
         if pkt_meta.packet_complete():
             arp_replies = self._control_plane_arp_handler(now, pkt_meta)
             if arp_replies:
@@ -979,6 +1032,7 @@ class ValveIPv6RouteManager(ValveRouteManager):
     }
 
     def _control_plane_icmpv6_handler(self, now, pkt_meta, ipv6_pkt):
+        """Handle ICMPv6 packets destined for router"""
         ofmsgs = []
         # Must be ICMPv6 and have no extended headers.
         if ipv6_pkt.nxt != valve_of.inet.IPPROTO_ICMPV6:
@@ -1010,6 +1064,7 @@ class ValveIPv6RouteManager(ValveRouteManager):
         return ofmsgs
 
     def control_plane_handler(self, now, pkt_meta):
+        """Resolve packets destined for router or proactively learn host information"""
         if pkt_meta.packet_complete():
             ipv6_pkt = self._ip_pkt(pkt_meta.pkt)
             if ipv6_pkt is not None:

--- a/faucet/valves_manager.py
+++ b/faucet/valves_manager.py
@@ -222,7 +222,6 @@ class ValvesManager:
             self._send_ofmsgs_by_valve(ofmsgs_by_valve)
             valve.update_metrics(now, pkt_meta.port, rate_limited=True)
 
-
     def update_config_applied(self, sent=None, reset=False):
         """Update faucet_config_applied from {dpid: sent} dict,
            defining applied == sent == enqueued via Ryu"""

--- a/faucet/vlan.py
+++ b/faucet/vlan.py
@@ -368,6 +368,7 @@ class VLAN(Conf):
         return False
 
     def _update_gw_types(self, ip_gw):
+        """Update dyn host/route gw information to a different ip version"""
         if self.is_host_fib_route(ip_gw):
             self.dyn_host_gws_by_ipv[ip_gw.version].add(ip_gw)
             self.dyn_route_gws_by_ipv[ip_gw.version] -= set([ip_gw])
@@ -500,6 +501,7 @@ class VLAN(Conf):
 
     @staticmethod
     def flood_ports(configured_ports, exclude_unicast):
+        """Return configured ports that allow flooding"""
         if exclude_unicast:
             return tuple([port for port in configured_ports if port.unicast_flood])
         return configured_ports
@@ -527,6 +529,7 @@ class VLAN(Conf):
         return actions
 
     def pkt_out_port(self, packet_builder, port, *args):
+        """Return packet-out actions with VLAN tag if port is tagged"""
         vid = None
         if self.port_is_tagged(port):
             vid = self.vid
@@ -534,6 +537,7 @@ class VLAN(Conf):
         return valve_of.packetout(port.number, pkt.data)
 
     def flood_pkt(self, packet_builder, multi_out=True, *args):
+        """Return Packet-out actions via flooding"""
         ofmsgs = []
         for vid, ports in (
                 (self.vid, self.tagged_flood_ports(False)),
@@ -561,6 +565,7 @@ class VLAN(Conf):
         return port in self.untagged or port in self.dot1x_untagged
 
     def vip_map(self, ipa):
+        """Return the vip containing ipa"""
         for faucet_vip in self.faucet_vips:
             if ipa in faucet_vip.network:
                 return faucet_vip

--- a/tests/integration/mininet_tests.py
+++ b/tests/integration/mininet_tests.py
@@ -610,13 +610,14 @@ listen {
 
 class Faucet8021XSuccessTest(Faucet8021XBaseTest):
 
-    DOT1X_EXPECTED_EVENTS = [{'ENABLED': {}},
-                             {'PORT_UP': {'port': 'port_1', 'port_type': 'supplicant'}},
-                             {'PORT_UP': {'port': 'port_2', 'port_type': 'supplicant'}},
-                             {'PORT_UP': {'port': 'port_4', 'port_type': 'nfv'}},
-                             {'AUTHENTICATION': {'port': 'port_1', 'eth_src': 'HOST1_MAC', 'status': 'success'}},
-                             {'AUTHENTICATION': {'port': 'port_2', 'eth_src': 'HOST2_MAC', 'status': 'success'}},
-                             {'AUTHENTICATION': {'port': 'port_2', 'eth_src': 'HOST2_MAC', 'status': 'logoff'}}]
+    DOT1X_EXPECTED_EVENTS = [
+        {'ENABLED': {}},
+        {'PORT_UP': {'port': 'port_1', 'port_type': 'supplicant'}},
+        {'PORT_UP': {'port': 'port_2', 'port_type': 'supplicant'}},
+        {'PORT_UP': {'port': 'port_4', 'port_type': 'nfv'}},
+        {'AUTHENTICATION': {'port': 'port_1', 'eth_src': 'HOST1_MAC', 'status': 'success'}},
+        {'AUTHENTICATION': {'port': 'port_2', 'eth_src': 'HOST2_MAC', 'status': 'success'}},
+        {'AUTHENTICATION': {'port': 'port_2', 'eth_src': 'HOST2_MAC', 'status': 'logoff'}}]
     SESSION_TIMEOUT = 3600
 
     def test_untagged(self):
@@ -640,11 +641,12 @@ class Faucet8021XFailureTest(Faucet8021XBaseTest):
     }
     """
 
-    DOT1X_EXPECTED_EVENTS = [{'ENABLED': {}},
-                             {'PORT_UP': {'port': 'port_1', 'port_type': 'supplicant'}},
-                             {'PORT_UP': {'port': 'port_2', 'port_type': 'supplicant'}},
-                             {'PORT_UP': {'port': 'port_4', 'port_type': 'nfv'}},
-                             {'AUTHENTICATION': {'port': 'port_1', 'eth_src': 'HOST1_MAC', 'status': 'failure'}}]
+    DOT1X_EXPECTED_EVENTS = [
+        {'ENABLED': {}},
+        {'PORT_UP': {'port': 'port_1', 'port_type': 'supplicant'}},
+        {'PORT_UP': {'port': 'port_2', 'port_type': 'supplicant'}},
+        {'PORT_UP': {'port': 'port_4', 'port_type': 'nfv'}},
+        {'AUTHENTICATION': {'port': 'port_1', 'eth_src': 'HOST1_MAC', 'status': 'failure'}}]
 
     def test_untagged(self):
         self.assertFalse(
@@ -655,19 +657,20 @@ class Faucet8021XFailureTest(Faucet8021XBaseTest):
 
 class Faucet8021XPortStatusTest(Faucet8021XBaseTest):
 
-    DOT1X_EXPECTED_EVENTS = [{'ENABLED': {}},
-                             {'PORT_UP': {'port': 'port_1', 'port_type': 'supplicant'}},
-                             {'PORT_UP': {'port': 'port_2', 'port_type': 'supplicant'}},
-                             {'PORT_UP': {'port': 'port_4', 'port_type': 'nfv'}},
-                             {'PORT_DOWN': {'port': 'port_1', 'port_type': 'supplicant'}},
-                             {'PORT_UP': {'port': 'port_1', 'port_type': 'supplicant'}},
-                             {'PORT_UP': {'port': 'port_4', 'port_type': 'nfv'}},
-                             {'PORT_DOWN': {'port': 'port_1', 'port_type': 'supplicant'}},
-                             {'PORT_UP': {'port': 'port_4', 'port_type': 'nfv'}},
-                             {'PORT_UP': {'port': 'port_1', 'port_type': 'supplicant'}},
-                             {'AUTHENTICATION': {'port': 'port_1', 'eth_src': 'HOST1_MAC', 'status': 'success'}},
-                             {'PORT_DOWN': {'port': 'port_1', 'port_type': 'supplicant'}},
-                             {'PORT_UP': {'port': 'port_1', 'port_type': 'supplicant'}}]
+    DOT1X_EXPECTED_EVENTS = [
+        {'ENABLED': {}},
+        {'PORT_UP': {'port': 'port_1', 'port_type': 'supplicant'}},
+        {'PORT_UP': {'port': 'port_2', 'port_type': 'supplicant'}},
+        {'PORT_UP': {'port': 'port_4', 'port_type': 'nfv'}},
+        {'PORT_DOWN': {'port': 'port_1', 'port_type': 'supplicant'}},
+        {'PORT_UP': {'port': 'port_1', 'port_type': 'supplicant'}},
+        {'PORT_UP': {'port': 'port_4', 'port_type': 'nfv'}},
+        {'PORT_DOWN': {'port': 'port_1', 'port_type': 'supplicant'}},
+        {'PORT_UP': {'port': 'port_4', 'port_type': 'nfv'}},
+        {'PORT_UP': {'port': 'port_1', 'port_type': 'supplicant'}},
+        {'AUTHENTICATION': {'port': 'port_1', 'eth_src': 'HOST1_MAC', 'status': 'success'}},
+        {'PORT_DOWN': {'port': 'port_1', 'port_type': 'supplicant'}},
+        {'PORT_UP': {'port': 'port_1', 'port_type': 'supplicant'}}]
 
     def test_untagged(self):
         port_no1 = self.port_map['port_1']
@@ -716,6 +719,7 @@ class Faucet8021XPortFlapTest(Faucet8021XBaseTest):
         port_no1 = self.port_map['port_1']
 
         for _ in range(2):
+
             self.set_port_up(port_no1)
             self.assertTrue(self.retry_8021x(
                 self.eapol1_host, port_no1, self.wpasupplicant_conf_1, and_logoff=True))
@@ -726,7 +730,8 @@ class Faucet8021XPortFlapTest(Faucet8021XBaseTest):
             self.one_ipv4_ping(
                 self.eapol1_host, self.ping_host.IP(),
                 require_host_learned=False, expected_result=False)
-            wpa_status = self.get_wpa_status(self.eapol1_host, self.get_wpa_ctrl_path(self.eapol1_host))
+            wpa_status = self.get_wpa_status(
+                self.eapol1_host, self.get_wpa_ctrl_path(self.eapol1_host))
             self.assertNotEqual('SUCCESS', wpa_status)
             # Kill supplicant so cant reply to the port up identity request.
             self.terminate_wpasupplicant(self.eapol1_host)
@@ -3852,7 +3857,8 @@ vlans:
                 # 'count=%u)\"' % ('ARP', self.FAUCET_VIPV4.ip, packets))):
             fuzz_out = first_host.cmd(fuzz_cmd)
             self.assertTrue(
-                re.search('Sent %u packets' % packets, fuzz_out), msg='%s: %s' % (fuzz_cmd, fuzz_out))
+                re.search('Sent %u packets' % packets, fuzz_out), msg='%s: %s' % (
+                    fuzz_cmd, fuzz_out))
         self.one_ipv4_controller_ping(first_host)
 
     def test_flap_ping_controller(self):
@@ -6446,11 +6452,11 @@ class FaucetStringOfDPTest(FaucetTest):
 
     def build_net(self, stack=False, n_dps=1,
                   n_tagged=0, tagged_vid=100,
-                  untagged_hosts = None,
+                  untagged_hosts=None,
                   include=None, include_optional=None,
                   switch_to_switch_links=1, hw_dpid=None,
                   stack_ring=False, lacp=False, use_external=False,
-                  router = None, dp_options = None):
+                  router=None, dp_options=None):
         """Set up Mininet and Faucet for the given topology."""
         if include is None:
             include = []
@@ -6464,7 +6470,7 @@ class FaucetStringOfDPTest(FaucetTest):
             dpids=self.dpids,
             n_tagged=n_tagged,
             tagged_vid=tagged_vid,
-            untagged_hosts = untagged_hosts,
+            untagged_hosts=untagged_hosts,
             links_per_host=self.LINKS_PER_HOST,
             switch_to_switch_links=switch_to_switch_links,
             test_name=self._test_name(),
@@ -6496,7 +6502,7 @@ class FaucetStringOfDPTest(FaucetTest):
     def get_config(self, dpids=None, hw_dpid=None, stack=False, hardware=None, ofchannel_log=None,
                    n_tagged=0, tagged_vid=0, untagged_hosts=None,
                    include=None, include_optional=None, acls=None, acl_in_dp=None,
-                   lacp=False, use_external=False, router = None, dp_options = None):
+                   lacp=False, use_external=False, router=None, dp_options=None):
         """Build a complete Faucet configuration for each datapath, using the given topology."""
         if dpids is None:
             dpids = []
@@ -6799,20 +6805,20 @@ class FaucetUntaggedIPV4RoutingWithStackingTest(FaucetStringOfDPTest):
             self.V100: {
                 'faucet_mac': self.FAUCET_MAC,
                 'faucet_vips': [self.get_faucet_vip(1)]
-            }, 
+            },
             self.V200: {
                 'faucet_mac': self.FAUCET_MAC2,
                 'faucet_vips': [self.get_faucet_vip(2)]
             }
         }
         self.build_net(
-            stack = True,
-            n_dps = self.NUM_DPS,
-            untagged_hosts = {self.V100: self.V100_NUM_HOSTS, self.V200: self.V200_NUM_HOSTS},
-            switch_to_switch_links = self.SWITCH_TO_SWITCH_LINKS,
-            hw_dpid = self.hw_dpid,
-            router = router_info,
-            dp_options = self.get_dp_options()
+            stack=True,
+            n_dps=self.NUM_DPS,
+            untagged_hosts={self.V100: self.V100_NUM_HOSTS, self.V200: self.V200_NUM_HOSTS},
+            switch_to_switch_links=self.SWITCH_TO_SWITCH_LINKS,
+            hw_dpid=self.hw_dpid,
+            router=router_info,
+            dp_options=self.get_dp_options()
         )
         self.start_net()
 
@@ -6834,17 +6840,17 @@ class FaucetUntaggedIPV4RoutingWithStackingTest(FaucetStringOfDPTest):
 
     def set_host_ip(self, host, ip):
         """Set the host ip"""
-        host.setIP(str(ip.ip), prefixLen = self.NETPREFIX)
+        host.setIP(str(ip.ip), prefixLen=self.NETPREFIX)
 
     def verify_intervlan_routing(self):
         """Setup host routes and verify intervlan routing is possible"""
         num_hosts = self.V100_NUM_HOSTS + self.V200_NUM_HOSTS
         first_faucet_vip = ipaddress.ip_interface(self.get_faucet_vip(1))
         second_faucet_vip = ipaddress.ip_interface(self.get_faucet_vip(2))
-        v100_hosts = [(self.net.hosts[i], ipaddress.ip_interface(self.get_ip(i+1, 1)))
-            for i in range(len(self.net.hosts)) if (i % num_hosts) == 0]
-        v200_hosts = [(self.net.hosts[i], ipaddress.ip_interface(self.get_ip(i+1, 2)))
-            for i in range(len(self.net.hosts)) if (i % num_hosts) == 1]
+        v100_hosts = [(self.net.hosts[i], ipaddress.ip_interface(
+            self.get_ip(i+1, 1))) for i in range(len(self.net.hosts)) if (i % num_hosts) == 0]
+        v200_hosts = [(self.net.hosts[i], ipaddress.ip_interface(
+            self.get_ip(i+1, 2))) for i in range(len(self.net.hosts)) if (i % num_hosts) == 1]
         for host_tuple in v100_hosts:
             host, host_ip = host_tuple
             self.set_host_ip(host, host_ip)
@@ -6860,8 +6866,10 @@ class FaucetUntaggedIPV4RoutingWithStackingTest(FaucetStringOfDPTest):
                 self.add_host_route(v200_host, v100_host_ip, second_faucet_vip.ip)
                 self.host_ping(v100_host, v200_host_ip.ip)
                 self.host_ping(v200_host, v100_host_ip.ip)
-                self.assertEqual(self._ip_neigh(v100_host, first_faucet_vip.ip, self.IPV), self.FAUCET_MAC)
-                self.assertEqual(self._ip_neigh(v200_host, second_faucet_vip.ip, self.IPV), self.FAUCET_MAC2)
+                self.assertEqual(
+                    self._ip_neigh(v100_host, first_faucet_vip.ip, self.IPV), self.FAUCET_MAC)
+                self.assertEqual(
+                    self._ip_neigh(v200_host, second_faucet_vip.ip, self.IPV), self.FAUCET_MAC2)
         for src_host_tuple in v100_hosts:
             src_host, src_ip = src_host_tuple
             for dst_host_tuple in v100_hosts:
@@ -6876,11 +6884,11 @@ class FaucetUntaggedIPV4RoutingWithStackingTest(FaucetStringOfDPTest):
                 self.host_ping(src_host, dst_ip.ip)
 
     def test_intervlan_routing_stack_of_2_dp(self):
-       """Verify intervlan routing works with 2 DPs in a stack"""
-       self.NUM_DPS = 2
-       self.set_up()
-       self.verify_all_stack_up()
-       self.verify_intervlan_routing()
+        """Verify intervlan routing works with 2 DPs in a stack"""
+        self.NUM_DPS = 2
+        self.set_up()
+        self.verify_all_stack_up()
+        self.verify_intervlan_routing()
 
     def test_intervlan_routing_stack_of_3_dp(self):
         """Verify intervlan routing works with 3 DPs in a stack"""
@@ -6890,11 +6898,11 @@ class FaucetUntaggedIPV4RoutingWithStackingTest(FaucetStringOfDPTest):
         self.verify_intervlan_routing()
 
     def test_intervlan_routing_stack_of_4_dp(self):
-      """Verify intervlan routing works with 4 DPs in a stack"""
-      self.NUM_DPS = 4
-      self.set_up()
-      self.verify_all_stack_up()
-      self.verify_intervlan_routing()
+        """Verify intervlan routing works with 4 DPs in a stack"""
+        self.NUM_DPS = 4
+        self.set_up()
+        self.verify_all_stack_up()
+        self.verify_intervlan_routing()
 
 
 class FaucetUntaggedIPV6RoutingWithStackingTest(FaucetUntaggedIPV4RoutingWithStackingTest):
@@ -6919,7 +6927,7 @@ class FaucetUntaggedIPV6RoutingWithStackingTest(FaucetUntaggedIPV4RoutingWithSta
     def set_host_ip(self, host, ip):
         """ """
         self.add_host_ipv6_address(host, ip)
-    
+
     def get_faucet_vip(self, vindex):
         """Get the IPV6 faucet vip"""
         return 'fc0%u::1:254/112' % vindex
@@ -7068,7 +7076,8 @@ class FaucetStringOfDPLACPUntaggedTest(FaucetStringOfDPTest):
         self.wait_until_matching_flow(
             self.match_bcast, self._FLOOD_TABLE, actions=[self.action_str % second_lacp_port])
         self.wait_until_matching_flow(
-            self.match_bcast, self._FLOOD_TABLE, actions=[self.action_str % remote_second_lacp_port],
+            self.match_bcast, self._FLOOD_TABLE, actions=[
+                self.action_str % remote_second_lacp_port],
             dpid=self.dpids[1])
         self.retry_net_ping()
         self.set_port_up(first_lacp_port)

--- a/tests/unit/clib/test_topo.py
+++ b/tests/unit/clib/test_topo.py
@@ -36,7 +36,7 @@ class FaucetStringOfDPSwitchTopoTest(TestCase):
         peer_link = FaucetStringOfDPSwitchTopo.peer_link
         args = self.string_of_dp_args(
             n_tagged=2,
-            n_untagged=2,
+            untagged_hosts={None: 2},
             links_per_host=1,
             switch_to_switch_links=2,
             start_port=1)
@@ -86,7 +86,7 @@ class FaucetStringOfDPSwitchTopoTest(TestCase):
         switch_map = {1:'p1', 2:'p2', 3:'p3', 4:'p4', 5:'p5', 6:'p6'}
         args = self.string_of_dp_args(
             n_tagged=2,
-            n_untagged=2,
+            untagged_hosts={None: 2},
             links_per_host=1,
             switch_to_switch_links=2,
             start_port=5,

--- a/tests/unit/faucet/test_check_config.py
+++ b/tests/unit/faucet/test_check_config.py
@@ -252,25 +252,6 @@ dps:
 """
         self.check_config_failure(unknown_hardware_config)
 
-    def test_routing_stacking(self):
-        """Test that routing and stacking cannot be enabled together."""
-        routing_stacking_config = """
-vlans:
-    100:
-        description: "100"
-        faucet_vips: ['1.2.3.4/24']
-dps:
-    switch1:
-        dp_id: 0xcafef00d
-        hardware: 'Open vSwitch'
-        stack:
-            priority: 1
-        interfaces:
-            1:
-                native_vlan: 100
-"""
-        self.check_config_failure(routing_stacking_config)
-
     def test_stacking_noroot(self):
         """Test that a stacking root is defined."""
         stacking_config = """

--- a/tests/unit/faucet/test_config.py
+++ b/tests/unit/faucet/test_config.py
@@ -3377,6 +3377,49 @@ dps:
 """
         self.check_config_failure(config, cp.dp_parser)
 
+    def test_stacking_with_intervlan_routing_accepted(self):
+        """Test config accepted when using intervlan routing with stacking"""
+        config = """
+vlans:
+    vlan100:
+        vid: 100
+        faucet_mac: '00:00:00:00:00:11'
+        faucet_vips: ['10.0.1.254/24']
+    vlan200:
+        vid: 200
+        faucet_mac: '00:00:00:00:00:22'
+        faucet_vips: ['10.0.2.254/24']
+routers:
+    router-1:
+        vlans: [vlan100, vlan200]
+dps:
+    sw1:
+        dp_id: 0x1
+        stack:
+            priority: 1
+        interfaces:
+            1:
+                native_vlan: vlan100
+            2:
+                native_vlan: vlan200
+            3:
+                stack:
+                    dp: sw2
+                    port: 3
+    sw2:
+        dp_id: 0x2
+        interfaces:
+            1:
+                native_vlan: vlan100
+            2:
+                native_vlan: vlan200
+            3:
+                stack:
+                    dp: sw1
+                    port: 3
+"""
+        self.check_config_success(config, cp.dp_parser)
+
 
 if __name__ == "__main__":
     unittest.main() # pytype: disable=module-attr

--- a/tests/unit/faucet/test_valve.py
+++ b/tests/unit/faucet/test_valve.py
@@ -2551,7 +2551,6 @@ dps:
         self.assertLessEqual(total_tt_prop, 50, msg=pstats_text)
 
 
-
 class ValveTestConfigHash(ValveTestBases.ValveTestSmall):
     """Verify faucet_config_hash_info update after config change"""
 
@@ -2824,6 +2823,212 @@ dps:
         self.assertEqual(len(self.get_valve(0x1).get_tunnel_flowmods()), 2)
         self.assertEqual(len(self.get_valve(0x2).get_tunnel_flowmods()), 1)
         self.assertEqual(len(self.get_valve(0x3).get_tunnel_flowmods()), 2)
+
+
+class ValveTestIPV4StackedRouting(ValveTestBases.ValveTestSmall):
+    """Test inter-vlan routing with stacking capabilities in an IPV4 network"""
+
+    V100 = 0x100
+    V200 = 0x200
+    VLAN100_FAUCET_MAC = '00:00:00:00:00:11'
+    VLAN100_FAUCET_VIPS = '10.0.1.254'
+    VLAN100_FAUCET_VIP_SPACE = '10.0.1.254/24'
+    VLAN200_FAUCET_MAC = '00:00:00:00:00:22'
+    VLAN200_FAUCET_VIPS = '10.0.2.254'
+    VLAN200_FAUCET_VIP_SPACE = '10.0.2.254/24'
+    BASE_CONFIG = """
+routers:
+    router1:
+        vlans: [vlan100, vlan200]
+dps:
+    s1:
+        hardware: 'GenericTFM'
+        dp_id: 0x1
+        stack: {priority: 1}
+        interfaces:
+            1:
+                native_vlan: vlan100
+            2:
+                native_vlan: vlan200
+            3:
+                stack: {dp: s2, port: 3}
+    s2:
+        dp_id: 0x2
+        interfaces:
+            1:
+                native_vlan: vlan100
+            2:
+                native_vlan: vlan200
+            3:
+                stack: {dp: s1, port: 3}
+            4:
+                stack: {dp: s3, port: 3}
+    s3:
+        dp_id: 0x3
+        interfaces:
+            1:
+                native_vlan: vlan100
+            2:
+                native_vlan: vlan200
+            3:
+                stack: {dp: s2, port: 4}
+            4:
+                stack: {dp: s4, port: 3}
+    s4:
+        dp_id: 0x4
+        interfaces:
+            1:
+                native_vlan: vlan100
+            2:
+                native_vlan: vlan200
+            3:
+                stack: {dp: s3, port: 4}
+"""
+
+    def create_config(self):
+        """Create the config file"""
+        self.CONFIG = """
+vlans:
+    vlan100:
+        vid: 0x100
+        faucet_mac: %s
+        faucet_vips: [%s]
+    vlan200:
+        vid: 0x200
+        faucet_mac: %s
+        faucet_vips: [%s]
+%s
+""" % (self.VLAN100_FAUCET_MAC, self.VLAN100_FAUCET_VIP_SPACE,
+       self.VLAN200_FAUCET_MAC, self.VLAN200_FAUCET_VIP_SPACE,
+       self.BASE_CONFIG)
+
+    def setUp(self):
+        self.create_config()
+        self.setup_valve(self.CONFIG)
+        for valve in self.valves_manager.valves.values():
+            valve.dp.dyn_running = True
+            for port in valve.dp.ports.values():
+                port.dyn_finalized = False
+                port.enabled = True
+                port.dyn_phys_up = True
+                port.dyn_finalized = True
+
+    def ip_to_address(self, ip_string, vid):
+        """Turns an IP address string into an IPV4 address object"""
+        return ipaddress.IPv4Address(ip_string)
+
+    def create_mac(self, vindex, host):
+        """Create a MAC address string"""
+        return '00:00:00:0%u:00:0%u' % (vindex, host)
+
+    def create_ip(self, vindex, host):
+        """Create a IP address string"""
+        return '10.0.%u.%u' % (vindex, host)
+
+    def create_match(self, vindex, host, faucet_mac, faucet_vip, code):
+        """Create an ARP reply message"""
+        return {
+            'eth_src': self.create_mac(vindex, host),
+            'eth_dst': faucet_mac,
+            'arp_code': code,
+            'arp_source_ip': self.create_ip(vindex, host),
+            'arp_target_ip': faucet_vip
+        }
+
+    def get_eth_type(self, vid):
+        """Returns IPV4 ether type"""
+        return valve_of.ether.ETH_TYPE_IP
+
+    def valve_rcv_packet(self, port, vid, match, dp_id):
+        """Simulate control plane receiving a packet on a port/VID."""
+        valve = self.valves_manager.valves[dp_id]
+        pkt = build_pkt(match)
+        vlan_pkt = pkt
+        if vid and vid not in match:
+            vlan_match = match
+            vlan_match['vid'] = vid
+            vlan_pkt = build_pkt(match)
+        msg = namedtuple(
+            'null_msg',
+            ('match', 'in_port', 'data', 'total_len', 'cookie', 'reason'))(
+                {'in_port': port}, port, vlan_pkt.data, len(vlan_pkt.data),
+                valve.dp.cookie, valve_of.ofp.OFPR_ACTION)
+        self.last_flows_to_dp[dp_id] = []
+        now = time.time()
+        self.valves_manager.valve_packet_in(now, valve, msg)
+        rcv_packet_ofmsgs = self.last_flows_to_dp[dp_id]
+        for valve_service in (
+                'resolve_gateways', 'advertise', 'fast_advertise', 'state_expire'):
+            self.valves_manager.valve_flow_services(
+                now, valve_service)
+        self.valves_manager.update_metrics(now)
+        return rcv_packet_ofmsgs
+
+    def verify_router_cache(self, ip_match, eth_match, vid, dp_id):
+        """Verify router nexthop cache stores correct values"""
+        host_valve = self.valves_manager.valves[dp_id]
+        for valve in self.valves_manager.valves.values():
+            vlan = valve.dp.vlans[vid]
+            route_manager = valve._route_manager_by_eth_type.get(
+                self.get_eth_type(vid), None)
+            vlan_nexthop_cache = route_manager._vlan_nexthop_cache(vlan)
+            self.assertTrue(vlan_nexthop_cache)
+            ip = self.ip_to_address(ip_match, vid)
+            #Check IP address is properly cached
+            self.assertIn(ip, vlan_nexthop_cache)
+            nexthop = vlan_nexthop_cache[ip]
+            #Check MAC address is properly cached
+            self.assertEqual(eth_match, nexthop.eth_src)
+            if host_valve != valve:
+                #Check the proper nexthop port is cached
+                expected_port = valve.dp.shortest_path_port(host_valve.dp.name)
+                self.assertEqual(expected_port, nexthop.port)
+
+    def test_router_cache_learn_hosts(self):
+        """Have all router caches contain proper host nexthops"""
+        #Learn Vlan100 hosts
+        for host in [1, 2, 3, 4]:
+            self.valve_rcv_packet(1, self.V100, self.create_match(
+                1, host, self.VLAN100_FAUCET_MAC, self.VLAN100_FAUCET_VIPS, arp.ARP_REPLY), host)
+            self.verify_router_cache(
+                self.create_ip(1, host), self.create_mac(1, host), self.V100, host)
+        #Learn Vlan200 hosts
+        for host in [1, 2, 3, 4]:
+            self.valve_rcv_packet(2, self.V200, self.create_match(
+                2, host, self.VLAN200_FAUCET_MAC, self.VLAN200_FAUCET_VIPS, arp.ARP_REPLY), host)
+            self.verify_router_cache(
+                self.create_ip(2, host), self.create_mac(2, host), self.V200, host)
+
+
+class ValveTestIPV6StackedRouting(ValveTestIPV4StackedRouting):
+    """Test inter-vlan routing with stacking capabilities in an IPV6 network"""
+
+    VLAN100_FAUCET_VIPS = 'fc80::1:254'
+    VLAN200_FAUCET_VIPS = 'fc80::2:254'
+    VLAN100_FAUCET_VIP_SPACE = 'fc80::1:254/64'
+    VLAN200_FAUCET_VIP_SPACE = 'fc80::1:254/64'
+
+    def ip_to_address(self, ip_string, vid):
+        """Turns an IP address string into an IPV6 address object"""
+        return ipaddress.IPv6Address(ip_string)
+
+    def create_ip(self, vindex, host):
+        """Create a IP address string"""
+        return 'fc80::%u:%u' % (vindex, host)
+
+    def create_match(self, vindex, host, faucet_mac, faucet_vip, code):
+        """Create an NA message"""
+        return {
+            'eth_src': self.create_mac(vindex, host),
+            'eth_dst': faucet_mac,
+            'ipv6_src': self.create_ip(vindex, host),
+            'ipv6_dst': faucet_vip,
+            'neighbor_advert_ip': self.create_ip(vindex, host)
+        }
+
+    def get_eth_type(self, vid):
+        """Returns IPV6 ether type"""
+        return valve_of.ether.ETH_TYPE_IPV6
 
 
 class ValveGroupTestCase(ValveTestBases.ValveTestSmall):


### PR DESCRIPTION
- Enable the ability to use stacking with inter-VLAN routing (#2672 ).
- drop_spoofed_faucet_mac should be set to false to allow a routed packet enter the eth_src table on another switch.
- A valve receiving packets will call other valves in the stack to also learn the host.