### PR TITLE
Simple stack root redundancy

### DIFF
--- a/faucet/check_faucet_config.py
+++ b/faucet/check_faucet_config.py
@@ -43,7 +43,7 @@ def check_config(conf_files, debug_level, check_output_file):
             check_result = False
 
             try:
-                _, dps = dp_parser(conf_file, logname)
+                _, dps, _ = dp_parser(conf_file, logname)
                 if dps is not None:
                     dps_conf = [(valve.valve_factory(dp), dp.to_conf()) for dp in dps]
                     check_output.extend([conf for _, conf in dps_conf])

--- a/faucet/dp.py
+++ b/faucet/dp.py
@@ -493,19 +493,15 @@ configuration.
                 table_config.table_id = relative_table_id
             table_configs[name] = table_config
 
-        # Stacking with external ports, so need loop protection field.
+        # Stacking with external ports, so need external forwarding request field.
         if self.has_externals:
-            flood_table = table_configs['flood']
-            flood_table.set_fields = (valve_of.STACK_LOOP_PROTECT_FIELD,)
-            flood_table.match_types += ((valve_of.STACK_LOOP_PROTECT_FIELD, False),)
-            vlan_table = table_configs['vlan']
-            vlan_table.set_fields += (valve_of.STACK_LOOP_PROTECT_FIELD,)
-            vlan_table.match_types += ((valve_of.STACK_LOOP_PROTECT_FIELD, False),)
-            eth_src_table = table_configs['eth_src']
-            eth_src_table.set_fields = (valve_of.STACK_LOOP_PROTECT_FIELD,)
-            eth_dst_table = table_configs['eth_dst']
-            eth_dst_table.set_fields = (valve_of.STACK_LOOP_PROTECT_FIELD,)
-            eth_dst_table.match_types += ((valve_of.STACK_LOOP_PROTECT_FIELD, False),)
+            for table_name in ('vlan', 'eth_dst', 'flood'):
+                table = table_configs[table_name]
+                table.match_types += ((valve_of.EXTERNAL_FORWARDING_FIELD, False),)
+                if table.set_fields is not None:
+                    table.set_fields += (valve_of.EXTERNAL_FORWARDING_FIELD,)
+                else:
+                    table.set_fields = (valve_of.EXTERNAL_FORWARDING_FIELD,)
 
         if 'egress_acl' in included_tables:
             table_configs['eth_dst'].miss_goto = 'egress_acl'

--- a/faucet/dp.py
+++ b/faucet/dp.py
@@ -34,6 +34,7 @@ from faucet.faucet_pipeline import ValveTableConfig
 from faucet.valve import SUPPORTED_HARDWARE
 from faucet.valve_table import ValveTable, ValveGroupTable
 
+
 # Documentation generated using documentation_generator.py
 # For attributues to be included in documentation they must
 # have a default value, and their descriptor must come
@@ -42,7 +43,8 @@ class DP(Conf):
     """Stores state related to a datapath controlled by Faucet, including
 configuration.
 """
-
+    DEFAULT_LLDP_SEND_INTERVAL = 5
+    DEFAULT_LLDP_MAX_PER_INTERVAL = 5
     mutable_attrs = frozenset(['stack', 'vlans'])
 
     # Values that are set to None will be set using set_defaults
@@ -298,6 +300,9 @@ configuration.
         self.strict_packet_in_cookie = None
         self.multi_out = None
         self.idle_dst = None
+        self.stack_root_name = None
+        self.stack_roots_names = None
+        self.stack_longest_path_to_root_len = None
 
         self.acls = {}
         self.vlans = {}
@@ -365,15 +370,17 @@ configuration.
             self.learn_ban_timeout = self.learn_jitter
         if self.lldp_beacon:
             self._check_conf_types(self.lldp_beacon, self.lldp_beacon_defaults_types)
-            test_config_condition('send_interval' not in self.lldp_beacon, (
-                'lldp_beacon send_interval not set'))
-            test_config_condition('max_per_interval' not in self.lldp_beacon, (
-                'lldp_beacon max_per_interval not set'))
+            if 'send_interval' not in self.lldp_beacon:
+                self.lldp_beacon['send_interval'] = self.DEFAULT_LLDP_SEND_INTERVAL
+            if 'max_per_interval' not in self.lldp_beacon:
+                self.lldp_beacon['max_per_interval'] = self.DEFAULT_LLDP_MAX_PER_INTERVAL
             self.lldp_beacon = self._set_unknown_conf(
                 self.lldp_beacon, self.lldp_beacon_defaults_types)
             if self.lldp_beacon['system_name'] is None:
                 self.lldp_beacon['system_name'] = self.name
         if self.stack:
+            if 'graph' in self.stack:
+                del self.stack['graph']
             self._check_conf_types(self.stack, self.stack_defaults_types)
         if self.dot1x:
             self._check_conf_types(self.dot1x, self.dot1x_defaults_types)
@@ -701,7 +708,7 @@ configuration.
         """Remove a stack link to the stack graph."""
         return cls.modify_stack_topology(graph, dp, port, False)
 
-    def resolve_stack_topology(self, dps):
+    def resolve_stack_topology(self, dps, meta_dp_state):
         """Resolve inter-DP config for stacking."""
         stack_dps = [dp for dp in dps if dp.stack is not None]
         stack_priority_dps = [dp for dp in stack_dps if 'priority' in dp.stack]
@@ -717,9 +724,17 @@ configuration.
                     int, type(dp.stack['priority']))))
             test_config_condition(dp.stack['priority'] <= 0, (
                 'stack priority must be > 0'))
+        stack_priority_dps = sorted(stack_priority_dps, key=lambda x: x.stack['priority'])
 
-        root_dps = sorted(stack_priority_dps, key=lambda x: x.stack['priority'])
-        root_dp = root_dps[0]
+        self.stack_roots_names = [dp.name for dp in stack_priority_dps]
+        self.stack_root_name = self.stack_roots_names[0]
+        if meta_dp_state:
+            if meta_dp_state.stack_root_name in self.stack_roots_names:
+                self.stack_root_name = meta_dp_state.stack_root_name
+        # Must set externals flag for entire stack.
+        for dp in stack_port_dps:
+            if dp.has_externals:
+                self.has_externals = True
 
         edge_count = Counter()
         graph = networkx.MultiGraph()
@@ -733,18 +748,14 @@ configuration.
         if graph.size() and self.name in graph:
             if self.stack is None:
                 self.stack = {}
-            self.stack.update({
-                'root_dp': root_dp,
-                'root_dps': root_dps,
-                'graph': graph})
-            longest_path_to_root_len = 0
+            self.stack.update({'graph': graph})
+            self.stack_longest_path_to_root_len = 0
             for dp in graph.nodes():
-                path_to_root_len = len(self.shortest_path(root_dp.name, src_dp=dp))
+                path_to_root_len = len(self.shortest_path(self.stack_root_name, src_dp=dp))
                 test_config_condition(
                     path_to_root_len == 0, '%s not connected to stack' % dp)
-                longest_path_to_root_len = max(
-                    path_to_root_len, longest_path_to_root_len)
-            self.stack['longest_path_to_root_len'] = longest_path_to_root_len
+                self.stack_longest_path_to_root_len = max(
+                    path_to_root_len, self.stack_longest_path_to_root_len)
 
         if self.tunnel_acls:
             self.finalize_tunnel_acls(dps)
@@ -778,41 +789,36 @@ configuration.
         """Return shortest path to a DP, as a list of DPs."""
         if src_dp is None:
             src_dp = self.name
-        if self.stack is not None and 'root_dp' in self.stack:
+        graph = self.stack.get('graph', None)
+        if graph:
             try:
-                return networkx.shortest_path(
-                    self.stack['graph'], src_dp, dest_dp)
+                return networkx.shortest_path(graph, src_dp, dest_dp)
             except (networkx.exception.NetworkXNoPath, networkx.exception.NodeNotFound):
                 pass
         return []
 
     def shortest_path_to_root(self):
         """Return shortest path to root DP, as list of DPs."""
-        # TODO: root_dp will be None, if stacking is enabled but the root DP is down.
-        if self.stack is not None and 'root_dp' in self.stack:
-            root_dp = self.stack['root_dp']
-            if root_dp is not None and root_dp != self:
-                return self.shortest_path(root_dp.name)
-        return []
+        return self.shortest_path(self.stack_root_name)
 
     def is_stack_root(self):
         """Return True if this DP is the root of the stack."""
-        return self.stack and 'priority' in self.stack
-
-    def longest_path_to_root_len(self):
-        """Return length of longest path to root or None."""
-        if self.stack:
-            return self.stack.get('longest_path_to_root_len', None)
-        return None
+        return self.stack_root_name == self.name
 
     def is_stack_edge(self):
         """Return True if this DP is a stack edge."""
-        return self.longest_path_to_root_len() == len(self.shortest_path_to_root())
+        return (not self.is_stack_root() and
+                self.stack_longest_path_to_root_len == len(self.shortest_path_to_root()))
+
+    @staticmethod
+    def canonical_port_order(ports):
+        return sorted(ports, key=lambda x: x.number)
 
     def peer_stack_up_ports(self, peer_dp):
         """Return list of stack ports that are up towards a peer."""
-        return [port for port in self.stack_ports if port.running() and (
-            port.stack['dp'].name == peer_dp)]
+        return self.canonical_port_order([
+            port for port in self.stack_ports if port.running() and (
+                port.stack['dp'].name == peer_dp)])
 
     def shortest_path_port(self, dest_dp):
         """Return first port on our DP, that is the shortest path towards dest DP."""
@@ -865,7 +871,6 @@ configuration.
 
         dp_by_name = {}
         vlan_by_name = {}
-        vlans_with_external_ports = set()
 
         def resolve_ports(port_names):
             """Resolve list of ports, by port by name or number."""
@@ -1148,16 +1153,13 @@ configuration.
         test_config_condition(not self.vlans, 'no VLANs referenced by interfaces in %s' % self.name)
         dp_by_name = {dp.name: dp for dp in dps}
         vlan_by_name = {vlan.name: vlan for vlan in self.vlans.values()}
-        vlans_with_external_ports = {
-            vlan for vlan in self.vlans.values() if vlan.loop_protect_external_ports()}
+        loop_protect_external_ports = {port for port in self.ports.values() if port.loop_protect_external}
+        self.has_externals = bool(loop_protect_external_ports)
 
-        self.has_externals = bool(vlans_with_external_ports)
         resolve_stack_dps()
         resolve_mirror_destinations()
         resolve_acls()
         resolve_routers()
-
-        self._configure_tables()
 
         for port in self.ports.values():
             port.finalize()
@@ -1167,7 +1169,11 @@ configuration.
             acl.finalize()
         for router in self.routers.values():
             router.finalize()
-        self.finalize()
+
+    def finalize(self):
+        """Need to configure OF tables as very last step."""
+        self._configure_tables()
+        super(DP, self).finalize()
 
     def get_native_vlan(self, port_num):
         """Return native VLAN for a port by number, or None."""
@@ -1353,6 +1359,8 @@ configuration.
             logger.info('pipeline table config change - requires cold start')
         elif new_dp.routers != self.routers:
             logger.info('DP routers config changed - requires cold start')
+        elif new_dp.stack_root_name != self.stack_root_name:
+            logger.info('Stack root change - requires cold start')
         else:
             changed_acls = self._get_acl_config_changes(logger, new_dp)
             deleted_vlans, changed_vlans = self._get_vlan_config_changes(logger, new_dp)

--- a/faucet/dp.py
+++ b/faucet/dp.py
@@ -496,16 +496,16 @@ configuration.
         # Stacking with external ports, so need loop protection field.
         if self.has_externals:
             flood_table = table_configs['flood']
-            flood_table.set_fields = (faucet_pipeline.STACK_LOOP_PROTECT_FIELD,)
-            flood_table.match_types += ((faucet_pipeline.STACK_LOOP_PROTECT_FIELD, False),)
+            flood_table.set_fields = (valve_of.STACK_LOOP_PROTECT_FIELD,)
+            flood_table.match_types += ((valve_of.STACK_LOOP_PROTECT_FIELD, False),)
             vlan_table = table_configs['vlan']
-            vlan_table.set_fields += (faucet_pipeline.STACK_LOOP_PROTECT_FIELD,)
-            vlan_table.match_types += ((faucet_pipeline.STACK_LOOP_PROTECT_FIELD, False),)
+            vlan_table.set_fields += (valve_of.STACK_LOOP_PROTECT_FIELD,)
+            vlan_table.match_types += ((valve_of.STACK_LOOP_PROTECT_FIELD, False),)
             eth_src_table = table_configs['eth_src']
-            eth_src_table.set_fields = (faucet_pipeline.STACK_LOOP_PROTECT_FIELD,)
+            eth_src_table.set_fields = (valve_of.STACK_LOOP_PROTECT_FIELD,)
             eth_dst_table = table_configs['eth_dst']
-            eth_dst_table.set_fields = (faucet_pipeline.STACK_LOOP_PROTECT_FIELD,)
-            eth_dst_table.match_types += ((faucet_pipeline.STACK_LOOP_PROTECT_FIELD, False),)
+            eth_dst_table.set_fields = (valve_of.STACK_LOOP_PROTECT_FIELD,)
+            eth_dst_table.match_types += ((valve_of.STACK_LOOP_PROTECT_FIELD, False),)
 
         if 'egress_acl' in included_tables:
             table_configs['eth_dst'].miss_goto = 'egress_acl'

--- a/faucet/dp.py
+++ b/faucet/dp.py
@@ -633,6 +633,14 @@ configuration.
         if port.lacp and port.lacp_active:
             self.lacp_active_ports.append(port)
 
+    def lacp_forwarding(self, port):
+        """Return 1 if should signal forwarding on a LACP bundle on this DP."""
+        # TODO: just handle stacks with multiple roots - add further useful combinations.
+        if port.loop_protect_external:
+            if self.stack_root_name and not self.is_stack_root():
+                return 0
+        return 1
+
     def lldp_beacon_send_ports(self, now):
         """Return list of ports to send LLDP packets; stacked ports always send LLDP."""
         send_ports = []

--- a/faucet/faucet_metrics.py
+++ b/faucet/faucet_metrics.py
@@ -35,6 +35,9 @@ class FaucetMetrics(PromClient):
         self.PORT_REQUIRED_LABELS = self.REQUIRED_LABELS + ['port', 'port_description']
         self._dpid_counters = {}
         self._dpid_gauges = {}
+        self.faucet_stack_root_dpid = self._gauge(
+            'faucet_stack_root_dpid',
+            'set to current stack root DPID', [])
         self.faucet_config_reload_requests = self._counter(
             'faucet_config_reload_requests',
             'number of config reload requests', [])

--- a/faucet/faucet_pipeline.py
+++ b/faucet/faucet_pipeline.py
@@ -16,7 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from faucet.valve_of import STACK_LOOP_PROTECT_FIELD
 from faucet.faucet_metadata import EGRESS_METADATA_MASK
 
 

--- a/faucet/faucet_pipeline.py
+++ b/faucet/faucet_pipeline.py
@@ -16,9 +16,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from faucet.valve_of import STACK_LOOP_PROTECT_FIELD
 from faucet.faucet_metadata import EGRESS_METADATA_MASK
-
-STACK_LOOP_PROTECT_FIELD = 'vlan_pcp'
 
 
 class ValveTableConfig: # pylint: disable=too-few-public-methods,too-many-instance-attributes

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -192,7 +192,7 @@ class Valve:
             self.flood_manager = valve_flood.ValveFloodStackManager(
                 self.logger, self.dp.tables['flood'], self.pipeline,
                 self.dp.group_table, self.dp.groups,
-                self.dp.combinatorial_port_flood,
+                self.dp.combinatorial_port_flood, self.dp.canonical_port_order,
                 self.dp.stack_ports, self.dp.has_externals,
                 self.dp.shortest_path_to_root, self.dp.shortest_path_port,
                 self.dp.stack_longest_path_to_root_len, self.dp.is_stack_root,

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -677,10 +677,9 @@ class Valve:
             match_vlan = NullVLAN()
         if self.dp.has_externals:
             if port.loop_protect_external:
-                vlan_pcp = valve_of.PCP_NONEXT_PORT_FLAG
+                actions.append(vlan_table.set_no_external_forwarding_requested())
             else:
-                vlan_pcp = valve_of.PCP_EXT_PORT_FLAG
-            actions.append(valve_of.set_field(**{valve_of.STACK_LOOP_PROTECT_FIELD: vlan_pcp}))
+                actions.append(vlan_table.set_external_forwarding_requested())
         inst = [
             valve_of.apply_actions(actions),
             vlan_table.goto(self._find_forwarding_table(vlan))]

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -921,13 +921,8 @@ class Valve:
         actor_state_activity = 0
         if port.lacp_active:
             actor_state_activity = 1
-        actor_state_collecting = 1
-        actor_state_distributing = 1
-        if (port.loop_protect_external and
-                self.dp.stack_root_name and not self.dp.is_stack_root()):
-            actor_state_collecting = 0
-            actor_state_distributing = 0
-
+        actor_state_collecting = self.dp.lacp_forwarding(port)
+        actor_state_distributing = actor_state_collecting
         if lacp_pkt:
             pkt = valve_packet.lacp_reqreply(
                 self.dp.faucet_dp_mac, self.dp.faucet_dp_mac,

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -33,7 +33,6 @@ from faucet import valve_table
 from faucet import valve_util
 from faucet import valve_pipeline
 
-from faucet.faucet_pipeline import STACK_LOOP_PROTECT_FIELD
 from faucet.port import STACK_STATE_INIT, STACK_STATE_UP, STACK_STATE_DOWN
 from faucet.vlan import NullVLAN
 
@@ -678,10 +677,10 @@ class Valve:
             match_vlan = NullVLAN()
         if self.dp.has_externals:
             if port.loop_protect_external:
-                vlan_pcp = valve_packet.PCP_NONEXT_PORT_FLAG
+                vlan_pcp = valve_of.PCP_NONEXT_PORT_FLAG
             else:
-                vlan_pcp = valve_packet.PCP_EXT_PORT_FLAG
-            actions.append(valve_of.set_field(**{STACK_LOOP_PROTECT_FIELD: vlan_pcp}))
+                vlan_pcp = valve_of.PCP_EXT_PORT_FLAG
+            actions.append(valve_of.set_field(**{valve_of.STACK_LOOP_PROTECT_FIELD: vlan_pcp}))
         inst = [
             valve_of.apply_actions(actions),
             vlan_table.goto(self._find_forwarding_table(vlan))]

--- a/faucet/valve_flood.py
+++ b/faucet/valve_flood.py
@@ -306,7 +306,7 @@ class ValveFloodStackManager(ValveFloodManager):
 
     def __init__(self, logger, flood_table, pipeline, # pylint: disable=too-many-arguments
                  use_group_table, groups,
-                 combinatorial_port_flood,
+                 combinatorial_port_flood, canonical_port_order,
                  stack_ports, has_externals,
                  dp_shortest_path_to_root, shortest_path_port,
                  longest_path_to_root_len, is_stack_root,
@@ -316,6 +316,7 @@ class ValveFloodStackManager(ValveFloodManager):
             use_group_table, groups,
             combinatorial_port_flood)
         self.stack_ports = stack_ports
+        self.canonical_port_order = canonical_port_order
         self.externals = has_externals
         self.shortest_path_port = shortest_path_port
         self.dp_shortest_path_to_root = dp_shortest_path_to_root
@@ -522,9 +523,8 @@ class ValveFloodStackManager(ValveFloodManager):
             toward_flood_actions, local_flood_actions)
         return flood_acts
 
-    @staticmethod
-    def _canonical_stack_up_ports(ports):
-        return sorted([port for port in ports if port.is_stack_up()], key=lambda x: x.number)
+    def _canonical_stack_up_ports(self, ports):
+        return self.canonical_port_order([port for port in ports if port.is_stack_up()])
 
     def _build_mask_flood_rules(self, vlan, eth_dst, eth_dst_mask, # pylint: disable=too-many-arguments
                                 exclude_unicast, command):

--- a/faucet/valve_flood.py
+++ b/faucet/valve_flood.py
@@ -40,9 +40,6 @@ class ValveFloodManager(ValveManagerBase):
         (False, valve_of.mac.BROADCAST_STR, valve_packet.mac_byte_mask(6)), # eth broadcasts
     )
 
-    EXT_PORT_FLAG = 1
-    NONEXT_PORT_FLAG = 0
-
     def __init__(self, logger, flood_table, pipeline,
                  use_group_table, groups, combinatorial_port_flood):
         self.logger = logger
@@ -97,7 +94,7 @@ class ValveFloodManager(ValveManagerBase):
     def _build_flood_rule_actions(self, vlan, exclude_unicast, in_port, exclude_all_external=False):
         tagged_flood_ports = vlan.tagged_flood_ports(exclude_unicast)
         has_external = vlan.loop_protect_external_ports() and tagged_flood_ports
-        pcp_prefix = [self._set_ext_flag(self.EXT_PORT_FLAG)] if has_external else []
+        pcp_prefix = [self._set_ext_flag(valve_packet.PCP_EXT_PORT_FLAG)] if has_external else []
         return pcp_prefix + self._build_flood_local_rule_actions(
             vlan, exclude_unicast, in_port, exclude_all_external)
 
@@ -345,10 +342,10 @@ class ValveFloodStackManager(ValveFloodManager):
         self._set_ext_port_flag = []
         self._set_nonext_port_flag = []
         if self.externals:
-            self._set_ext_port_flag = [self._set_ext_flag(self.EXT_PORT_FLAG)]
-            self._set_nonext_port_flag = [self._set_ext_flag(self.NONEXT_PORT_FLAG)]
+            self._set_ext_port_flag = [self._set_ext_flag(valve_packet.PCP_EXT_PORT_FLAG)]
+            self._set_nonext_port_flag = [self._set_ext_flag(valve_packet.PCP_NONEXT_PORT_FLAG)]
         self._flood_actions_func = self._flood_actions
-        stack_size = self.longest_path_to_root_len()
+        stack_size = self.longest_path_to_root_len
         if stack_size == 2:
             self._flood_actions_func = self._flood_actions_size2
 
@@ -534,7 +531,6 @@ class ValveFloodStackManager(ValveFloodManager):
         # Stack ports aren't in VLANs, so need special rules to cause flooding from them.
         ofmsgs = super(ValveFloodStackManager, self)._build_mask_flood_rules(
             vlan, eth_dst, eth_dst_mask, exclude_unicast, command)
-        external_ports = vlan.loop_protect_external_ports()
         towards_up_ports = self._canonical_stack_up_ports(self.towards_root_stack_ports)
         away_up_ports_by_dp = defaultdict(list)
         for port in self._canonical_stack_up_ports(self.away_from_root_stack_ports):
@@ -583,11 +579,11 @@ class ValveFloodStackManager(ValveFloodManager):
                     ofmsgs.extend(self.pipeline.remove_filter(
                         match, priority_offset=priority_offset))
 
-            if self.externals and external_ports:
+            if self.externals:
                 # If external flag is set, flood to external ports, otherwise exclude them.
                 for ext_port_flag, exclude_all_external in (
-                        (self.NONEXT_PORT_FLAG, True),
-                        (self.EXT_PORT_FLAG, False)):
+                        (valve_packet.PCP_NONEXT_PORT_FLAG, True),
+                        (valve_packet.PCP_EXT_PORT_FLAG, False)):
                     if not prune:
                         flood_acts, _, _ = self._build_flood_acts_for_port(
                             vlan, exclude_unicast, port, exclude_all_external=exclude_all_external)

--- a/faucet/valve_host.py
+++ b/faucet/valve_host.py
@@ -229,16 +229,19 @@ class ValveHostManager(ValveManagerBase):
             return ofmsgs
 
         external_forwarding_requested = None
-        if port.tagged_vlans and port.loop_protect_external and self.stack:
-            external_forwarding_requested = False
-        elif self.has_externals and not port.stack:
-            external_forwarding_requested = True
+        vlan_pcp = None
+        if self.has_externals:
+            vlan_pcp = valve_of.PCP_EXT_PORT_FLAG
+
+            if port.tagged_vlans and port.loop_protect_external and self.stack:
+                external_forwarding_requested = False
+            elif not port.stack:
+                external_forwarding_requested = True
 
         inst = self.pipeline.output(
             port, vlan, external_forwarding_requested=external_forwarding_requested)
 
         # Output packets for this MAC to specified port.
-        vlan_pcp = valve_of.PCP_EXT_PORT_FLAG if self.has_externals else None
         ofmsgs.append(self.eth_dst_table.flowmod(
             self.eth_dst_table.match(
                 vlan=vlan, eth_dst=eth_src, vlan_pcp=vlan_pcp),

--- a/faucet/valve_host.py
+++ b/faucet/valve_host.py
@@ -20,6 +20,7 @@
 import random
 
 from faucet import valve_of
+from faucet import valve_packet
 from faucet.valve_manager_base import ValveManagerBase
 
 
@@ -28,7 +29,8 @@ class ValveHostManager(ValveManagerBase):
 
     def __init__(self, logger, ports, vlans, eth_src_table, eth_dst_table,
                  eth_dst_hairpin_table, pipeline, learn_timeout, learn_jitter,
-                 learn_ban_timeout, cache_update_guard_time, idle_dst, stack):
+                 learn_ban_timeout, cache_update_guard_time, idle_dst, stack,
+                 has_externals):
         self.logger = logger
         self.ports = ports
         self.vlans = vlans
@@ -45,7 +47,7 @@ class ValveHostManager(ValveManagerBase):
         self.output_table = self.eth_dst_table
         self.idle_dst = idle_dst
         self.stack = stack
-        self.has_externals = self._has_externals(vlans)
+        self.has_externals = has_externals
         if self.eth_dst_hairpin_table:
             self.output_table = self.eth_dst_hairpin_table
 
@@ -167,12 +169,6 @@ class ValveHostManager(ValveManagerBase):
             dst_rule_idle_timeout = 0
         return (src_rule_idle_timeout, src_rule_hard_timeout, dst_rule_idle_timeout)
 
-    def _has_externals(self, vlans):
-        has_externals = False
-        for vlan in vlans.values():
-            has_externals = has_externals | bool(vlan.loop_protect_external_ports())
-        return has_externals
-
     def learn_host_intervlan_routing_flows(self, port, vlan, eth_src, eth_dst):
         """Returns flows for the eth_src_table that enable packets that have been
            routed to be accepted from an adjacent DP and then switched to the destination.
@@ -234,12 +230,12 @@ class ValveHostManager(ValveManagerBase):
 
         loop_protect_field = None
         if port.tagged_vlans and port.loop_protect_external and self.stack:
-            loop_protect_field = 0
+            loop_protect_field = valve_packet.PCP_NONEXT_PORT_FLAG
         elif self.has_externals and not port.stack:
-            loop_protect_field = 1
+            loop_protect_field = valve_packet.PCP_EXT_PORT_FLAG
 
         # Output packets for this MAC to specified port.
-        vlan_pcp = 1 if self.has_externals else None
+        vlan_pcp = valve_packet.PCP_EXT_PORT_FLAG if self.has_externals else None
         ofmsgs.append(self.eth_dst_table.flowmod(
             self.eth_dst_table.match(vlan=vlan, eth_dst=eth_src, vlan_pcp=vlan_pcp),
             priority=self.host_priority,
@@ -248,7 +244,9 @@ class ValveHostManager(ValveManagerBase):
 
         if self.has_externals and not port.loop_protect_external:
             ofmsgs.append(self.eth_dst_table.flowmod(
-                self.eth_dst_table.match(vlan=vlan, eth_dst=eth_src, vlan_pcp=0),
+                self.eth_dst_table.match(
+                    vlan=vlan, eth_dst=eth_src,
+                    vlan_pcp=valve_packet.PCP_NONEXT_PORT_FLAG),
                 priority=self.host_priority,
                 inst=self.pipeline.output(port, vlan, loop_protect_field=loop_protect_field),
                 idle_timeout=dst_rule_idle_timeout))

--- a/faucet/valve_host.py
+++ b/faucet/valve_host.py
@@ -20,7 +20,6 @@
 import random
 
 from faucet import valve_of
-from faucet import valve_packet
 from faucet.valve_manager_base import ValveManagerBase
 
 

--- a/faucet/valve_host.py
+++ b/faucet/valve_host.py
@@ -230,12 +230,12 @@ class ValveHostManager(ValveManagerBase):
 
         loop_protect_field = None
         if port.tagged_vlans and port.loop_protect_external and self.stack:
-            loop_protect_field = valve_packet.PCP_NONEXT_PORT_FLAG
+            loop_protect_field = valve_of.PCP_NONEXT_PORT_FLAG
         elif self.has_externals and not port.stack:
-            loop_protect_field = valve_packet.PCP_EXT_PORT_FLAG
+            loop_protect_field = valve_of.PCP_EXT_PORT_FLAG
 
         # Output packets for this MAC to specified port.
-        vlan_pcp = valve_packet.PCP_EXT_PORT_FLAG if self.has_externals else None
+        vlan_pcp = valve_of.PCP_EXT_PORT_FLAG if self.has_externals else None
         ofmsgs.append(self.eth_dst_table.flowmod(
             self.eth_dst_table.match(vlan=vlan, eth_dst=eth_src, vlan_pcp=vlan_pcp),
             priority=self.host_priority,
@@ -246,7 +246,7 @@ class ValveHostManager(ValveManagerBase):
             ofmsgs.append(self.eth_dst_table.flowmod(
                 self.eth_dst_table.match(
                     vlan=vlan, eth_dst=eth_src,
-                    vlan_pcp=valve_packet.PCP_NONEXT_PORT_FLAG),
+                    vlan_pcp=valve_of.PCP_NONEXT_PORT_FLAG),
                 priority=self.host_priority,
                 inst=self.pipeline.output(port, vlan, loop_protect_field=loop_protect_field),
                 idle_timeout=dst_rule_idle_timeout))

--- a/faucet/valve_of.py
+++ b/faucet/valve_of.py
@@ -41,6 +41,13 @@ OFP_IN_PORT = ofp.OFPP_IN_PORT
 MAX_PACKET_IN_BYTES = 160 # largest packet is icmp6 echo.
 ECTP_ETH_TYPE = 0x9000
 
+# https://en.wikipedia.org/wiki/IEEE_P802.1p
+# Avoid use of PCP 1 which is BK priority (lowest)
+PCP_EXT_PORT_FLAG = 2
+PCP_NONEXT_PORT_FLAG = 0
+STACK_LOOP_PROTECT_FIELD = 'vlan_pcp'
+
+
 OFERROR_TYPE_CODE = {
     0: ('OFPET_HELLO_FAILED', {
         ofp.OFPHFC_INCOMPATIBLE: 'OFPHFC_INCOMPATIBLE',

--- a/faucet/valve_of.py
+++ b/faucet/valve_of.py
@@ -45,7 +45,7 @@ ECTP_ETH_TYPE = 0x9000
 # Avoid use of PCP 1 which is BK priority (lowest)
 PCP_EXT_PORT_FLAG = 2
 PCP_NONEXT_PORT_FLAG = 0
-STACK_LOOP_PROTECT_FIELD = 'vlan_pcp'
+EXTERNAL_FORWARDING_FIELD = 'vlan_pcp'
 
 
 OFERROR_TYPE_CODE = {

--- a/faucet/valve_packet.py
+++ b/faucet/valve_packet.py
@@ -68,6 +68,11 @@ LACP_SIZE = 124
 EUI_BITS = len(EUI(0).packed*8)
 MAC_MASK_BITMAP = {(2**EUI_BITS - 2**i): (EUI_BITS - i) for i in range(0, EUI_BITS + 1)}
 
+# https://en.wikipedia.org/wiki/IEEE_P802.1p
+# Avoid use of PCP 1 which is BK priority (lowest)
+PCP_EXT_PORT_FLAG = 1
+PCP_NONEXT_PORT_FLAG = 0
+
 
 def mac_mask_bits(mac_mask):
     """Return number of bits in MAC mask or 0."""
@@ -351,6 +356,8 @@ def lacp_reqreply(eth_src,
                   actor_system, actor_key, actor_port,
                   actor_state_synchronization=0,
                   actor_state_activity=0,
+                  actor_state_collecting=1,
+                  actor_state_distibuting=1,
                   partner_system='00:00:00:00:00:00',
                   partner_key=0,
                   partner_port=0,
@@ -373,6 +380,8 @@ def lacp_reqreply(eth_src,
         actor_port (int): actor port number.
         actor_state_synchronization (int): 1 if we will use this link.
         actor_state_activity (int): 1 if actively sending LACP.
+        actor_state_collecting (int): 1 if receiving on this link.
+        actor_state_distibuting (int): 1 if transmitting on this link.
         partner_system (str): partner system ID (MAC address)
         partner_key (int): partner's LACP key assigned to this port.
         partner_port (int): partner port number.

--- a/faucet/valve_packet.py
+++ b/faucet/valve_packet.py
@@ -68,11 +68,6 @@ LACP_SIZE = 124
 EUI_BITS = len(EUI(0).packed*8)
 MAC_MASK_BITMAP = {(2**EUI_BITS - 2**i): (EUI_BITS - i) for i in range(0, EUI_BITS + 1)}
 
-# https://en.wikipedia.org/wiki/IEEE_P802.1p
-# Avoid use of PCP 1 which is BK priority (lowest)
-PCP_EXT_PORT_FLAG = 2
-PCP_NONEXT_PORT_FLAG = 0
-
 
 def mac_mask_bits(mac_mask):
     """Return number of bits in MAC mask or 0."""

--- a/faucet/valve_packet.py
+++ b/faucet/valve_packet.py
@@ -70,7 +70,7 @@ MAC_MASK_BITMAP = {(2**EUI_BITS - 2**i): (EUI_BITS - i) for i in range(0, EUI_BI
 
 # https://en.wikipedia.org/wiki/IEEE_P802.1p
 # Avoid use of PCP 1 which is BK priority (lowest)
-PCP_EXT_PORT_FLAG = 1
+PCP_EXT_PORT_FLAG = 2
 PCP_NONEXT_PORT_FLAG = 0
 
 

--- a/faucet/valve_pipeline.py
+++ b/faucet/valve_pipeline.py
@@ -95,7 +95,7 @@ class ValvePipeline(ValveManagerBase):
         assert self.egress_table is not None
         return self._accept_to_table(self.egress_table, actions)
 
-    def output(self, port, vlan, hairpin=False, loop_protect_field=None):
+    def output(self, port, vlan, hairpin=False, external_forwarding_requested=None):
         """Get instructions list to output a packet through the regular
         pipeline.
 
@@ -121,7 +121,7 @@ class ValvePipeline(ValveManagerBase):
         else:
             instructions.append(valve_of.apply_actions(vlan.output_port(
                 port, hairpin=hairpin, output_table=self.output_table,
-                loop_protect_field=loop_protect_field)))
+                external_forwarding_requested=external_forwarding_requested)))
         return instructions
 
     def initialise_tables(self):

--- a/faucet/valve_table.py
+++ b/faucet/valve_table.py
@@ -72,6 +72,14 @@ class ValveTable: # pylint: disable=too-many-arguments,too-many-instance-attribu
                         '%s not configured as set field in %s' % (field, self.name))
         return valve_of.set_field(**kwds)
 
+    def set_external_forwarding_requested(self):
+        """Set field for external forwarding requested."""
+        return self.set_field(**{valve_of.EXTERNAL_FORWARDING_FIELD: valve_of.PCP_EXT_PORT_FLAG})
+
+    def set_no_external_forwarding_requested(self):
+        """Set field for no external forwarding requested."""
+        return self.set_field(**{valve_of.EXTERNAL_FORWARDING_FIELD: valve_of.PCP_NONEXT_PORT_FLAG})
+
     def set_vlan_vid(self, vlan_vid):
         """Set VLAN VID with VID_PRESENT flag set.
 

--- a/tests/integration/mininet_tests.py
+++ b/tests/integration/mininet_tests.py
@@ -4871,7 +4871,7 @@ acls:
             actions:
                 output:
                     set_fields:
-                        - vlan_pcp: 1
+                        - vlan_pcp: 2
                 allow: 1
         - rule:
             actions:
@@ -4904,7 +4904,7 @@ acls:
             second_host, tcpdump_filter, [
                 lambda: first_host.cmd(
                     'ping -c3 %s' % second_host.IP())], root_intf=True, packets=1)
-        self.assertTrue(re.search('vlan 100, p 1,', tcpdump_txt))
+        self.assertTrue(re.search('vlan 100, p 2,', tcpdump_txt))
 
 
 class FaucetTaggedGlobalIPv4RouteTest(FaucetTaggedTest):
@@ -5243,7 +5243,7 @@ acls:
             actions:
                 output:
                     set_fields:
-                        - vlan_pcp: 1
+                        - vlan_pcp: 2
                 allow: 1
 """
 
@@ -5270,7 +5270,7 @@ acls:
                 lambda: from_port.cmd(
                     'ping -c3 %s' % to_port.IP())], root_intf=True, packets=2)
         if expected:
-            self.assertTrue(re.search('vlan 100, p 1,', tcpdump_txt))
+            self.assertTrue(re.search('vlan 100, p 2,', tcpdump_txt))
             self.assertFalse(re.search('vlan 100, p 0,', tcpdump_txt))
         else:
             self.assertFalse(re.search('vlan 100,', tcpdump_txt))

--- a/tests/integration/mininet_tests.py
+++ b/tests/integration/mininet_tests.py
@@ -6816,7 +6816,7 @@ class FaucetStringOfDPTest(FaucetTest):
         ), 'Tunnel was not established')
 
 
-class FaucetUntaggedIPV4RoutingWithStackingTest(FaucetStringOfDPTest):
+class FaucetSingleUntaggedIPV4RoutingWithStackingTest(FaucetStringOfDPTest):
     """IPV4 intervlan routing with stacking test"""
 
     IPV = 4
@@ -6849,7 +6849,7 @@ class FaucetUntaggedIPV4RoutingWithStackingTest(FaucetStringOfDPTest):
         pass
 
     def set_up(self):
-        super(FaucetUntaggedIPV4RoutingWithStackingTest, self).setUp()
+        super(FaucetSingleUntaggedIPV4RoutingWithStackingTest, self).setUp()
         router_info = {
             self.V100: {
                 'faucet_mac': self.FAUCET_MAC,
@@ -7026,7 +7026,7 @@ class FaucetUntaggedIPV4RoutingWithStackingTest(FaucetStringOfDPTest):
             self._ip_neigh(v200_host, second_faucet_vip.ip, self.IPV), self.FAUCET_MAC2)
 
 
-class FaucetUntaggedIPV6RoutingWithStackingTest(FaucetUntaggedIPV4RoutingWithStackingTest):
+class FaucetSingleUntaggedIPV6RoutingWithStackingTest(FaucetSingleUntaggedIPV4RoutingWithStackingTest):
     """IPV6 intervlan routing with stacking tests"""
 
     IPV = 6

--- a/tests/unit/faucet/test_config.py
+++ b/tests/unit/faucet/test_config.py
@@ -68,11 +68,8 @@ class TestConfig(unittest.TestCase): # pytype: disable=module-attr
         self.assertEqual(config_success, True, config_err)
 
     def _get_dps_as_dict(self, config):
-        result = {}
-        _, dps = cp.dp_parser(self.create_config_file(config), LOGNAME)
-        for dp in dps:
-            result[dp.dp_id] = dp
-        return result
+        _, dps, _ = cp.dp_parser(self.create_config_file(config), LOGNAME)
+        return {dp.dp_id: dp for dp in dps}
 
     def test_one_port_dp(self):
         """Test basic port configuration."""
@@ -128,7 +125,7 @@ vlans:
     office:
         vid: 100
 dps:
-    sw1:
+    t1-1:
         dp_id: 0x1
         hardware: "Open vSwitch"
         stack:
@@ -136,20 +133,43 @@ dps:
         interfaces:
             1:
                 stack:
-                    dp: sw2
+                    dp: t2-1
                     port: 1
             2:
                 native_vlan: office
-    sw2:
+            3:
+                native_vlan: office
+                loop_protect_external: True
+    t1-2:
         dp_id: 0x2
+        hardware: "Open vSwitch"
+        stack:
+            priority: 2
+        interfaces:
+            1:
+                stack:
+                    dp: t2-1
+                    port: 2
+            2:
+                native_vlan: office
+            3:
+                native_vlan: office
+                loop_protect_external: True
+    t2-1:
+        dp_id: 0x3
         hardware: "Open vSwitch"
         interfaces:
             1:
                 stack:
-                    dp: sw1
+                    dp: t1-1
                     port: 1
             2:
+                stack:
+                    dp: t1-2
+                    port: 1
+            3:
                 native_vlan: office
+                loop_protect_external: False
 """
         self.check_config_success(config, cp.dp_parser)
         dps = self._get_dps_as_dict(config)
@@ -157,28 +177,35 @@ dps:
             self.assertTrue(
                 dp.stack is not None, 'stack not configured for DP')
             self.assertEqual(
-                dp.stack['root_dp'].dp_id, 1, 'root_dp configured incorrectly')
+                dp.stack_root_name, 't1-1', 'root_dp configured incorrectly')
+            self.assertEqual(
+                dp.stack_roots_names, ('t1-1', 't1-2'), 'root_dps configured incorrectly')
             self.assertEqual(
                 len(dp.stack['graph'].nodes),
-                2,
+                3,
                 'stack graph has incorrect nodes'
                 )
-        for dp_id, remote_dp_id in ((1, 2), (2, 1)):
-            stack_port = dps[dp_id].stack_ports[0]
-            self.assertEqual(
-                stack_port.number, 1, 'incorrect stack port configured')
             self.assertTrue(
-                stack_port.stack is not None, 'stack not configured for port')
-            self.assertEqual(
-                stack_port.stack['dp'].dp_id,
-                remote_dp_id,
-                'remote stack dp configured incorrectly'
-                )
-            self.assertEqual(
-                stack_port.stack['port'].number,
-                1,
-                'remote stack port configured incorrectly'
-                )
+                dp.has_externals,
+                'All DPs must have external flag set if one DP has it')
+
+        t2_dpid = 0x3
+        for root_dpid in (1, 2):
+            root_stack_port = dps[root_dpid].stack_ports[0]
+            t2_stack_port = dps[t2_dpid].stack_ports[root_dpid-1]
+            stack_link_a = (root_dpid, root_stack_port)
+            stack_link_b = (t2_dpid, t2_stack_port)
+            for dpid_a, port_a, dpid_b, port_b in (
+                    (stack_link_a + stack_link_b),
+                    (stack_link_b + stack_link_a)):
+                self.assertEqual(
+                    port_a.stack['dp'].dp_id,
+                    dpid_b,
+                    'remote stack dp configured incorrectly')
+                self.assertEqual(
+                    port_a.stack['port'].number,
+                    port_b.number,
+                    'remote stack dp configured incorrectly')
 
     def test_config_stack_and_non_stack(self):
         """Test stack and non-stacking config."""
@@ -746,7 +773,7 @@ dps:
                 native_vlan: 'v100'
 """
         conf_file = self.create_config_file(config)
-        _, dps = cp.dp_parser(conf_file, LOGNAME)
+        _, dps, _ = cp.dp_parser(conf_file, LOGNAME)
         outputs = {
             's1': 2,
             's2': 3
@@ -787,7 +814,7 @@ dps:
                 description: "video conf"
 """
         conf_file = self.create_config_file(config)
-        _, dps = cp.dp_parser(conf_file, LOGNAME)
+        _, dps, _ = cp.dp_parser(conf_file, LOGNAME)
         dp = dps[0]
         self.assertEqual(len(dp.ports), 8)
         self.assertTrue(all([p.permanent_learn for p in dp.ports.values() if p.number < 9]))
@@ -809,7 +836,7 @@ dps:
                 native_vlan: office
 """
         conf_file = self.create_config_file(config)
-        _, dps = cp.dp_parser(conf_file, LOGNAME)
+        _, dps, _ = cp.dp_parser(conf_file, LOGNAME)
         dp = dps[0]
         self.assertEqual(len(dp.ports), 1)
 
@@ -2924,24 +2951,6 @@ dps:
             unknown_key:
                 name: port1
                 number: 3
-                native_vlan: office
-"""
-        self.check_config_failure(config, cp.dp_parser)
-
-    def test_dp_lldp_minimal_invalid(self):
-        """Test minimal invalid DP config."""
-        config = """
-vlans:
-    office:
-        vid: 100
-dps:
-    sw1:
-        dp_id: 0x1
-        lldp_beacon:
-            system_name: test_system
-        interfaces:
-            testing:
-                number: 1
                 native_vlan: office
 """
         self.check_config_failure(config, cp.dp_parser)


### PR DESCRIPTION
* Add support for multiple stack roots (FAUCET will pick one, only the active one will use any LACP bundle)
* Clarify use of external forwarding requested field, avoid PCP 1, remove unneeded TFM request to vlan_pcp on eth_src.
