### PR TITLE
Add a profiling option to the integration tests

### DIFF
--- a/docker/runtests.sh
+++ b/docker/runtests.sh
@@ -9,7 +9,7 @@ set -e  # quit on error
 
 # allow user to skip parts of docker test
 # this wrapper script only cares about -n, -u, -i, others passed to test suite.
-while getopts "cdijknrsuxozl" o $FAUCET_TESTS; do
+while getopts "cdijknrsuxozlp" o $FAUCET_TESTS; do
   case "${o}" in
         i)
             # run only integration tests


### PR DESCRIPTION
Add a `--profile` option to report elapsed real (wall clock) time for functions, sorted by
cumulative time spent. This may help to identify opportunities for speeding up the tests, for
example reducing unnecessary `sleep()` calls.