### PR TITLE
Improve deploy_deb.sh.

### DIFF
--- a/gitlab/deploy_deb.sh
+++ b/gitlab/deploy_deb.sh
@@ -2,20 +2,29 @@
 
 echo "{\"url\":\"https://packagecloud.io\",\"token\":\"$PACKAGECLOUD_TOKEN\"}" > ~/.packagecloud
 
-curl -o /tmp/ubuntu-releases.csv https://salsa.debian.org/debian/distro-info-data/raw/master/ubuntu.csv
-curl -o /tmp/debian-releases.csv https://salsa.debian.org/debian/distro-info-data/raw/master/debian.csv
+git_tmp_dir=$(mktemp -d /tmp/distro-info-data-XXXXX)
+
+echo "==== Cloning distro-info-data git repo ==="
+
+git clone --depth 1 https://salsa.debian.org/debian/distro-info-data "${git_tmp_dir}"
 
 for release in $(awk -F ',' -v today="$(date --utc "+%F")" \
     'BEGIN {OFS=","} NR>1 { if (($6 == "" || $6 >= today) && ($5 != "" && $5 <= today)) print $3 }' \
-    /tmp/ubuntu-releases.csv); do
+    ${git_tmp_dir}/ubuntu.csv); do
 
-    package_cloud push faucetsdn/faucet/ubuntu/$release *.deb || true
+    echo "==== Uploading packages to ubuntu/${release} ==="
+    package_cloud push faucetsdn/faucet/ubuntu/${release} *.deb < /dev/null || true
 done
 
 for release in $(awk -F ',' -v today="$(date --utc "+%F")" \
     'BEGIN {OFS=","} NR>1 { if (($6 == "" || $6 >= today) && ($4 != "" && $4 <= today)) print $3 }' \
-    /tmp/debian-releases.csv | egrep -v "(sid|experimental)"); do
+    ${git_tmp_dir}/debian.csv | egrep -v "(sid|experimental)"); do
 
-    package_cloud push faucetsdn/faucet/debian/$release *.deb || true
-    package_cloud push faucetsdn/faucet/raspbian/$release *.deb || true
+    echo "==== Uploading packages to debian/${release} ==="
+    package_cloud push faucetsdn/faucet/debian/$release *.deb < /dev/null || true
+
+    echo "==== Uploading packages to raspbian/${release} ==="
+    package_cloud push faucetsdn/faucet/raspbian/$release *.deb < /dev/null || true
 done
+
+rm -rf "${git_tmp_dir}"


### PR DESCRIPTION
  * Don't use gitlab web interface (which is rate limited) to download CSVs.
  * Allow script to run interactively better by disconnecting stdin.