### PR TITLE
Allow FAUCET to optionally, automatically revert bad configs itself

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1078,7 +1078,11 @@ such as paths for configuration files and port numbers.
       - Colon-separated list of file paths
       - | /etc/faucet/faucet.yaml:
         | /etc/ryu/faucet/faucet.yaml
-      - Faucet will load it's configuration from the first valid file in list
+      - Faucet will load its configuration from the first valid file in list
+    * - FAUCET_CONFIG_AUTO_REVERT
+      - boolean
+      - False
+      - If true, Faucet will attempt to revert a bad config file back to the last known good version.
     * - FAUCET_CONFIG_STAT_RELOAD
       - boolean
       - False

--- a/faucet/check_faucet_config.py
+++ b/faucet/check_faucet_config.py
@@ -43,7 +43,7 @@ def check_config(conf_files, debug_level, check_output_file):
             check_result = False
 
             try:
-                _, dps, _ = dp_parser(conf_file, logname)
+                _, _, dps, _ = dp_parser(conf_file, logname)
                 if dps is not None:
                     dps_conf = [(valve.valve_factory(dp), dp.to_conf()) for dp in dps]
                     check_output.extend([conf for _, conf in dps_conf])

--- a/faucet/config_parser.py
+++ b/faucet/config_parser.py
@@ -16,7 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import collections
 import copy
 import re
 
@@ -46,10 +45,13 @@ def dp_parser(config_file, logname, meta_dp_state=None):
     dps = None
 
     test_config_condition(conf is None, 'Config file is empty')
-    test_config_condition(not isinstance(conf, dict), 'Config file does not have valid syntax')
+    test_config_condition(
+        not isinstance(conf, dict),
+        'Config file does not have valid syntax')
     version = conf.pop('version', 2)
     test_config_condition(version != 2, 'Only config version 2 is supported')
-    config_hashes, config_contents, dps, top_conf = _config_parser_v2(config_file, logname, meta_dp_state)
+    config_hashes, config_contents, dps, top_conf = _config_parser_v2(
+        config_file, logname, meta_dp_state)
     test_config_condition(dps is None, 'no DPs are not defined')
 
     return config_hashes, config_contents, dps, top_conf

--- a/faucet/config_parser.py
+++ b/faucet/config_parser.py
@@ -41,7 +41,7 @@ V2_TOP_CONFS = (
 
 def dp_parser(config_file, logname, meta_dp_state=None):
     """Parse a config file into DP configuration objects with hashes of config include/files."""
-    conf = config_parser_util.read_config(config_file, logname)
+    conf, _ = config_parser_util.read_config(config_file, logname)
     config_hashes = None
     dps = None
 
@@ -242,7 +242,7 @@ def _config_parser_v2(config_file, logname, meta_dp_state):
 
 def watcher_parser(config_file, logname, prom_client):
     """Return Watcher instances from config."""
-    conf = config_parser_util.read_config(config_file, logname)
+    conf, _ = config_parser_util.read_config(config_file, logname)
     conf_hash = config_parser_util.config_file_hash(config_file)
     faucet_config_files, faucet_conf_hashes, result = _watcher_parser_v2(
         conf, logname, prom_client)

--- a/faucet/config_parser.py
+++ b/faucet/config_parser.py
@@ -200,12 +200,11 @@ def _dp_parser_v2(dps_conf, acls_conf, meters_conf,
             'DPID %u is duplicated' % dp.dp_id))
         dpid_refs.add(dp.dp_id)
 
-    router_ref_dps = collections.defaultdict(set)
+    routers_referenced = set()
     for dp in dps:
-        for router in dp.routers.keys():
-            router_ref_dps[router].add(dp)
-    for router in routers_conf.keys():
-        test_config_condition(not router_ref_dps[router], (
+        routers_referenced.update(dp.routers.keys())
+    for router in routers_conf:
+        test_config_condition(router not in routers_referenced, (
             'router %s configured but not used by any DP' % router))
 
     return dps

--- a/faucet/config_parser_util.py
+++ b/faucet/config_parser_util.py
@@ -120,7 +120,7 @@ def dp_include(config_hashes, config_contents, config_file, logname, top_confs):
     new_config_hashes = config_hashes.copy()
     new_config_hashes[config_file] = config_file_hash(config_file)
     new_config_contents = config_contents.copy()
-    new_config_contents[config_file] = config_contents
+    new_config_contents[config_file] = config_content
 
     # Save the updated configuration state in separate dicts,
     # so if an error is found, the changes can simply be thrown away.

--- a/faucet/config_parser_util.py
+++ b/faucet/config_parser_util.py
@@ -67,16 +67,19 @@ def get_logger(logname):
 def read_config(config_file, logname):
     """Return a parsed YAML config file or None."""
     logger = get_logger(logname)
+    conf_txt = None
+    conf = None
+
     try:
         with open(config_file, 'r') as stream:
             conf_txt = stream.read()
-        return yaml.safe_load(conf_txt)
+        conf = yaml.safe_load(conf_txt)
     except (yaml.YAMLError, UnicodeDecodeError,
             PermissionError, ValueError) as err: # pytype: disable=name-error
         logger.error('Error in file %s (%s)', config_file, str(err))
     except FileNotFoundError as err: # pytype: disable=name-error
         logger.error('Could not find requested file: %s', config_file)
-    return None
+    return conf, conf_txt
 
 
 def config_file_hash(config_file_name):
@@ -100,7 +103,7 @@ def dp_include(config_hashes, config_file, logname, top_confs):
     if not os.path.isfile(config_file):
         logger.warning('not a regular file or does not exist: %s', config_file)
         return False
-    conf = read_config(config_file, logname)
+    conf, _ = read_config(config_file, logname)
     if not conf:
         logger.warning('error loading config from file: %s', config_file)
         return False

--- a/faucet/faucet.py
+++ b/faucet/faucet.py
@@ -116,6 +116,7 @@ class Faucet(RyuAppBase):
             self.logname, self.logger, self.metrics, self.notifier, self.bgp,
             self.dot1x, self._send_flow_msgs)
         self.thread_managers = (self.bgp, self.dot1x, self.metrics, self.notifier)
+        self.config_auto_revert = self.get_setting('AUTO_REVERT')
 
     @kill_on_exception(exc_logname)
     def _check_thread_exception(self):

--- a/faucet/faucet.py
+++ b/faucet/faucet.py
@@ -114,9 +114,8 @@ class Faucet(RyuAppBase):
             self.get_setting('EVENT_SOCK'), self.metrics, self.logger)
         self.valves_manager = valves_manager.ValvesManager(
             self.logname, self.logger, self.metrics, self.notifier, self.bgp,
-            self.dot1x, self._send_flow_msgs)
+            self.dot1x, self.get_setting('CONFIG_AUTO_REVERT'), self._send_flow_msgs)
         self.thread_managers = (self.bgp, self.dot1x, self.metrics, self.notifier)
-        self.config_auto_revert = self.get_setting('AUTO_REVERT')
 
     @kill_on_exception(exc_logname)
     def _check_thread_exception(self):

--- a/faucet/valve_util.py
+++ b/faucet/valve_util.py
@@ -73,6 +73,7 @@ DEFAULTS = {
         _PREFIX,
         '/etc/ryu/faucet/faucet.yaml')),
     'FAUCET_CONFIG_STAT_RELOAD': False,
+    'FAUCET_CONFIG_AUTO_REVERT': False,
     'FAUCET_LOG_LEVEL': 'INFO',
     'FAUCET_LOG': _PREFIX + '/var/log/faucet/faucet.log',
     'FAUCET_EVENT_SOCK': '',  # Special-case, see get_setting().

--- a/faucet/valves_manager.py
+++ b/faucet/valves_manager.py
@@ -36,6 +36,7 @@ class MetaDPState:
         self.stack_root_name = None
         self.dp_last_live_time = {}
         self.top_conf = None
+        self.last_good_config = {}
 
 
 class ConfigWatcher:
@@ -79,15 +80,16 @@ class ValvesManager:
     valves = None # type: dict
 
     def __init__(self, logname, logger, metrics, notifier, bgp,
-                 dot1x, send_flows_to_dp_by_id):
+                 dot1x, config_auto_revert, send_flows_to_dp_by_id):
         """Initialize ValvesManager.
 
         Args:
             logname (str): log name to use in logging.
-            logger  (logging.logging): logger instance to use for logging.
+            logger (logging.logging): logger instance to use for logging.
             metrics (FaucetMetrics): metrics instance.
             notifier (FaucetEvent): event notifier instance.
             bgp (FaucetBgp): BGP instance.
+            config_auto_revert (bool): True if FAUCET should attempt to revert bad configs.
             send_flows_to_dp_by_id: callable, two args - DP ID and list of flows to send to DP.
         """
         self.logname = logname
@@ -96,6 +98,7 @@ class ValvesManager:
         self.notifier = notifier
         self.bgp = bgp
         self.dot1x = dot1x
+        self.config_auto_revert = config_auto_revert
         self.send_flows_to_dp_by_id = send_flows_to_dp_by_id
         self.valves = {}
         self.config_applied = {}
@@ -176,18 +179,19 @@ class ValvesManager:
         """Return parsed configs for Valves, or None."""
         self.metrics.faucet_config_hash_func.labels(algorithm=CONFIG_HASH_FUNC)
         try:
-            new_conf_hashes, _, new_dps, top_conf = dp_parser(
+            new_conf_hashes, new_config_content, new_dps, top_conf = dp_parser(
                 new_config_file, self.logname, self.meta_dp_state)
-            self.config_watcher.update(new_config_file, new_conf_hashes)
             new_present_conf_hashes = [
                 (conf_file, conf_hash) for conf_file, conf_hash in sorted(new_conf_hashes.items())
                 if conf_hash is not None]
             conf_files = [conf_file for conf_file, _ in new_present_conf_hashes]
             conf_hashes = [conf_hash for _, conf_hash in new_present_conf_hashes]
+            self.config_watcher.update(new_config_file, new_conf_hashes)
+            self.meta_dp_state.top_conf = top_conf
+            self.last_good_config = new_config_content
             self.metrics.faucet_config_hash.info(
                 dict(config_files=','.join(conf_files), hashes=','.join(conf_hashes)))
             self.metrics.faucet_config_load_error.set(0)
-            self.meta_dp_state.top_conf = top_conf
         except InvalidConfigError as err:
             self.logger.error('New config bad (%s) - rejecting', err)
             self.config_watcher.update(new_config_file)

--- a/faucet/valves_manager.py
+++ b/faucet/valves_manager.py
@@ -176,7 +176,7 @@ class ValvesManager:
         """Return parsed configs for Valves, or None."""
         self.metrics.faucet_config_hash_func.labels(algorithm=CONFIG_HASH_FUNC)
         try:
-            new_conf_hashes, new_dps, top_conf = dp_parser(
+            new_conf_hashes, _, new_dps, top_conf = dp_parser(
                 new_config_file, self.logname, self.meta_dp_state)
             self.config_watcher.update(new_config_file, new_conf_hashes)
             new_present_conf_hashes = [

--- a/tests/unit/faucet/test_config.py
+++ b/tests/unit/faucet/test_config.py
@@ -773,7 +773,7 @@ dps:
                 native_vlan: 'v100'
 """
         conf_file = self.create_config_file(config)
-        _, dps, _ = cp.dp_parser(conf_file, LOGNAME)
+        _, _, dps, _ = cp.dp_parser(conf_file, LOGNAME)
         outputs = {
             's1': 2,
             's2': 3
@@ -814,7 +814,7 @@ dps:
                 description: "video conf"
 """
         conf_file = self.create_config_file(config)
-        _, dps, _ = cp.dp_parser(conf_file, LOGNAME)
+        _, _, dps, _ = cp.dp_parser(conf_file, LOGNAME)
         dp = dps[0]
         self.assertEqual(len(dp.ports), 8)
         self.assertTrue(all([p.permanent_learn for p in dp.ports.values() if p.number < 9]))
@@ -836,7 +836,7 @@ dps:
                 native_vlan: office
 """
         conf_file = self.create_config_file(config)
-        _, dps, _ = cp.dp_parser(conf_file, LOGNAME)
+        _, _, dps, _ = cp.dp_parser(conf_file, LOGNAME)
         dp = dps[0]
         self.assertEqual(len(dp.ports), 1)
 

--- a/tests/unit/faucet/test_config.py
+++ b/tests/unit/faucet/test_config.py
@@ -68,7 +68,7 @@ class TestConfig(unittest.TestCase): # pytype: disable=module-attr
         self.assertEqual(config_success, True, config_err)
 
     def _get_dps_as_dict(self, config):
-        _, dps, _ = cp.dp_parser(self.create_config_file(config), LOGNAME)
+        _, _, dps, _ = cp.dp_parser(self.create_config_file(config), LOGNAME)
         return {dp.dp_id: dp for dp in dps}
 
     def test_one_port_dp(self):

--- a/tests/unit/faucet/valve_test_lib.py
+++ b/tests/unit/faucet/valve_test_lib.py
@@ -407,6 +407,7 @@ class ValveTestBases:
         LOGNAME = 'faucet'
         ICMP_PAYLOAD = bytes('A'*64, encoding='UTF-8')  # must support 64b payload.
         REQUIRE_TFM = True
+        CONFIG_AUTO_REVERT = False
 
         def __init__(self, *args, **kwargs):
             self.dot1x = None
@@ -444,7 +445,7 @@ class ValveTestBases:
                 self.logger, logfile, self.metrics, self.send_flows_to_dp_by_id)
             self.valves_manager = valves_manager.ValvesManager(
                 self.LOGNAME, self.logger, self.metrics, self.notifier,
-                self.bgp, self.dot1x, self.send_flows_to_dp_by_id)
+                self.bgp, self.dot1x, self.CONFIG_AUTO_REVERT, self.send_flows_to_dp_by_id)
             self.last_flows_to_dp[self.DP_ID] = []
             self.notifier.start()
             initial_ofmsgs = self.update_config(config, reload_expected=False)

--- a/tests/unit/faucet/valve_test_lib.py
+++ b/tests/unit/faucet/valve_test_lib.py
@@ -515,7 +515,8 @@ class ValveTestBases:
             flows = valve.prepare_send_flows(flows)
             self.last_flows_to_dp[valve.dp.dp_id] = flows
 
-        def update_config(self, config, reload_type='cold', reload_expected=True):
+        def update_config(self, config, reload_type='cold',
+                          reload_expected=True, error_expected=0):
             """Update FAUCET config with config as text."""
             before_dp_status = int(self.get_prom('dp_status'))
             existing_config = None
@@ -529,20 +530,26 @@ class ValveTestBases:
                 content_change_expected,
                 self.valves_manager.config_watcher.content_changed(self.config_file))
             self.last_flows_to_dp[self.DP_ID] = []
-            var = 'faucet_config_reload_%s_total' % reload_type
-            self.prom_inc(
-                partial(self.valves_manager.request_reload_configs,
-                        time.time(), self.config_file), var=var, inc_expected=reload_expected)
-            self.valve = self.valves_manager.valves[self.DP_ID]
-            if self.DP_ID in self.last_flows_to_dp:
-                reload_ofmsgs = self.last_flows_to_dp[self.DP_ID]
-                # DP requested reconnection
-                if reload_ofmsgs is None:
-                    reload_ofmsgs = self.connect_dp()
-                else:
-                    self.apply_ofmsgs(reload_ofmsgs)
+            reload_ofmsgs = []
+            reload_func = partial(
+                self.valves_manager.request_reload_configs,
+                time.time(), self.config_file)
+
+            if error_expected:
+                reload_func()
+            else:
+                var = 'faucet_config_reload_%s_total' % reload_type
+                self.prom_inc(reload_func, var=var, inc_expected=reload_expected)
+                self.valve = self.valves_manager.valves[self.DP_ID]
+                if self.DP_ID in self.last_flows_to_dp:
+                    reload_ofmsgs = self.last_flows_to_dp[self.DP_ID]
+                    # DP requested reconnection
+                    if reload_ofmsgs is None:
+                        reload_ofmsgs = self.connect_dp()
+                    else:
+                        self.apply_ofmsgs(reload_ofmsgs)
             self.assertEqual(before_dp_status, int(self.get_prom('dp_status')))
-            self.assertEqual(0, self.get_prom('faucet_config_load_error', bare=True))
+            self.assertEqual(error_expected, self.get_prom('faucet_config_load_error', bare=True))
             return reload_ofmsgs
 
         def connect_dp(self):


### PR DESCRIPTION
Fixes https://github.com/faucetsdn/faucet/issues/2719.

Setting FAUCET_CONFIG_AUTO_REVERT enables the feature.
