### PR TITLE
Enable table size to override estimate always.

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -249,7 +249,11 @@ string names given to the datapath, or the OFP datapath id.
     * - table_sizes
       - dictionary
       - {}
-      - For TFM based switches, size of each FAUCET table (all must be specified)
+      - For TFM based switches, size of each FAUCET table (any may be specified)
+    * - port_table_scale_factor
+      - float
+      - 1.0
+      - For TFM based switches, and for tables that are sized by number of ports, scale size estimate.
     * - global_vlan
       - int
       - 2**11-1

--- a/tests/unit/faucet/test_valve.py
+++ b/tests/unit/faucet/test_valve.py
@@ -372,6 +372,35 @@ vlans:
             0, int(self.get_prom('port_lacp_status', labels=labels)))
 
 
+class ValveTFMSizeOverride(ValveTestBases.ValveTestSmall):
+    """Test TFM size override."""
+
+    CONFIG = """
+dps:
+    s1:
+%s
+        table_sizes:
+            eth_src: 999
+        interfaces:
+            p1:
+                number: 1
+                native_vlan: v100
+vlans:
+    v100:
+        vid: 0x100
+""" % DP1_CONFIG
+
+    def setUp(self):
+        self.setup_valve(self.CONFIG)
+
+    def test_size(self):
+        tfm_by_name = {body.name: body for body in self.table.tfm.values()}
+        eth_src_table = tfm_by_name.get(b'eth_src', None)
+        self.assertTrue(eth_src_table)
+        if eth_src_table is not None:
+            self.assertEqual(999, eth_src_table.max_entries)
+
+
 class ValveTFMSize(ValveTestBases.ValveTestSmall):
     """Test TFM sizer."""
 


### PR DESCRIPTION
Allow scaling of port scale tables.