### PR TITLE
Faucet unit test fixup

### DIFF
--- a/tests/unit/faucet/fakeoftable.py
+++ b/tests/unit/faucet/fakeoftable.py
@@ -328,8 +328,8 @@ class FakeOFTable:
     def __str__(self):
         string = ''
         for table_id, table in enumerate(self.tables):
-            string += '----- Table %u -----\n' % (table_id)
-            string += '\n'.join([str(flowmod) for flowmod in table])
+            string += '\n----- Table %u -----\n' % (table_id)
+            string += '\n'.join(sorted([str(flowmod) for flowmod in table]))
         return string
 
     def sort_tables(self):
@@ -351,6 +351,7 @@ class FlowMod:
     def __init__(self, flowmod):
         """flowmod is a ryu flow modification message object"""
         self.priority = flowmod.priority
+        self.cookie = flowmod.cookie
         self.instructions = flowmod.instructions
         self.validate_instructions()
         self.match_values = {}
@@ -485,10 +486,10 @@ class FlowMod:
                 self.instructions == other.instructions)
 
     def __str__(self):
-        string = 'priority: {0}'.format(self.priority)
-        for key, val in self.match_values.items():
+        string = 'priority: {0} cookie: {1}'.format(self.priority, self.cookie)
+        for key in sorted(self.match_values.keys()):
             mask = self.match_masks[key]
-            string += ' {0}: {1}'.format(key, val)
+            string += ' {0}: {1}'.format(key, self.match_values[key])
             if mask.int != -1: # pytype: disable=attribute-error
                 string += '/{0}'.format(mask)
         string += ' Instructions: {0}'.format(str(self.instructions))

--- a/tests/unit/faucet/test_valve.py
+++ b/tests/unit/faucet/test_valve.py
@@ -18,7 +18,6 @@
 # limitations under the License.
 
 
-import time
 import unittest
 from ryu.lib import mac
 from ryu.lib.packet import slow
@@ -261,12 +260,12 @@ vlans:
         self.learn_hosts()
         self.assertTrue(
             self.valve.flow_timeout(
-                time.time(),
+                self.mock_time(),
                 self.valve.dp.tables['eth_dst'].table_id,
                 {'vlan_vid': self.V100, 'eth_dst': self.P1_V100_MAC}))
         self.assertFalse(
             self.valve.flow_timeout(
-                time.time(),
+                self.mock_time(),
                 self.valve.dp.tables['eth_src'].table_id,
                 {'vlan_vid': self.V100, 'in_port': 1, 'eth_src': self.P1_V100_MAC}))
 
@@ -365,7 +364,7 @@ vlans:
             'actor_state_synchronization': 1})
         self.assertEqual(
             1, int(self.get_prom('port_lacp_status', labels=labels)))
-        future_now = time.time() + 10
+        future_now = self.mock_time(10)
         expire_ofmsgs = self.valve.state_expire(future_now, None)
         self.assertTrue(expire_ofmsgs)
         self.assertEqual(
@@ -499,7 +498,7 @@ vlans:
         self.assertEqual(
             0, int(self.get_prom('port_lacp_status', labels=labels)))
         # Ensure LACP packet sent.
-        ofmsgs = self.valve.fast_advertise(time.time(), None)[self.valve]
+        ofmsgs = self.valve.fast_advertise(self.mock_time(), None)[self.valve]
         self.assertTrue(self.packet_outs_from_flows(ofmsgs))
         self.rcv_packet(test_port, 0, {
             'actor_system': '0e:00:00:00:00:02',

--- a/tests/unit/faucet/test_valve_config.py
+++ b/tests/unit/faucet/test_valve_config.py
@@ -19,7 +19,6 @@
 
 from functools import partial
 import hashlib
-import time
 import unittest
 from ryu.ofproto import ofproto_v1_3 as ofp
 from faucet import config_parser_util
@@ -91,7 +90,7 @@ dps: {}
                 (self.CONFIG, 0)):
             with open(self.config_file, 'w') as config_file:
                 config_file.write(config)
-            self.valves_manager.request_reload_configs(time.time(), self.config_file)
+            self.valves_manager.request_reload_configs(self.mock_time(), self.config_file)
             self.assertEqual(
                 load_error,
                 self.get_prom('faucet_config_load_error', bare=True),


### PR DESCRIPTION
Use a mock time provider rather than time.time(), and fix some problems with fake table handling (installing flows from wrong table), and refactor loop topology definition.

This is all "functionality neutral" and doesn't change any existing test behavior, or add any new test functionality.

I discovered all this while working through PR https://github.com/faucetsdn/faucet/pull/3261 -- and once this is resolved, I'll update that to match.