### PR TITLE
Change the output format for gauge text flow table stats

### DIFF
--- a/clib/mininet_test_base.py
+++ b/clib/mininet_test_base.py
@@ -822,11 +822,11 @@ dbs:
         path: %s
 %s
 """ % (faucet_config_file,
-       self.get_gauge_watcher_config(),
-       monitor_stats_file,
-       monitor_state_file,
-       monitor_flow_table_dir,
-       self.GAUGE_CONFIG_DBS)
+            self.get_gauge_watcher_config(),
+            monitor_stats_file,
+            monitor_state_file,
+            monitor_flow_table_dir,
+            self.GAUGE_CONFIG_DBS)
 
     @staticmethod
     def get_exabgp_conf(peer, peer_config=''):

--- a/etc/faucet/gauge.yaml
+++ b/etc/faucet/gauge.yaml
@@ -27,7 +27,7 @@ dbs:
     ft_file:
         type: 'text'
         compress: True
-        file: 'flow_table.yaml.gz'
+        path: 'flow_tables'
     influx:
         type: 'influx'
         influx_db: 'faucet'

--- a/faucet/watcher.py
+++ b/faucet/watcher.py
@@ -156,6 +156,13 @@ class GaugeFlowTableLogger(GaugeFlowTablePoller):
             path,
             "{}--flowtable--{}.json".format(self.dp.name, rcv_time_str)
             )
+        # Add an increment for dealing with parts of a multipart message
+        # arriving at the same time
+        inc = 1
+        while os.path.isfile(filename):
+            filename = os.path.join(path, "{}--flowtable--{}--{}.json".format(
+                self.dp.name, rcv_time_str, inc))
+
         if self.conf.compress:
             with gzip.open(filename, 'wt') as outfile:
                 outfile.write(json.dumps(msg.to_jsondict()))

--- a/faucet/watcher.py
+++ b/faucet/watcher.py
@@ -21,6 +21,7 @@
 import os
 import json
 import gzip
+import time
 
 from ryu.ofproto import ofproto_v1_3 as ofp
 
@@ -143,12 +144,17 @@ class GaugeFlowTableLogger(GaugeFlowTablePoller):
     config for this watcher
     """
 
+    def _rcv_time(self, rcv_time):
+        # Use ISO8601 times for filenames
+        return time.strftime('%Y-%m-%dT%H:%M:%S', time.gmtime(rcv_time))
+
     def _update(self, rcv_time, msg):
         rcv_time_str = self._rcv_time(rcv_time)
         path = self.conf.path
+        # Double Hyphen to avoid confusion with ISO8601 times
         filename = os.path.join(
             path,
-            "{}-flowtable-{}.json".format(self.dp.name, rcv_time_str)
+            "{}--flowtable--{}.json".format(self.dp.name, rcv_time_str)
             )
         if self.conf.compress:
             with gzip.open(filename, 'wt') as outfile:

--- a/faucet/watcher.py
+++ b/faucet/watcher.py
@@ -18,6 +18,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import json
 import gzip
 
@@ -143,17 +144,15 @@ class GaugeFlowTableLogger(GaugeFlowTablePoller):
     """
 
     def _update(self, rcv_time, msg):
-        # TODO: it might be good to aggregate all OFFlowStatsReplies somehow
         rcv_time_str = self._rcv_time(rcv_time)
-        jsondict = {
-            'time': rcv_time_str,
-            'ref': '-'.join((self.dp.name, 'flowtables')),
-            'msg': msg.to_jsondict()}
-        filename = self.conf.file
-        outstr = '---\n{}\n'.format(json.dumps(jsondict))
+        path = self.conf.path
+        filename = os.path.join(
+            path,
+            "{}-flowtable-{}.json".format(self.dp.name, rcv_time_str)
+            )
         if self.conf.compress:
-            with gzip.open(filename, 'at') as outfile:
-                outfile.write(outstr)
+            with gzip.open(filename, 'wt') as outfile:
+                outfile.write(json.dumps(msg.to_jsondict()))
         else:
-            with open(filename, 'a') as outfile:
-                outfile.write(outstr)
+            with open(filename, 'w') as outfile:
+                json.dump(msg.to_jsondict(), outfile, indent=2)

--- a/faucet/watcher_conf.py
+++ b/faucet/watcher_conf.py
@@ -53,8 +53,9 @@ The following elements can be configured for each db, at the level of
 
 The following config elements then depend on the type.
 For text:
-
  * file (string): the filename of the file to write output to.
+ * path (string): path where files should be written when writing to \
+       muiltiple files
  * compress (bool): compress (with gzip) flow_table output while writing it
 
 For influx:
@@ -80,6 +81,7 @@ For Prometheus:
     db_defaults = {
         'type': None,
         'file': None,
+        'path': None,
         'compress': False,
         # compress flow table file
         'influx_db': 'faucet',
@@ -104,6 +106,7 @@ For Prometheus:
     db_defaults_types = {
         'type': str,
         'file': str,
+        'path': str,
         'compress': bool,
         'influx_db': str,
         'influx_host': str,
@@ -150,6 +153,7 @@ For Prometheus:
         self.dps = None
         self.compress = None
         self.file = None
+        self.path = None
         self.influx_db = None
         self.influx_host = None
         self.influx_port = None
@@ -177,6 +181,9 @@ For Prometheus:
         test_config_condition(
             self.file is not None and not
             (os.path.dirname(self.file) and os.access(os.path.dirname(self.file), os.W_OK)),
+            '%s is not writable' % self.file)
+        test_config_condition(
+            self.path is not None and not os.access(self.path, os.W_OK),
             '%s is not writable' % self.file)
 
     def add_dp(self, dp): # pylint: disable=invalid-name

--- a/tests/unit/faucet/fakeoftable.py
+++ b/tests/unit/faucet/fakeoftable.py
@@ -25,7 +25,8 @@ class FakeOFTableException(Exception):
 
 
 class FakeOFTable:
-    """Fake OFTable is a virtual openflow pipeline used for testing openflow controllers.
+    """Fake OFTable is a virtual openflow pipeline used for testing openflow
+    controllers.
 
     The tables are populated using apply_ofmsgs and can be queried with
     is_output.
@@ -49,12 +50,14 @@ class FakeOFTable:
 
         def _add(ofmsg, group_id):
             if group_id in self.groups:
-                raise FakeOFTableException('group already in group table: %s' % ofmsg)
+                raise FakeOFTableException(
+                    'group already in group table: %s' % ofmsg)
             self.groups[group_id] = ofmsg
 
         def _modify(ofmsg, group_id):
             if group_id not in self.groups:
-                raise FakeOFTableException('group not in group table: %s' % ofmsg)
+                raise FakeOFTableException(
+                    'group not in group table: %s' % ofmsg)
             self.groups[group_id] = ofmsg
 
         _groupmod_handlers = {
@@ -75,11 +78,17 @@ class FakeOFTable:
 
             if table_id == ofp.OFPTT_ALL:
                 if ofmsg.match.items() and not self.tfm:
-                    raise FakeOFTableException('got %s with matches before TFM that defines tables' % ofmsg)
+                    raise FakeOFTableException(
+                        'got %s with matches before TFM that defines tables'
+                        % ofmsg)
                 return
 
             if tfm_body is None:
-                raise FakeOFTableException('got %s before TFM that defines table %u' % (ofmsg, table_id))
+                raise FakeOFTableException(
+                    'got %s before TFM that defines table %u' % (
+                        ofmsg, table_id
+                        )
+                    )
 
         def _add(table, flowmod):
             # From the 1.3 spec, section 6.4:
@@ -158,9 +167,10 @@ class FakeOFTable:
             for table in tables:
                 entries = len(table)
                 if entries > tfm_body.max_entries:
+                    tfm_table_details = 'table %u %s full (max %u)' % (
+                        table_id, tfm_body.name, tfm_body.max_entries)
                     flow_dump = '\n\n'.join(
-                        ('table %u %s full (max %u)' % (table_id, tfm_body.name, tfm_body.max_entries),
-                            str(ofmsg), str(tfm_body)))
+                        (tfm_table_details, str(ofmsg), str(tfm_body)))
                     raise FakeOFTableException(flow_dump)
 
     def _apply_tfm(self, ofmsg):
@@ -208,7 +218,7 @@ class FakeOFTable:
         Returns: a list of the flowmods that will be applied to the packet
                 represented by match
         """
-        packet_dict = match.copy() # Packet headers may be modified
+        packet_dict = match.copy()  # Packet headers may be modified
         instructions = []
         table_id = 0
         goto_table = True
@@ -293,7 +303,8 @@ class FakeOFTable:
             for action in instruction.actions:
                 vid_stack = _process_vid_stack(action, vid_stack)
                 if action.type == ofp.OFPAT_OUTPUT:
-                    output_result = _output_result(action, vid_stack, port, vid)
+                    output_result = _output_result(
+                        action, vid_stack, port, vid)
                     if output_result is not None:
                         return output_result
                 elif action.type == ofp.OFPAT_GROUP:
@@ -317,10 +328,11 @@ class FakeOFTable:
         """
         Send packet through the fake OF table pipeline
         Args:
-            match (dict): A dict keyed by header fields with values, represents a packet
+            match (dict): A dict keyed by header fields with values, represents
+                a packet
         Returns:
-            dict: Modified match dict, represents packet that has been through the pipeline \
-                with values possibly altered
+            dict: Modified match dict, represents packet that has been through
+                the pipeline with values possibly altered
         """
         _, packet_dict = self.lookup(match)
         return packet_dict
@@ -357,8 +369,8 @@ class FlowMod:
         self.match_values = {}
         self.match_masks = {}
         self.out_port = None
-        if ((flowmod.command == ofp.OFPFC_DELETE or flowmod.command == ofp.OFPFC_DELETE_STRICT) and
-                flowmod.out_port != ofp.OFPP_ANY):
+        if (flowmod.command in (ofp.OFPFC_DELETE, ofp.OFPFC_DELETE_STRICT))\
+                and flowmod.out_port != ofp.OFPP_ANY:
             self.out_port = flowmod.out_port
 
         for key, val in flowmod.match.items():
@@ -490,7 +502,7 @@ class FlowMod:
         for key in sorted(self.match_values.keys()):
             mask = self.match_masks[key]
             string += ' {0}: {1}'.format(key, self.match_values[key])
-            if mask.int != -1: # pytype: disable=attribute-error
+            if mask.int != -1:  # pytype: disable=attribute-error
                 string += '/{0}'.format(mask)
         string += ' Instructions: {0}'.format(str(self.instructions))
         return string

--- a/tests/unit/gauge/test_gauge.py
+++ b/tests/unit/gauge/test_gauge.py
@@ -736,22 +736,26 @@ class GaugeWatcherTest(unittest.TestCase): # pytype: disable=module-attr
     """Checks the loggers in watcher.py."""
 
     conf = None
-    temp_fd = None
     temp_path = None
+    tmp_filename = "tmp_filename"
 
     def setUp(self):
-        """Creates a temporary file and a mocked conf object"""
-        self.temp_fd, self.temp_path = tempfile.mkstemp()
-        self.conf = mock.Mock(file=self.temp_path, compress=False)
+        """Creates a temporary file and directory and a mocked conf object"""
+        self.temp_path = tempfile.mkdtemp()
+        self.conf = mock.Mock(
+            file=os.path.join(self.temp_path, self.tmp_filename),
+            path=self.temp_path,
+            compress=False
+            )
 
     def tearDown(self):
-        """Closes and deletes the temporary file"""
-        os.close(self.temp_fd)
-        os.remove(self.temp_path)
+        """Removes the temporary directory and its contents"""
+        shutil.rmtree(self.temp_path)
 
-    def get_file_contents(self):
+    def get_file_contents(self, filename=tmp_filename):
         """Return the contents of the temporary file and clear it"""
-        with open(self.temp_path, 'r+') as file_:
+        filename = os.path.join(self.temp_path, filename)
+        with open(filename, 'r+') as file_:
             contents = file_.read()
             file_.seek(0, 0)
             file_.truncate()
@@ -850,10 +854,14 @@ class GaugeWatcherTest(unittest.TestCase): # pytype: disable=module-attr
         instructions = [parser.OFPInstructionGotoTable(1)]
 
         msg = flow_stats_msg(datapath, instructions)
-        logger.update(time.time(), msg)
-        log_str = self.get_file_contents()
+        rcv_time = time.time()
+        rcv_time_str = logger._rcv_time(rcv_time)
+        logger.update(rcv_time, msg)
+        log_str = self.get_file_contents(
+            "{}-flowtable-{}.json".format(datapath.name, rcv_time_str)
+            )
 
-        yaml_dict = yaml.safe_load(log_str)['msg']['OFPFlowStatsReply']['body'][0]['OFPFlowStats']
+        yaml_dict = yaml.safe_load(log_str)['OFPFlowStatsReply']['body'][0]['OFPFlowStats']
 
         compare_flow_msg(msg, yaml_dict, self)
 

--- a/tests/unit/gauge/test_gauge.py
+++ b/tests/unit/gauge/test_gauge.py
@@ -858,7 +858,7 @@ class GaugeWatcherTest(unittest.TestCase): # pytype: disable=module-attr
         rcv_time_str = logger._rcv_time(rcv_time)
         logger.update(rcv_time, msg)
         log_str = self.get_file_contents(
-            "{}-flowtable-{}.json".format(datapath.name, rcv_time_str)
+            "{}--flowtable--{}.json".format(datapath.name, rcv_time_str)
             )
 
         yaml_dict = yaml.safe_load(log_str)['OFPFlowStatsReply']['body'][0]['OFPFlowStats']


### PR DESCRIPTION
This branch failed travis on my github and on my desktop, but passed when I accidentally pushed to my old github https://github.com/KitL/faucet/runs/264929690
The failure isnt obviously connected with the changes I have made.
So I'm not sure what is going on with it at the moment, but I figured if I make the PR I will get a known good environment for running the tests.

    This is a breaking change.

    The old format involved severe hackiness to make it manageable
    This format instead will just dump each OFStatsReply message
    straight into its own file.

    The filename will be {datapath_name}-flowtable-{timestamp}.json
    The directory these files will be stored can be configured using
    the "path" key in the configuration for a text db

    The tests and the default gauge.yaml have been changed accordingly

    The gauge unit tests now create a temporary directory rather than
    a temporary file, then a file within that directory is created
    (currently called temp_filename) for use with the port_stats tests.

    It is probably a good idea that port stats change to use a similar
    format in future.