### PR TITLE
Remove workaround for github issue #3272.

### DIFF
--- a/docs/tutorials/stacking.rst
+++ b/docs/tutorials/stacking.rst
@@ -433,9 +433,6 @@ The two ACLs are then applied to the ports host1 and host2 are connected to.
                     stack:
                         dp: br2
                         port: 2
-                3:
-                    description: "dummy port (workaround for github issue #3272)"
-                    tagged_vlans: [host1, host2]
         br2:
             dp_id: 0x3
             hardware: "Open vSwitch"
@@ -737,9 +734,6 @@ network.
                     stack:
                         dp: br2
                         port: 3
-                3:
-                    description: "dummy port (workaround for github issue #3272)"
-                    native_vlan: hosts
         br2:
             dp_id: 0x3
             hardware: "Open vSwitch"


### PR DESCRIPTION
Remove the dummy ports I was using to workaround #3272 which got fixed by #3309 