### PR TITLE
Help re: why does this fail?

### DIFF
--- a/tests/integration/mininet_tests.py
+++ b/tests/integration/mininet_tests.py
@@ -7508,7 +7508,12 @@ class FaucetSingleStackStringOfDPExtLoopProtUntaggedTest(FaucetStringOfDPTest):
             use_external=True)
         self.start_net()
 
-    def test_untagged(self):
+    def test_port_down(self):
+        """Basic port up/down functionality works"""
+        self.set_port_down(5, self.dpids[0])
+        self.set_port_down(5, self.dpids[1])
+
+    def x_test_untagged(self):
         """Host can reach each other, unless both marked loop_protect_external"""
         for host in self.hosts_name_ordered():
             self.require_host_learned(host)


### PR DESCRIPTION
I'm trying to write some tests for what happens when certain ports go up/down in a configuration, but I'm having a really hard time figuring out how to incite the desired behavior. There's the "set_port_down" function, but I can't seem to get it to work for anything other than the first dp (self.dpids[0]) -- that works, but when I try it with the other dp it fails.  Any help understanding how to bring a port down during a test would be greatly appreciated.

The hard-coded port 5 shouldn't matter, and doesn't seem to cause any problems. In this example test case I don't actually care which port is down, just that I want to set a port down on the second switch.
