### PR TITLE
Add lacp_collect_and_distribute port config option

### DIFF
--- a/faucet/dp.py
+++ b/faucet/dp.py
@@ -735,6 +735,12 @@ configuration.
                 return 0
         return 1
 
+    def lacp_collect_and_distribute(self, port):
+        """Return 1 if LACP should advertise collect and distribute on this port."""
+        if port.lacp_collect_and_distribute:
+            return 1
+        return self.lacp_forwarding(port)
+
     def lldp_beacon_send_ports(self, now):
         """Return list of ports to send LLDP packets; stacked ports always send LLDP."""
         send_ports = []

--- a/faucet/port.py
+++ b/faucet/port.py
@@ -59,10 +59,12 @@ class Port(Conf):
         # if non 0 (LAG ID), experimental LACP support enabled on this port.
         'lacp_active': False,
         # experimental active LACP
+        'lacp_collect_and_distribute': False,
+        # if true, forces LACP port to collect and distribute when syncing with the peer.
         'lacp_passthrough': None,
         # If set, fail the lacp on this port if any of the peer ports are down.
         'lacp_resp_interval': 1,
-        # Min time since last LACP response. Used to control rate of responce for LACP
+        # Min time since last LACP response. Used to control rate of response for LACP
         'loop_protect': False,
         # if True, do simple (host/access port) loop protection on this port.
         'loop_protect_external': False,
@@ -111,6 +113,7 @@ class Port(Conf):
         'hairpin_unicast': bool,
         'lacp': int,
         'lacp_active': bool,
+        'lacp_collect_and_distribute': bool,
         'lacp_passthrough': list,
         'lacp_resp_interval': int,
         'loop_protect': bool,
@@ -166,6 +169,7 @@ class Port(Conf):
         self.hairpin_unicast = None
         self.lacp = None
         self.lacp_active = None
+        self.lacp_collect_and_distribute = None
         self.lacp_passthrough = None
         self.lacp_resp_interval = None
         self.loop_protect = None

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -972,7 +972,7 @@ class Valve:
         actor_state_activity = 0
         if port.lacp_active:
             actor_state_activity = 1
-        lacp_forwarding = self.dp.lacp_forwarding(port)
+        lacp_forwarding = self.dp.lacp_forwarding(port) or port.lacp_collect_and_distribute
         actor_state_collecting = lacp_forwarding
         actor_state_distributing = lacp_forwarding
         if lacp_pkt:

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -972,9 +972,8 @@ class Valve:
         actor_state_activity = 0
         if port.lacp_active:
             actor_state_activity = 1
-        lacp_forwarding = self.dp.lacp_forwarding(port) or port.lacp_collect_and_distribute
-        actor_state_collecting = lacp_forwarding
-        actor_state_distributing = lacp_forwarding
+        actor_state_collecting = self.dp.lacp_collect_and_distribute(port)
+        actor_state_distributing = actor_state_collecting
         if lacp_pkt:
             pkt = valve_packet.lacp_reqreply(
                 self.dp.faucet_dp_mac, self.dp.faucet_dp_mac,

--- a/tests/unit/faucet/test_valve_stack.py
+++ b/tests/unit/faucet/test_valve_stack.py
@@ -997,12 +997,12 @@ dps:
         """Test topology functions."""
         dp_ids = [0x1, 0x2, 0x3]
         port = 1
-        want = [1, 0, 1]
+        want_collect_and_distribute = [1, 0, 1]
 
         valves = [self.valves_manager.valves[dp_id] for dp_id in dp_ids]
         ports = [valve.dp.ports[port] for valve in valves]
         c_and_d = [valves[i].dp.lacp_collect_and_distribute(ports[i]) for i in range(0, len(dp_ids))]
-        self.assertEqual(c_and_d, want)
+        self.assertEqual(c_and_d, want_collect_and_distribute)
 
 
 class ValveTwoDpRootEdge(ValveTestBases.ValveTestSmall):

--- a/tests/unit/faucet/test_valve_stack.py
+++ b/tests/unit/faucet/test_valve_stack.py
@@ -937,7 +937,7 @@ dps:
 
 
 class ValveStackCollectDistributeLACPTestCase(ValveTestBases.ValveTestSmall):
-    """Test simple stack topology from root."""
+    """Test stack topology with 3 electable roots and one LACP link each."""
 
     CONFIG = """
 dps:

--- a/tests/unit/faucet/test_valve_stack.py
+++ b/tests/unit/faucet/test_valve_stack.py
@@ -936,6 +936,75 @@ dps:
         self.assertFalse(dp.is_stack_edge())
 
 
+class ValveStackCollectDistributeLACPTestCase(ValveTestBases.ValveTestSmall):
+    """Test simple stack topology from root."""
+
+    CONFIG = """
+dps:
+    s1:
+        dp_id: 0x1
+        hardware: 'GenericTFM'
+        stack:
+            priority: 1
+        interfaces:
+            1:
+                lacp: 1
+                native_vlan: 100
+                loop_protect_external: True
+            2:
+                stack:
+                    dp: s2
+                    port: 2
+    s2:
+        dp_id: 0x2
+        hardware: 'GenericTFM'
+        stack:
+            priority: 2
+        interfaces:
+            1:
+                lacp: 1
+                native_vlan: 100
+                loop_protect_external: True
+            2:
+                stack:
+                    dp: s1
+                    port: 2
+            3:
+                stack:
+                    dp: s3
+                    port: 2
+    s3:
+        dp_id: 0x3
+        hardware: 'GenericTFM'
+        stack:
+            priority: 3
+        interfaces:
+            1:
+                lacp: 1
+                native_vlan: 100
+                loop_protect_external: True
+                lacp_collect_and_distribute: True
+            2:
+                stack:
+                    dp: s2
+                    port: 3
+    """
+
+    def setUp(self):
+        self.setup_valve(self.CONFIG)
+
+    def test_topo(self):
+        """Test topology functions."""
+        dp_ids = [0x1, 0x2, 0x3]
+        port = 1
+        want = [1, 0, 1]
+
+        valves = [self.valves_manager.valves[dp_id] for dp_id in dp_ids]
+        ports = [valve.dp.ports[port] for valve in valves]
+        c_and_d = [valves[i].dp.lacp_collect_and_distribute(ports[i]) for i in range(0, len(dp_ids))]
+        self.assertEqual(c_and_d, want)
+
+
 class ValveTwoDpRootEdge(ValveTestBases.ValveTestSmall):
     """Test simple stack topology from edge."""
 


### PR DESCRIPTION
Allow a multi root stack to aggregate its LACP ports to non MC-LAG devices.

Normally Faucet sets one port (on the root stack switch) to Collecting and Distributing (Active) and the others to not Collecting and not Distributing (Standby). This works fine with MC-LAG enabled devices where different devices establish aggregation via multiple ports as it they were one device. However, enabling this for non MC-LAG devices is just a matter of overriding the need to Standby. This knob forces all LACP configured ports to Collecting and Distributing.

Because enabled ports will all state that they desire to collect traffic, they will receive traffic, however this traffic will always be dropped on non root stack switch.
