### PR TITLE
Add additional events for system monitoring

### DIFF
--- a/clib/mininet_test_base.py
+++ b/clib/mininet_test_base.py
@@ -226,17 +226,17 @@ class FaucetTestBase(unittest.TestCase):
         self._set_var(name, 'FAUCET_LOG_LEVEL', str(self.LOG_LEVEL))
 
     def _enable_event_log(self, timeout=None):
-      """Creates a file event.log in the test folder that tracks all events sent out by faucet to the event socket"""
-      if not timeout:
-        timeout = self.EVENT_LOGGER_TIMEOUT
-      self.event_log = os.path.join(self.tmpdir, 'event.log')
-      controller = self._get_controller()
-      sock = self.env['faucet']['FAUCET_EVENT_SOCK']
-      # Relying on a timeout seems a bit brittle;
-      # as an alternative we might possibly use something like
-      # `with popen(cmd...) as proc`to clean up on exceptions
-      controller.cmd(mininet_test_util.timeout_cmd(
-          'nc -U %s > %s &' % (sock, self.event_log), timeout))
+        """Creates a file event.log in the test folder that tracks all events sent out by faucet to the event socket"""
+        if not timeout:
+          timeout = self.EVENT_LOGGER_TIMEOUT
+        self.event_log = os.path.join(self.tmpdir, 'event.log')
+        controller = self._get_controller()
+        sock = self.env['faucet']['FAUCET_EVENT_SOCK']
+        # Relying on a timeout seems a bit brittle;
+        # as an alternative we might possibly use something like
+        # `with popen(cmd...) as proc`to clean up on exceptions
+        controller.cmd(mininet_test_util.timeout_cmd(
+            'nc -U %s > %s &' % (sock, self.event_log), timeout))
 
     def _read_yaml(self, yaml_path):
         with open(yaml_path) as yaml_file:

--- a/clib/mininet_test_base.py
+++ b/clib/mininet_test_base.py
@@ -228,7 +228,7 @@ class FaucetTestBase(unittest.TestCase):
     def _enable_event_log(self, timeout=None):
         """Creates a file event.log in the test folder that tracks all events sent out by faucet to the event socket"""
         if not timeout:
-          timeout = self.EVENT_LOGGER_TIMEOUT
+            timeout = self.EVENT_LOGGER_TIMEOUT
         self.event_log = os.path.join(self.tmpdir, 'event.log')
         controller = self._get_controller()
         sock = self.env['faucet']['FAUCET_EVENT_SOCK']

--- a/faucet/dp.py
+++ b/faucet/dp.py
@@ -863,6 +863,11 @@ configuration.
         if self.tunnel_acls:
             self.finalize_tunnel_acls(dps)
 
+    def get_node_link_data(self):
+        """Return network stacking graph as a node link representation"""
+        graph = self.stack.get('graph', None)
+        return networkx.json_graph.node_link_data(graph)
+
     def stack_longest_path_to_root_len(self):
         """Return length of the longest path to root in the stack."""
         if not self.stack or not self.stack_root_name:

--- a/faucet/dp.py
+++ b/faucet/dp.py
@@ -569,8 +569,8 @@ configuration.
                 scale_factor *= self.port_table_scale_factor
 
             # Always multiple of min_wildcard_table_size
-            size = (int(scale_factor / self.min_wildcard_table_size)
-                    + 1) * self.min_wildcard_table_size
+            table_size_multiple = int(scale_factor / self.min_wildcard_table_size) + 1
+            size = table_size_multiple * self.min_wildcard_table_size
 
             if not table_config.exact_match:
                 size = max(size, self.min_wildcard_table_size)
@@ -983,7 +983,7 @@ configuration.
         for vlan in vlans.values():
             vlan.reset_ports(self.ports.values())
             if (vlan.get_ports() or vlan.reserved_internal_vlan or
-                vlan.dot1x_assigned or vlan._id in router_vlans):
+                    vlan.dot1x_assigned or vlan._id in router_vlans):
                 self.vlans[vlan.vid] = vlan
 
     def resolve_port(self, port_name):

--- a/faucet/dp.py
+++ b/faucet/dp.py
@@ -115,7 +115,7 @@ configuration.
         'lldp_beacon': {},
         # Config for LLDP beacon service.
         'metrics_rate_limit_sec': 0,
-        # Rate limit metric updates - don't update metrics if last update was less than this many seconds ago.
+        # Rate limit metric updates if last update was less than this many seconds ago.
         'faucet_dp_mac': valve_packet.FAUCET_MAC,
         # MAC address of packets sent by FAUCET, not associated with any VLAN.
         'combinatorial_port_flood': False,
@@ -343,11 +343,13 @@ configuration.
         return self.name
 
     def clone_dyn_state(self, prev_dp):
+        """Clone dynamic state for this dp"""
         self.dyn_running = prev_dp.dyn_running
         self.dyn_up_port_nos = set(prev_dp.dyn_up_port_nos)
         self.dyn_last_coldstart_time = prev_dp.dyn_last_coldstart_time
 
     def check_config(self):
+        """Check configuration of this dp"""
         super(DP, self).check_config()
         test_config_condition(not isinstance(self.dp_id, int), (
             'dp_id must be %s not %s' % (int, type(self.dp_id))))
@@ -567,7 +569,8 @@ configuration.
                 scale_factor *= self.port_table_scale_factor
 
             # Always multiple of min_wildcard_table_size
-            size = (int(scale_factor / self.min_wildcard_table_size) + 1) * self.min_wildcard_table_size
+            size = (int(scale_factor / self.min_wildcard_table_size)
+                    + 1) * self.min_wildcard_table_size
 
             if not table_config.exact_match:
                 size = max(size, self.min_wildcard_table_size)
@@ -979,7 +982,8 @@ configuration.
         self.vlans = {}
         for vlan in vlans.values():
             vlan.reset_ports(self.ports.values())
-            if vlan.get_ports() or vlan.reserved_internal_vlan or vlan.dot1x_assigned or vlan._id in router_vlans:
+            if (vlan.get_ports() or vlan.reserved_internal_vlan or
+                vlan.dot1x_assigned or vlan._id in router_vlans):
                 self.vlans[vlan.vid] = vlan
 
     def resolve_port(self, port_name):

--- a/faucet/faucet_event.py
+++ b/faucet/faucet_event.py
@@ -83,7 +83,7 @@ class FaucetEventNotifier:
                 self.logger.info('event client connected')
                 while True:
                     event = self.event_q.get()
-                    event_bytes = bytes('\n'.join((json.dumps(event), '')).encode('UTF-8'))
+                    event_bytes = bytes('\n'.join((json.dumps(event, default=str), '')).encode('UTF-8'))
                     try:
                         sock.sendall(event_bytes)
                     except (socket.error, IOError) as err:

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -625,7 +625,7 @@ class Valve:
             for valve in stacked_valves:
                 graph = valve.dp.get_node_link_data()
                 if graph:
-                    self._notify(
+                    self.notify(
                         {'STACK_TOPO_CHANGE': {
                             'stack_root': valve.dp.stack_root_name,
                             'graph': graph,
@@ -930,7 +930,7 @@ class Valve:
 
     def _reset_lacp_status(self, port):
         self._set_var('port_lacp_status', port.dyn_lacp_up, labels=self.dp.port_labels(port.number))
-        self._notify(
+        self.notify(
                 {'LAG_CHANGE': {
                     'port_no': port.number,
                     'status': port.dyn_lacp_up}})

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -603,7 +603,7 @@ class Valve:
                         valve.flood_manager.update_stack_topo(port_stack_up, self.dp, port)
         if stack_changes:
             self.logger.info('%u stack ports changed state' % stack_changes)
-            path_to_root = {}
+            dps_root_hop = {}
             for valve in stacked_valves:
                 valve.update_tunnel_flowrules()
                 if not valve.dp.dyn_running:
@@ -614,7 +614,7 @@ class Valve:
                 for port in valve.dp.stack_ports:
                     ofmsgs_by_valve[valve].extend(valve.host_manager.del_port(port))
                 path_port = valve.dp.shortest_path_port(valve.dp.stack_root_name)
-                path_to_root[valve.dp.name] = getattr(path_port, 'number', {})
+                dps_root_hop[valve.dp.name] = path_port.number if path_port else None
 
             # Find the first valve with a valid stack and trigger notification.
             for valve in stacked_valves:
@@ -624,7 +624,7 @@ class Valve:
                         {'STACK_TOPO_CHANGE': {
                             'stack_root': valve.dp.stack_root_name,
                             'graph': graph,
-                            'path_to_root': path_to_root}})
+                            'dps_root_hop': path_to_root}})
                     break
 
         return ofmsgs_by_valve

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -603,7 +603,7 @@ class Valve:
                         valve.flood_manager.update_stack_topo(port_stack_up, self.dp, port)
         if stack_changes:
             self.logger.info('%u stack ports changed state' % stack_changes)
-            dps_root_hop = {}
+            notify_dps = {}
             for valve in stacked_valves:
                 valve.update_tunnel_flowrules()
                 if not valve.dp.dyn_running:
@@ -614,7 +614,8 @@ class Valve:
                 for port in valve.dp.stack_ports:
                     ofmsgs_by_valve[valve].extend(valve.host_manager.del_port(port))
                 path_port = valve.dp.shortest_path_port(valve.dp.stack_root_name)
-                dps_root_hop[valve.dp.name] = path_port.number if path_port else None
+                notify_dps.setdefault(valve.dp.name, {})['root_hop_port'] = (
+                    path_port.number if path_port else None)
 
             # Find the first valve with a valid stack and trigger notification.
             for valve in stacked_valves:
@@ -624,7 +625,8 @@ class Valve:
                         {'STACK_TOPO_CHANGE': {
                             'stack_root': valve.dp.stack_root_name,
                             'graph': graph,
-                            'dps_root_hop': path_to_root}})
+                            'dps': notify_dps
+                            }})
                     break
 
         return ofmsgs_by_valve

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -19,7 +19,6 @@
 
 import copy
 import logging
-import networkx
 
 from collections import defaultdict, deque
 
@@ -616,14 +615,18 @@ class Valve:
                     ofmsgs_by_valve[valve].extend(valve.host_manager.del_port(port))
                 path_port = valve.dp.shortest_path_port(valve.dp.stack_root_name)
                 path_to_root[valve.dp.name] = getattr(path_port, 'number', {})
+
+            # Find the first valve with a valid stack and trigger notification.
             for valve in stacked_valves:
-                if valve.flood_manager.graph:
+                graph = valve.dp.get_node_link_data()
+                if graph:
                     self._notify(
-                            {'STACK_TOPO_CHANGE': {
-                                'stack_root': valve.dp.stack_root_name,
-                                'graph': networkx.json_graph.node_link_data(valve.flood_manager.graph),
-                                'path_to_root': path_to_root}})
+                        {'STACK_TOPO_CHANGE': {
+                            'stack_root': valve.dp.stack_root_name,
+                            'graph': graph,
+                            'path_to_root': path_to_root}})
                     break
+
         return ofmsgs_by_valve
 
     def update_tunnel_flowrules(self):

--- a/faucet/valves_manager.py
+++ b/faucet/valves_manager.py
@@ -267,7 +267,7 @@ class ValvesManager:
             for valve, ofmsgs in ofmsgs_by_valve.items():
                 self.send_flows_to_dp_by_id(valve, ofmsgs)
 
-    def _notify(self, event_dict, dp=dp):
+    def _notify(self, event_dict, dp=None):
         """Send an event notification."""
         if dp:
             self.notifier.notify(dp.dp_id, dp.name, event_dict)

--- a/faucet/valves_manager.py
+++ b/faucet/valves_manager.py
@@ -246,6 +246,7 @@ class ValvesManager:
                 valve = self.new_valve(new_dp)
                 if valve is None:
                     continue
+                self._notify({'CONFIG_CHANGE': {'restart_type': 'new'}}, dp=new_dp)
             valve.update_config_metrics()
             self.valves[dp_id] = valve
         if delete_dp is not None:
@@ -266,16 +267,20 @@ class ValvesManager:
             for valve, ofmsgs in ofmsgs_by_valve.items():
                 self.send_flows_to_dp_by_id(valve, ofmsgs)
 
-    def _notify(self, event_dict):
+    def _notify(self, event_dict, dp=dp):
         """Send an event notification."""
-        self.notifier.notify(0, str(0), event_dict)
+        if dp:
+            self.notifier.notify(dp.dp_id, dp.name, event_dict)
+        else:
+            self.notifier.notify(0, str(0), event_dict)
 
     def request_reload_configs(self, now, new_config_file, delete_dp=None):
         """Process a request to load config changes."""
         if self.config_watcher.content_changed(new_config_file):
             self.logger.info('configuration %s changed, analyzing differences', new_config_file)
             result = self.load_configs(now, new_config_file, delete_dp=delete_dp)
-            self._notify({'CONFIG_CHANGE': {'success': result}})
+            self._notify({'CONFIG_CHANGE': {'success': result,
+                                            'dps_config': self.meta_dp_state.top_conf}})
         else:
             self.logger.info('configuration is unchanged, not reloading')
             self.metrics.faucet_config_load_error.set(0)

--- a/tests/integration/mininet_tests.py
+++ b/tests/integration/mininet_tests.py
@@ -7462,12 +7462,13 @@ class FaucetStringOfDPLACPUntaggedTest(FaucetStringOfDPTest):
             self.wait_for_all_lacp_up()
 
     def test_untagged(self):
-        """All untagged hosts in stack topology can reach each other."""
+        """All untagged hosts in stack topology can reach each other, LAG_CHANGE event emitted."""
         self._enable_event_log()
         for _ in range(3):
             self.wait_for_all_lacp_up()
             self.verify_stack_hosts()
             self.flap_all_switch_ports()
+        # Check for presence of LAG_CHANGE event in event socket log
         self.wait_until_matching_lines_from_file(r'.+LAG_CHANGE.+', self.event_log)
 
     def test_dyn_fail(self):
@@ -7666,7 +7667,7 @@ class FaucetStackRingOfDPTest(FaucetStringOfDPTest):
         self.start_net()
 
     def test_untagged(self):
-        """Stack loop prevention works and hosts can ping each other."""
+        """Stack loop prevention works and hosts can ping each other, STACK_TOPO_CHANGE event emitted."""
         self._enable_event_log()
         self.verify_stack_up()
         self.verify_stack_has_no_loop()
@@ -7681,6 +7682,7 @@ class FaucetStackRingOfDPTest(FaucetStringOfDPTest):
                 self.one_stack_port_down(dpid, dp_name, port)
                 self.retry_net_ping()
                 self.one_stack_port_up(dpid, dp_name, port)
+        # Check for presence of STACK_TOPO_CHANGE event in event socket log
         self.wait_until_matching_lines_from_file(r'.+STACK_TOPO_CHANGE.+', self.event_log)
 
 


### PR DESCRIPTION
Adding STACK_TOPO_CHANGE and LAG_CHANGE events to dump stack topology graph obj and LAG status info to event socket. Events will be consumed by forch to show current faucet network status.