### PR TITLE
Cli fakeoftable

### DIFF
--- a/tests/unit/faucet/fakeoftable.py
+++ b/tests/unit/faucet/fakeoftable.py
@@ -32,7 +32,7 @@ class FakeOFTable:
     is_output.
     """
 
-    def __init__(self, num_tables, requires_tfm=True):
+    def __init__(self, num_tables=1, requires_tfm=True):
         self.tables = [[] for _ in range(0, num_tables)]
         self.groups = {}
         self.requires_tfm = requires_tfm

--- a/tests/unit/faucet/fakeoftable.py
+++ b/tests/unit/faucet/fakeoftable.py
@@ -553,6 +553,8 @@ class FlowMod:
                 value_int = value.int
             if isinstance(mask, Bits):
                 mask_int = mask.int
+            elif mask is None:
+                mask_int = -1
             if value_int & ofp.OFPVID_PRESENT == 0:
                 result = 'vlan untagged'
             elif key == 'vlan_vid' and mask_int == ofp.OFPVID_PRESENT:
@@ -563,7 +565,7 @@ class FlowMod:
                     mask_str = str(mask_int ^ ofp.OFPVID_PRESENT)
         elif isinstance(value, Bits):
             result = self.bits_to_str(key, value)
-            if mask.int != -1:
+            if mask is not None and mask.int != -1:
                 mask_str = self.bits_to_str(key, mask)
         elif isinstance(value, str):
             result = value

--- a/tests/unit/faucet/fakeoftable.py
+++ b/tests/unit/faucet/fakeoftable.py
@@ -641,14 +641,14 @@ class FakeRyuDp:
     def __init__(self):
         self.ofproto_parser = parser
 
-def parse_args(sys_args):
+def parse_args():
     arg_parser = argparse.ArgumentParser(
         prog='fakeoftable',
         description='Performs lookups on openflow tables',
         usage="""
     Find the flow table entries in a given flow table that match a given packet
     {self} -f FILE PACKET_STRING
-""".format(self=sys_args[0])
+""".format(self=sys.argv[0])
         )
     arg_parser.add_argument(
         'packet',
@@ -671,7 +671,7 @@ def parse_args(sys_args):
     return (message_file, packet)
 
 def main():
-    message_file, pkt = parse_args(sys.argv)
+    message_file, pkt = parse_args()
     with open(message_file, 'r') as f:
         msg = json.load(f)
     dp = FakeRyuDp()

--- a/tests/unit/faucet/fakeoftable.py
+++ b/tests/unit/faucet/fakeoftable.py
@@ -640,7 +640,8 @@ class FlowMod:
         string += ' Instructions: {0}'.format(str(self.instructions))
         return string
 
-class FakeRyuDp: # pylint: disable=too-few-public-methods
+
+class FakeRyuDp:  # pylint: disable=too-few-public-methods
     """Fake ryu Datapath object.
 
     Just needed to provide a parser to allow us to extract ryu objects from
@@ -648,6 +649,7 @@ class FakeRyuDp: # pylint: disable=too-few-public-methods
     """
     def __init__(self):
         self.ofproto_parser = parser
+
 
 def parse_print_args():
     """Parse arguments for the print command"""
@@ -666,6 +668,7 @@ def parse_print_args():
         )
     args = arg_parser.parse_args(sys.argv[2:])
     return {'filename': args.file}
+
 
 def parse_probe_args():
     """Parse arguments for the probe command"""
@@ -700,6 +703,7 @@ def parse_probe_args():
         packet['vlan_vid'] |= ofp.OFPVID_PRESENT
     return {'packet': packet, 'filename': args.file}
 
+
 def parse_args():
     """parse arguments"""
     arg_parser = argparse.ArgumentParser(
@@ -726,6 +730,7 @@ def parse_args():
         sys.exit(-1)
     return (args.command, command_args)
 
+
 def _print(filename):
     """Prints the JSON flow table from a file in a human readable format"""
     with open(filename, 'r') as f:
@@ -735,6 +740,7 @@ def _print(filename):
     table = FakeOFTable()
     table.apply_ofmsgs([ofmsg])
     print(table)
+
 
 def probe(filename, packet):
     """Prints the actions applied to packet by the table from the file"""
@@ -750,12 +756,14 @@ def probe(filename, packet):
         print(instruction)
     print(out_packet)
 
+
 def main():
     command, kwargs = parse_args()
     if command == 'probe':
         probe(**kwargs)
     elif command == 'print':
         _print(**kwargs)
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Allows using fakeoftable from the CLI to print a flow table into a human readable format, or to probe for what actions are applied to a packet.

It currently doesnt really handle groups at all. It can tell you what groups are applied but doesnt tell you what the groups do. We would need to add monitoring of the group table in gauge for that to work.

Here are examples:
(faucet)chrislorier@kit:~/faucet/tests/unit/faucet$ python fakeoftable.py probe -f ~/ft_1.json -p '{"in_port": 1, "vlan_vid": 1000, "eth_dst": "ff:ff:ff:ff:ff:ff", "eth_src": "00:00:00:00:00:01"}'
{'vlan_vid': 5096, 'eth_src': '00:00:00:00:00:01', 'eth_dst': 'ff:ff:ff:ff:ff:ff', 'in_port': 1}
OFPInstructionGotoTable(len=8,table_id=1,type=1)
OFPInstructionGotoTable(len=8,table_id=2,type=1)
OFPInstructionActions(actions=[OFPActionOutput(len=16,max_len=96,port=4294967293,type=0)],type=4)
OFPInstructionGotoTable(len=8,table_id=3,type=1)
OFPInstructionGotoTable(len=8,table_id=4,type=1)
OFPInstructionActions(actions=[OFPActionPopVlan(len=8,type=18), OFPActionOutput(len=16,max_len=0,port=2,type=0)],type=4)
{'vlan_vid': 5096, 'eth_src': '00:00:00:00:00:01', 'eth_dst': 'ff:ff:ff:ff:ff:ff', 'in_port': 1}

It prints the state of the packet at the start and at the end of processing.
It would be good to show the flow table entries that it matches rather than just the actions that get applied, but for now it is just showing the actions.
Also it would be good to make it more human readable. When we do show flow table entries rather than actions that should be easy to achieve, because I can print flow table entries in a human readable format now.

And the printing in human readable format is like this (I have cut off the end of the flow table because obviously it is big):

(faucet)chrislorier@kit:~/faucet/tests/unit/faucet$ python fakeoftable.py print -f ~/ft_1.json

----- Table 0 -----
Priority: 0 | Match:  | Instructions : drop
Priority: 9099 | Match:  in_port 1 | Instructions : goto 1
Priority: 9099 | Match:  in_port 2 | Instructions : goto 1
----- Table 1 -----
Priority: 0 | Match:  | Instructions : drop
Priority: 9000 | Match:  in_port 1, vlan_vid 1000 | Instructions : goto 2
Priority: 9000 | Match:  in_port 1, vlan_vid 2000 | Instructions : goto 2
[...]