### PR TITLE
router.py: Add 'repr' implementation for vip_map_by_ipv (#3347)

### DIFF
--- a/faucet/conf.py
+++ b/faucet/conf.py
@@ -124,7 +124,7 @@ class Conf:
     def _conf_keys(conf, dyn=False, subconf=True, ignore_keys=None):
         """Return a list of key/values of attributes with dyn/Conf attributes/filtered."""
         conf_keys = []
-        for key, value in conf.__dict__.items():
+        for key, value in sorted(conf.__dict__.items()):
             if not dyn and key.startswith('dyn'):
                 continue
             if not subconf and isinstance(value, Conf):

--- a/faucet/router.py
+++ b/faucet/router.py
@@ -21,6 +21,11 @@ import pytricia
 from faucet.conf import Conf, test_config_condition
 
 
+class _PyTricia(pytricia.PyTricia):
+    def __repr__(self):
+        return str([(k, self[k]) for k in sorted(self.keys())])
+
+
 class Router(Conf):
     """Implement FAUCET configuration for a router."""
 
@@ -116,7 +121,7 @@ class Router(Conf):
             for faucet_vip in vlan.faucet_vips:
                 ipv = faucet_vip.version
                 if ipv not in self.vip_map_by_ipv:
-                    self.vip_map_by_ipv[ipv] = pytricia.PyTricia(
+                    self.vip_map_by_ipv[ipv] = _PyTricia(
                         faucet_vip.ip.max_prefixlen)
                 self.vip_map_by_ipv[ipv][faucet_vip.network] = (
                     vlan, faucet_vip)

--- a/tests/integration/mininet_tests.py
+++ b/tests/integration/mininet_tests.py
@@ -7221,7 +7221,7 @@ class FaucetSingleUntaggedIPV4RoutingWithStackingTest(FaucetStringOfDPTest):
             conf['dps']['faucet-2']['interfaces'][port_key]['native_vlan'] = self.V300
         self.reload_conf(
             conf, self.faucet_config_path,
-            restart=True, cold_start=True, change_expected=True)
+            restart=True, cold_start=False, change_expected=True)
         self.verify_stack_up()
         self.set_host_ip(v100_host, v100_host_ip)
         self.set_host_ip(v200_host, v200_host_ip)
@@ -7258,7 +7258,7 @@ class FaucetSingleUntaggedIPV4RoutingWithStackingTest(FaucetStringOfDPTest):
                 conf['dps']['faucet-2']['interfaces'][port_key]['native_vlan'] = self.V300
         self.reload_conf(
             conf, self.faucet_config_path,
-            restart=True, cold_start=True, change_expected=True)
+            restart=True, cold_start=False, change_expected=True)
         self.verify_stack_up()
         self.set_host_ip(v100_host, v100_host_ip)
         self.set_host_ip(v200_host, v200_host_ip)


### PR DESCRIPTION
To create ia 'hash'able Router class, the PyTricia
tree needs to be unrolled (the 'id()' based 'repr'
does not allow for comparison of equivalent objects)