### PR TITLE
Adding a varz to track shortest root path port for every DP

### DIFF
--- a/faucet/faucet_metrics.py
+++ b/faucet/faucet_metrics.py
@@ -151,6 +151,9 @@ class FaucetMetrics(PromClient):
         self.dp_status = self._dpid_gauge(
             'dp_status',
             'status of datapaths')
+        self.dp_root_hop_port = self._dpid_gauge(
+            'dp_root_hop_port',
+            'port that leads to stack root DP')
         self.of_dp_desc_stats = self._gauge(
             'of_dp_desc_stats',
             'DP description (OFPDescStatsReply)',

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -617,8 +617,9 @@ class Valve:
                 for port in valve.dp.stack_ports:
                     ofmsgs_by_valve[valve].extend(valve.host_manager.del_port(port))
                 path_port = valve.dp.shortest_path_port(valve.dp.stack_root_name)
-                notify_dps.setdefault(valve.dp.name, {})['root_hop_port'] = (
-                    path_port.number if path_port else None)
+                path_port_number = path_port.number if path_port else 0.0
+                self._set_var('dp_root_hop_port', path_port_number)
+                notify_dps.setdefault(valve.dp.name, {})['root_hop_port'] = path_port_number
 
             # Find the first valve with a valid stack and trigger notification.
             for valve in stacked_valves:

--- a/tests/unit/faucet/test_valve_stack.py
+++ b/tests/unit/faucet/test_valve_stack.py
@@ -294,7 +294,9 @@ class ValveStackRedundancyTestCase(ValveTestBases.ValveTestSmall):
         for valve in self.valves_manager.valves.values():
             self.assertFalse(valve.dp.dyn_running)
             self.assertEqual('s1', valve.dp.stack_root_name)
-            self.assertEqual(valve.dp.shortest_path_port('s1'),self.get_prom('dp_root_hop_port', bare=True))
+            root_hop_port = valve.dp.shortest_path_port('s1')
+            root_hop_port = root_hop_port.number if root_hop_port else 0
+            self.assertEqual(root_hop_port, self.get_prom('dp_root_hop_port', bare=True))
         # From a cold start - we pick the s1 as root.
         self.assertEqual(None, self.valves_manager.meta_dp_state.stack_root_name)
         self.assertFalse(self.valves_manager.maintain_stack_root(now))

--- a/tests/unit/faucet/test_valve_stack.py
+++ b/tests/unit/faucet/test_valve_stack.py
@@ -294,6 +294,7 @@ class ValveStackRedundancyTestCase(ValveTestBases.ValveTestSmall):
         for valve in self.valves_manager.valves.values():
             self.assertFalse(valve.dp.dyn_running)
             self.assertEqual('s1', valve.dp.stack_root_name)
+            self.assertEqual(valve.dp.shortest_path_port('s1'),self.get_prom('dp_root_hop_port', bare=True))
         # From a cold start - we pick the s1 as root.
         self.assertEqual(None, self.valves_manager.meta_dp_state.stack_root_name)
         self.assertFalse(self.valves_manager.maintain_stack_root(now))


### PR DESCRIPTION
Includes modifying a stack redundancy test to check for the validity of the varz.