### PR TITLE
Make runtests.sh argument parsing more robust.

### DIFF
--- a/docker/runtests.sh
+++ b/docker/runtests.sh
@@ -7,32 +7,74 @@ MINCOVERAGE=85
 
 set -e  # quit on error
 
-# allow user to skip parts of docker test
-# this wrapper script only cares about -n, -u, -i, others passed to test suite.
-while getopts "cdijknrsuxozlp" o $FAUCET_TESTS; do
-  case "${o}" in
-        i)
+
+if [ -z "${FAUCET_TESTS}" ]; then
+  # If FAUCET_TESTS env var isn't set read arguments from argv
+  FAUCET_TESTS="$@"
+fi
+
+# Shorten long form arguments to make parsing easier
+FAUCET_TESTS_SHORTENED=""
+for opt in ${FAUCET_TESTS}; do
+  case "${opt}" in
+    --integration)
+      FAUCET_TESTS_SHORTENED+=" -i"
+      ;;
+    --nocheck)
+      FAUCET_TESTS_SHORTENED+=" -n"
+      ;;
+    *)
+      FAUCET_TESTS_SHORTENED+=" ${opt}"
+      ;;
+  esac
+done
+
+PARAMS=""
+
+# Parse options, some are used by this script, some are
+# passed onto mininet_main.py & clib_mininet_main.py
+for opt in ${FAUCET_TESTS_SHORTENED}; do
+  case "${opt}" in
+    --*)
+      PARAMS+=" ${opt}"
+      ;;
+    -*)
+      for (( i=1; i<${#opt}; i++ )); do
+        case "${opt:$i:1}" in
+          i)
             # run only integration tests
             UNITTESTS=0
             DEPCHECK=0
+            PARAMS+=" -${opt:$i:1}"
             ;;
-        n)
+          n)
             # skip code check
             DEPCHECK=0
+            PARAMS+=" -${opt:$i:1}"
             ;;
-        u)
+          u)
             # skip unit tests
             UNITTESTS=0
             ;;
-        z)
+          z)
             # Skip pip installer
             echo "Option set to assume environment is set up."
             SKIP_PIP=1
             ;;
-        *)
+          *)
+            PARAMS+=" -${opt:$i:1}"
             ;;
-    esac
+        esac
+      done
+      ;;
+    *)
+      PARAMS+=" ${opt}"
+      ;;
+  esac
 done
+
+# Remove leading space
+FAUCET_TESTS="${PARAMS#"${PARAMS%%[![:space:]]*}"}"
 
 cd /faucet-src
 

--- a/docker/runtests.sh
+++ b/docker/runtests.sh
@@ -3,6 +3,7 @@
 UNITTESTS=1
 DEPCHECK=1
 SKIP_PIP=0
+HELP=0
 MINCOVERAGE=85
 
 set -e  # quit on error
@@ -35,6 +36,9 @@ PARAMS=""
 # passed onto mininet_main.py & clib_mininet_main.py
 for opt in ${FAUCET_TESTS_SHORTENED}; do
   case "${opt}" in
+    --help)
+      HELP=1
+      ;;
     --*)
       PARAMS+=" ${opt}"
       ;;
@@ -114,6 +118,12 @@ export LANGUAGE=en_US.en
 export LC_ALL=en_US.UTF-8
 
 export PYTHONPATH=/faucet-src:/faucet-src/faucet:/faucet-src/clib
+
+if [ "$HELP" == 1 ] ; then
+  cd /faucet-src/tests/integration
+  ./mininet_main.py --help
+  exit 0
+fi
 
 if [ "$UNITTESTS" == 1 ] ; then
     echo "========== Running faucet unit tests =========="

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -203,6 +203,13 @@ the test suite.
      Multiple flags can be added to FAUCET_TESTS, below are just some examples
      of  how individual flags work.
 
+To find the full list of options you can pass to the test suite, set
+``FAUCET_TESTS`` to ``--help``.
+
+.. code:: console
+
+      -e FAUCET_TESTS="--help"
+
 Running specific integration tests
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
* Support long-form argument names
* Add support for reading arguments from ARGV
* Don't pass arguments meant for just runtests.sh onto mininet scripts

fixes #3364