### PR TITLE
Fix issues in tutorial due to changed BGP syntax in 1.9

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -34,6 +34,7 @@ Shaun Wackerly <wackerly@hp.com>
 Shivaram Mysore <shivaram.mysore@gmail.com>
 Simeon Miteff <simeon.miteff@gmail.com>
 Stacey Sheldon <stac@corsa.com>
+Thomas Glanzmann <thomas@glanzmann.de>
 Trevor Pering <peringknife@google.com>
 Trung Truong <truonghuut@ecs.vuw.ac.nz>
 youf3 <youff3@gmail.com>

--- a/docs/tutorials/routing.rst
+++ b/docs/tutorials/routing.rst
@@ -387,31 +387,22 @@ We can now start BIRD inside the bgp namespace:
     as_ns bgp bird -P /run/bird-bgp.pid
 
 We'll configure Faucet to talk to BIRD by adding BGP configuration to
-``/etc/faucet/faucet.yaml``. Change the servers VLAN to look like the
-configuration below, leaving all other VLANs alone, and add a Faucet
-router.
+``/etc/faucet/faucet.yaml``. Replace the routers section with the below.
 
 .. code-block:: yaml
     :caption: /etc/faucet/faucet.yaml
 
     routers:
         bird:
-            vlans: servers
+            vlans: [hosts, servers]
             bgp:
+                vlan: servers                       # The VLAN faucet use for BGP
                 as: 65000                           # Faucet's AS number
                 port: 9179                          # BGP port for Faucet to listen on.
                 routerid: '10.0.1.3'                # Faucet's Unique ID.
                 server_addresses: ['10.0.1.3']      # Faucet's listen IP for BGP
                 neighbor_addresses: ['10.0.1.2']    # Neighbouring IP addresses (IPv4/IPv6)
                 neighbor_as: 65001                  # Neighbour's AS number
-    vlans:
-        servers:
-            vid: 200
-            description: "vlan for gw port"
-            faucet_mac: "00:00:00:00:00:22"
-            faucet_vips: ["10.0.1.254/24"]
-    ...
-
 
 And finally add the port configuration for the Faucet data plane interface (veth-faucet0).
 

--- a/docs/tutorials/routing.rst
+++ b/docs/tutorials/routing.rst
@@ -387,14 +387,14 @@ We can now start BIRD inside the bgp namespace:
     as_ns bgp bird -P /run/bird-bgp.pid
 
 We'll configure Faucet to talk to BIRD by adding BGP configuration to
-``/etc/faucet/faucet.yaml``. Replace the routers section with the below.
+``/etc/faucet/faucet.yaml``. Add the following to the routers section.
 
 .. code-block:: yaml
     :caption: /etc/faucet/faucet.yaml
 
     routers:
+        ...
         bird:
-            vlans: [hosts, servers]
             bgp:
                 vlan: servers                       # The VLAN faucet use for BGP
                 as: 65000                           # Faucet's AS number

--- a/docs/tutorials/stacking.rst
+++ b/docs/tutorials/stacking.rst
@@ -598,6 +598,12 @@ let's define a faucet.yaml that matches our ring topology.
                         dp: br1
                         port: 3
 
+Reload faucet to enable the ring topology.
+
+.. code:: console
+
+    sudo systemctl reload faucet
+
 We will define three hosts, one on each switch.
 
 .. code:: console


### PR DESCRIPTION
Hello,
this fixes to issues in the tutorial: BGP syntax changed for version 1.9 and it was once forgotten to
mention to reload faucet after a configuration change. I build the docs successfully.

Cheers,
      Thomas