### PR TITLE
WIP: Don't edge_learn ports

### DIFF
--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -1209,8 +1209,8 @@ class Valve:
         Returns:
             list: OpenFlow messages, if any.
         """
-        #learn_port = self.flood_manager.edge_learn_port(
-        #    self._stacked_valves(other_valves), pkt_meta)
+        # learn_port = self.flood_manager.edge_learn_port(
+        #     self._stacked_valves(other_valves), pkt_meta)
         learn_port = pkt_meta.port
         if learn_port is not None:
             learn_flows, previous_port, update_cache = self.host_manager.learn_host_on_vlan_ports(

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -1209,8 +1209,9 @@ class Valve:
         Returns:
             list: OpenFlow messages, if any.
         """
-        learn_port = self.flood_manager.edge_learn_port(
-            self._stacked_valves(other_valves), pkt_meta)
+        #learn_port = self.flood_manager.edge_learn_port(
+        #    self._stacked_valves(other_valves), pkt_meta)
+        learn_port = pkt_meta.port
         if learn_port is not None:
             learn_flows, previous_port, update_cache = self.host_manager.learn_host_on_vlan_ports(
                 now, learn_port, pkt_meta.vlan, pkt_meta.eth_src,

--- a/travis/runtests.sh
+++ b/travis/runtests.sh
@@ -5,6 +5,8 @@
 echo TRAVIS_BRANCH: $TRAVIS_BRANCH
 echo TRAVIS_COMMIT: $TRAVIS_COMMIT
 
+ovs-vsctl -V
+
 # If PY_FILES_CHANGED is empty, run all codecheck tests (otherwise only on changed files).
 FILES_CHANGED=""
 PY_FILES_CHANGED=""
@@ -64,8 +66,6 @@ else
   shard "$ALLTESTS" ${MATRIX_SHARDS}
   FAUCET_TESTS="-din ${sharded[${MATRIX_SHARD}]}"
 fi
-
-ovs-vsctl -V
 
 if [[ "$FILES_CHANGED" != "" ]] ; then
   if [[ "$PY_FILES_CHANGED" == "" && "$RQ_FILES_CHANGED" == "" ]] ; then

--- a/travis/runtests.sh
+++ b/travis/runtests.sh
@@ -88,6 +88,8 @@ ulimit -c unlimited && sudo echo '/var/tmp/core.%h.%e.%t' > /proc/sys/kernel/cor
 sudo modprobe openvswitch
 sudo modprobe ebtables
 
+ovs-vsctl -V
+
 if [ "${MATRIX_SHARD}" == "sanity" ] ; then
   # Simulate hardware test switch
   # TODO: run a standalone DP and also a stacked DP test to test hardware linkages.

--- a/travis/runtests.sh
+++ b/travis/runtests.sh
@@ -65,6 +65,8 @@ else
   FAUCET_TESTS="-din ${sharded[${MATRIX_SHARD}]}"
 fi
 
+ovs-vsctl -V
+
 if [[ "$FILES_CHANGED" != "" ]] ; then
   if [[ "$PY_FILES_CHANGED" == "" && "$RQ_FILES_CHANGED" == "" ]] ; then
     echo Not running docker tests because only non-python/requirements changes: $FILES_CHANGED
@@ -87,8 +89,6 @@ echo Shard $MATRIX_SHARD: $FAUCETTESTS: $SHARDARGS
 ulimit -c unlimited && sudo echo '/var/tmp/core.%h.%e.%t' > /proc/sys/kernel/core_pattern
 sudo modprobe openvswitch
 sudo modprobe ebtables
-
-ovs-vsctl -V
 
 if [ "${MATRIX_SHARD}" == "sanity" ] ; then
   # Simulate hardware test switch


### PR DESCRIPTION
My integration tests are running into a problem where sometimes they run into nasty forwarding loops -- I'm raising this PR just as a FYI and discussion point around the right fix. I'm still investigating the root cause and trying to create a reproducible test case... I *think* the actual problem is that sometimes learned flows don't stick and are rejected for some unknown reason -- and that combined with the edge_learn algorithm causes problems.