### PR TITLE
Test all topologies

### DIFF
--- a/clib/mininet_test_watcher.py
+++ b/clib/mininet_test_watcher.py
@@ -82,7 +82,7 @@ class TopologyWatcher():
         Add a general/controller fault
         Logs the fault name and resets the actual graph
         """
-        error('FAULT: %s' % name)
+        error('FAULT: %s\n' % name)
         self.fault_list.append(name)
         self.host_connectivity_graph = networkx.MultiDiGraph()
         self.eligable_links = []

--- a/tests/tolerance/mininet_main.py
+++ b/tests/tolerance/mininet_main.py
@@ -10,9 +10,42 @@ It is strongly recommended to run these tests via Docker, to ensure you have
 all dependencies correctly installed. See ../docs/.
 """
 
+import networkx
+from networkx.generators.atlas import graph_atlas_g
+
 from clib.clib_mininet_test_main import test_main
+from clib.mininet_test_topo_generator import FaucetTopoGenerator
 
 import mininet_tests
 
+
+def test_generator(num_dps, num_vlans, n_dp_links, stack_roots, func_graph):
+    """Return the function that will start the fault-tolerance testing for a graph"""
+    def test(self):
+        """Test fault-tolerance of the topology"""
+        dp_links = FaucetTopoGenerator.dp_links_networkx_graph(
+            func_graph, n_dp_links=n_dp_links)
+        self.set_up(num_dps, num_vlans, dp_links, stack_roots)
+        self.network_function()
+    return test
+
 if __name__ == '__main__':
+    GRAPHS = {}
+    GRAPH_ATLAS = graph_atlas_g()
+    for graph in GRAPH_ATLAS:
+        if (not graph or
+                graph.number_of_nodes() > mininet_tests.MAX_NODES or
+                graph.number_of_nodes() < mininet_tests.MIN_NODES):
+            continue
+        if networkx.is_connected(graph):
+            GRAPHS.setdefault(graph.number_of_nodes(), [])
+            GRAPHS[graph.number_of_nodes()].append(graph)
+    for i, test_class in enumerate(mininet_tests.TEST_CLASS_LIST):
+        for test_graph in GRAPHS[test_class.NUM_DPS]:
+            test_name = 'test_%s' % test_graph.name
+            test_func = test_generator(
+                test_class.NUM_DPS, test_class.NUM_VLANS,
+                test_class.N_DP_LINKS, test_class.STACK_ROOTS, test_graph)
+            setattr(test_class, test_name, test_func)
+
     test_main([mininet_tests.__name__])

--- a/tests/tolerance/mininet_tests.py
+++ b/tests/tolerance/mininet_tests.py
@@ -288,69 +288,30 @@ class FaucetSingleFaultTolerance2DPTest(FaucetFaultToleranceBaseTest):
     """Run a range of fault-tolerance tests for topologies on 2 DPs"""
 
     NUM_DPS = 2
-    NUM_HOSTS = 2
-    NUM_VLANS = 1
-
-    def test_2_line(self):
-        """Test fault-tolerance of a path of length 2"""
-        stack_roots = {0: 1}
-        dp_links = FaucetTopoGenerator.dp_links_networkx_graph(
-            networkx.path_graph(self.NUM_DPS))
-        self.set_up(self.NUM_DPS, self.NUM_VLANS, dp_links, stack_roots)
-        self.network_function()
-
-
-class FaucetSingleFaucetTolerance2DP2VLANTest(FaucetSingleFaultTolerance2DPTest):
-    """Run a range of fault-tolerance tests for topologies on 2 DPs 2 VLANS"""
-
+    NUM_HOSTS = 4
     NUM_VLANS = 2
+    N_DP_LINKS = 1
+    STACK_ROOTS = {0: 1}
 
 
 class FaucetSingleFaultTolerance3DPTest(FaucetFaultToleranceBaseTest):
     """Run a range of fault-tolerance tests for topologies on 3 DPs"""
 
     NUM_DPS = 3
-    NUM_HOSTS = 3
-    NUM_VLANS = 1
-
-    def test_3_line(self):
-        """Test fault-tolerance of a path of length 3"""
-        stack_roots = {0: 1}
-        dp_links = FaucetTopoGenerator.dp_links_networkx_graph(
-            networkx.path_graph(self.NUM_DPS))
-        self.set_up(self.NUM_DPS, self.NUM_VLANS, dp_links, stack_roots)
-        self.network_function()
-
-    def test_3_node_ring_links(self):
-        """Test fault-tolerance of a 3-cycle graph"""
-        stack_roots = {0: 1}
-        dp_links = FaucetTopoGenerator.dp_links_networkx_graph(
-            networkx.cycle_graph(self.NUM_DPS))
-        self.set_up(self.NUM_DPS, self.NUM_VLANS, dp_links, stack_roots)
-        self.network_function()
-
-
-class FaucetSingleFaultTolerance3DP2VLANTest(FaucetSingleFaultTolerance3DPTest):
-    """Run a range of fault-tolerance tests for topologies on 3 DPs 2 VLANs"""
-
+    NUM_HOSTS = 6
     NUM_VLANS = 2
-    INTERVLAN_ONLY = True
+    N_DP_LINKS = 1
+    STACK_ROOTS = {0: 1}
 
 
-class FaucetSingleFaultTolerance4DPRingTest(FaucetFaultToleranceBaseTest):
+class FaucetSingleFaultTolerance4DPTest(FaucetFaultToleranceBaseTest):
     """Run a range of fault-tolerance tests for topologies on 4 DPs"""
 
     NUM_DPS = 4
-    NUM_HOSTS = 1
+    NUM_HOSTS = 4
     NUM_VLANS = 1
-
-    def test_4_node_ring_links(self):
-        """Test fault-tolerance of a 4-cycle graph"""
-        stack_roots = {0: 1}
-        dp_links = FaucetTopoGenerator.dp_links_networkx_graph(
-            networkx.cycle_graph(self.NUM_DPS))
-        self.set_up(self.NUM_DPS, self.NUM_VLANS, dp_links, stack_roots)
-        self.network_function()
+    N_DP_LINKS = 1
+    STACK_ROOTS = {0: 1}
 
     def test_ftp2_all_random_switch_failures(self):
         """Test fat-tree-pod-2 randomly tearing down only switches"""
@@ -392,80 +353,47 @@ class FaucetSingleFaultTolerance4DPRingTest(FaucetFaultToleranceBaseTest):
         self.set_up(self.NUM_DPS, self.NUM_VLANS, dp_links, stack_roots)
         self.network_function(fault_events=fault_events, num_faults=num_faults)
 
-    @unittest.skip('Does not work')
-    def test_ftp2_external_host(self):
-        """Test fat-tree-pod-2 with an external host connected to both roots"""
-        dp_links = FaucetTopoGenerator.dp_links_networkx_graph(
-            networkx.cycle_graph(self.NUM_DPS))
-        stack_roots = {2*i: 1 for i in range(self.NUM_DPS//2)}
-        host_links = {0: [0, 2], 1: [1], 2: [3]}
-        host_vlans = {0: 0, 1: 0, 2: 0}
-        host_options = {0: {'loop_protect_external': True}}
-        self.set_up(self.NUM_DPS, self.NUM_VLANS, dp_links, stack_roots,
-                    host_links=host_links, host_vlans=host_vlans, host_options=host_options)
-        self.network_function()
 
-
-class FaucetSingleFaultTolerance4DP2VLANTest(FaucetSingleFaultTolerance4DPRingTest):
-    """Run a range of fault-tolerance tests for topologies on 4 DP 2 VLAN"""
-
-    NUM_VLANS = 2
-    INTERVLAN_ONLY = True
-
-
-@unittest.skip('Expensive to run')
+@unittest.skip('Too expensive for Travis to run')
 class FaucetSingleFaultTolerance5DPTest(FaucetFaultToleranceBaseTest):
     """Run a range of fault-tolerance tests for topologies on 5 DPs"""
 
     NUM_DPS = 5
     NUM_HOSTS = 5
     NUM_VLANS = 1
-
-    def test_k23(self):
-        """Test fault-tolerance of a complete bipartite graph K_{2,3}"""
-        stack_roots = {i: 1 for i in range(2)}
-        dp_links = FaucetTopoGenerator.dp_links_networkx_graph(
-            networkx.complete_bipartite_graph(2, 3))
-        self.set_up(self.NUM_DPS, self.NUM_VLANS, dp_links, stack_roots)
-        self.network_function()
+    N_DP_LINKS = 1
+    STACK_ROOTS = {0: 1}
 
 
-@unittest.skip('Expensive to run')
-class FaucetSingleFaultTolerance5DP2VLANTest(FaucetSingleFaultTolerance5DPTest):
-    """Run a range of fault-tolerance tests for topologies on 5 DP"""
-
-    NUM_VLANS = 2
-    INTERVLAN_ONLY = True
-
-
-@unittest.skip('Expensive to run')
+@unittest.skip('Too expensive for Travis to run')
 class FaucetSingleFaultTolerance6DPTest(FaucetFaultToleranceBaseTest):
-    """Run a range of fault-tolerance tests for topologies on 6 DPs"""
+    """Run a range of fault-tolerance tests for topologies on 5 DPs"""
 
     NUM_DPS = 6
     NUM_HOSTS = 6
     NUM_VLANS = 1
+    N_DP_LINKS = 1
+    STACK_ROOTS = {0: 1}
 
-    def test_fat_tree_3(self):
-        """Test fault-tolerance of a 6-cycle/3-fat tree pod"""
-        stack_roots = {i: 1 for i in range(self.NUM_DPS//2)}
-        dp_links = FaucetTopoGenerator.dp_links_networkx_graph(
-            networkx.cycle_graph(self.NUM_DPS))
-        self.set_up(self.NUM_DPS, self.NUM_VLANS, dp_links, stack_roots)
-        self.network_function()
 
-    def test_3_ladder(self):
-        """Test fault-tolerance of a complete ladder graph n=3"""
-        stack_roots = {i: 1 for i in range(self.NUM_DPS//2)}
-        dp_links = FaucetTopoGenerator.dp_links_networkx_graph(
-            networkx.ladder_graph(self.NUM_DPS//2))
-        self.set_up(self.NUM_DPS, self.NUM_VLANS, dp_links, stack_roots)
-        self.network_function()
+@unittest.skip('Too expensive for Travis to run')
+class FaucetSingleFaultTolerance7DPTest(FaucetFaultToleranceBaseTest):
+    """Run a range of fault-tolerance tests for topologies on 5 DPs"""
 
-    def test_k33(self):
-        """Test fault-tolerance of a complete bipartite graph K_{3,3}"""
-        stack_roots = {i: 1 for i in range(self.NUM_DPS//2)}
-        dp_links = FaucetTopoGenerator.dp_links_networkx_graph(
-            networkx.complete_bipartite_graph(self.NUM_DPS//2, self.NUM_DPS//2))
-        self.set_up(self.NUM_DPS, self.NUM_VLANS, dp_links, stack_roots)
-        self.network_function()
+    NUM_DPS = 7
+    NUM_HOSTS = 7
+    NUM_VLANS = 1
+    N_DP_LINKS = 1
+    STACK_ROOTS = {0: 1}
+
+
+TEST_CLASS_LIST = [
+    FaucetSingleFaultTolerance2DPTest,
+    FaucetSingleFaultTolerance3DPTest,
+    FaucetSingleFaultTolerance4DPTest,
+    FaucetSingleFaultTolerance5DPTest,
+    FaucetSingleFaultTolerance6DPTest,
+    FaucetSingleFaultTolerance7DPTest
+    ]
+MIN_NODES = min([c.NUM_DPS for c in TEST_CLASS_LIST])
+MAX_NODES = max([c.NUM_DPS for c in TEST_CLASS_LIST])


### PR DESCRIPTION
Dynamically add in tests for all (connected, (probably) non-isomorphic) topologies on 2-7 nodes, ~1000 topologies overall.

Travis only tests 2-4 node topologies.