### PR TITLE
WIP: Remove actor_sync bit hardcoding

### DIFF
--- a/faucet/dp.py
+++ b/faucet/dp.py
@@ -305,6 +305,7 @@ configuration.
         self.multi_out = None
         self.idle_dst = None
         self.stack_root_name = None
+        self.stack_root_healthy = False
         self.stack_roots_names = None
         self.stack_route_learning = None
         self.stack_root_flood_reflection = None
@@ -852,6 +853,7 @@ configuration.
         if meta_dp_state:
             if meta_dp_state.stack_root_name in self.stack_roots_names:
                 self.stack_root_name = meta_dp_state.stack_root_name
+                self.stack_root_healthy = meta_dp_state.stack_root_healthy
 
         self.stack_route_learning = False
         for dp in stack_port_dps:

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -1018,10 +1018,11 @@ class Valve:
             actor_state_activity = 1
         actor_state_collecting = self.dp.lacp_collect_and_distribute(port)
         actor_state_distributing = actor_state_collecting
+        actor_state_sync = int(self.dp.lacp_forwarding(port) or not self.dp.stack_root_healthy)
         if lacp_pkt:
             pkt = valve_packet.lacp_reqreply(
                 self.dp.faucet_dp_mac, self.dp.faucet_dp_mac,
-                port.lacp, port.number, 1, actor_state_activity,
+                port.lacp, port.number, actor_state_sync, actor_state_activity,
                 actor_state_collecting, actor_state_distributing,
                 lacp_pkt.actor_system, lacp_pkt.actor_key, lacp_pkt.actor_port,
                 lacp_pkt.actor_system_priority, lacp_pkt.actor_port_priority,

--- a/faucet/valves_manager.py
+++ b/faucet/valves_manager.py
@@ -143,12 +143,15 @@ class ValvesManager:
 
         if healthy_stack_roots_names:
             new_stack_root_name = self.meta_dp_state.stack_root_name
+            new_stack_root_healthy = self.meta_dp_state.stack_root_healthy
             # Only pick a new root if the current one is unhealthy.
             if self.meta_dp_state.stack_root_name not in healthy_stack_roots_names:
                 new_stack_root_name = healthy_stack_roots_names[0]
+                new_stack_root_healthy = True
         else:
             # Pick the first candidate if no roots are healthy
             new_stack_root_name = candidate_stack_roots_names[0]
+            new_stack_root_healthy = False
 
         stack_change = False
         if self.meta_dp_state.stack_root_name != new_stack_root_name:
@@ -157,6 +160,7 @@ class ValvesManager:
             if self.meta_dp_state.stack_root_name:
                 stack_change = True
             self.meta_dp_state.stack_root_name = new_stack_root_name
+            self.meta_dp_state.stack_root_healthy = new_stack_root_healthy
             dpids = [dp.dp_id for dp in stacked_dps if dp.name == new_stack_root_name]
             self.metrics.faucet_stack_root_dpid.set(dpids[0])
         else:


### PR DESCRIPTION
The idea is to set the Actor sync bit under certain conditions rather than hardcoding it to True. According to the logic below, we set it to 1 if lacp_forwarding is enabled on port(dp is stack root) or if there are no healthy stack roots. 

Testing: I am unsure about the testing that needs to be done. One test might be to check the dp member "stack_root_healthy" when there are no healthy roots available. Please advise. 