### PR TITLE
Allow stack switches to know all VLANs

### DIFF
--- a/clib/mininet_test_topo_generator.py
+++ b/clib/mininet_test_topo_generator.py
@@ -178,6 +178,8 @@ class FaucetTopoGenerator(FaucetSwitchTopo):
         port1, port2 = [self.start_port + self.port_order[i] for i in (index1, index2)]
         self.addLink(src, dst, port1=port1, port2=port2)
         # Update port and link lists
+        self.switch_ports.setdefault(src, [])
+        self.switch_ports.setdefault(dst, [])
         self.switch_ports[src].append(port1)
         self.switch_ports[dst].append(port2)
         self.switch_peer_links[src].append(self.peer_link(port1, dpid2, port2))

--- a/docs/tutorials/stacking.rst
+++ b/docs/tutorials/stacking.rst
@@ -722,9 +722,6 @@ network.
                     stack:
                         dp: br3
                         port: 3
-                3:
-                    description: "dummy port (workaround for github issue #3383)"
-                    native_vlan: hosts
         br1:
             dp_id: 0x2
             hardware: "Open vSwitch"
@@ -741,9 +738,6 @@ network.
                     stack:
                         dp: br2
                         port: 3
-                3:
-                    description: "dummy port (workaround for github issue #3383)"
-                    native_vlan: hosts
         br2:
             dp_id: 0x3
             hardware: "Open vSwitch"

--- a/faucet/dp.py
+++ b/faucet/dp.py
@@ -992,6 +992,18 @@ configuration.
         path = self.shortest_path(dst_dp.name, src_dp.name)
         return self.name in path
 
+    def is_transit_stack_switch(self):
+        """
+        Return true if this is a stack switch
+            in reset_refs self.stack might not be configured yet
+        """
+        if self.stack:
+            return True
+        for port in self.ports.values():
+            if port.stack:
+                return True
+        return False
+
     def reset_refs(self, vlans=None):
         """Resets VLAN references."""
         if vlans is None:
@@ -1003,7 +1015,8 @@ configuration.
         for vlan in vlans.values():
             vlan.reset_ports(self.ports.values())
             if (vlan.get_ports() or vlan.reserved_internal_vlan or
-                    vlan.dot1x_assigned or vlan._id in router_vlans):
+                    vlan.dot1x_assigned or vlan._id in router_vlans or
+                    self.is_transit_stack_switch()):
                 self.vlans[vlan.vid] = vlan
 
     def resolve_port(self, port_name):

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -1565,7 +1565,6 @@ class Valve:
         #        pkt_meta.eth_src,
         #        pkt_meta.port.number,
         #        pkt_meta.vlan))
-
         if pkt_meta.vlan is None:
             return self._non_vlan_rcv_packet(now, other_valves, pkt_meta)
         return self._vlan_rcv_packet(now, other_valves, pkt_meta)

--- a/tests/integration/mininet_multidp_tests.py
+++ b/tests/integration/mininet_multidp_tests.py
@@ -1009,6 +1009,5 @@ class FaucetUntaggedStackTransitVLANTest(FaucetTopoTestBase):
 
     def test_hosts_connect_over_stack_transit(self):
         """Test to ensure that hosts can be connected over stack transit switches"""
-        self.set_up()
         self.verify_stack_up()
         self.verify_intervlan_routing()

--- a/tests/integration/mininet_multidp_tests.py
+++ b/tests/integration/mininet_multidp_tests.py
@@ -957,3 +957,58 @@ class FaucetSingleUntaggedVlanStackFloodTest(FaucetTopoTestBase):
         src_host = self.host_information[1]['host']
         dst_ip = self.host_information[0]['ip']
         self.host_ping(src_host, dst_ip.ip)
+
+
+class FaucetUntaggedStackTransitTest(FaucetTopoTestBase):
+    """Test that L2 connectivity exists over a transit switch with no VLANs"""
+
+    NUM_DPS = 3
+    NUM_HOSTS = 2
+    NUM_VLANS = 1
+    SOFTWARE_ONLY = True
+
+    def setUp(self):
+        """Set up network with transit switch with no hosts"""
+        super(FaucetUntaggedStackTransitTest, self).setUp()
+        stack_roots = {0: 1}
+        dp_links = FaucetTopoGenerator.dp_links_networkx_graph(networkx.path_graph(self.NUM_DPS))
+        host_links = {0: [0], 1: [2]}
+        host_vlans = {0: 0, 1: 0}
+        self.build_net(
+            n_dps=self.NUM_DPS, n_vlans=self.NUM_VLANS, dp_links=dp_links,
+            host_links=host_links, host_vlans=host_vlans,
+            stack_roots=stack_roots)
+        self.start_net()
+
+    def test_hosts_connect_over_stack_transit(self):
+        """Test to ensure that hosts can be connected over stack transit switches"""
+        self.verify_stack_up()
+        self.verify_intervlan_routing()
+
+
+class FaucetUntaggedStackTransitVLANTest(FaucetTopoTestBase):
+    """Test that L2 connectivity exists over a transit switch with different VLANs"""
+
+    NUM_DPS = 3
+    NUM_HOSTS = 2
+    NUM_VLANS = 2
+    SOFTWARE_ONLY = True
+
+    def setUp(self):
+        """Set up network with transit switch on different VLAN"""
+        super(FaucetUntaggedStackTransitVLANTest, self).setUp()
+        stack_roots = {0: 1}
+        dp_links = FaucetTopoGenerator.dp_links_networkx_graph(networkx.path_graph(self.NUM_DPS))
+        host_links = {0: [0], 1: [1], 2: [2]}
+        host_vlans = {0: 0, 1: 1, 2: 0}
+        self.build_net(
+            n_dps=self.NUM_DPS, n_vlans=self.NUM_VLANS, dp_links=dp_links,
+            host_links=host_links, host_vlans=host_vlans,
+            stack_roots=stack_roots)
+        self.start_net()
+
+    def test_hosts_connect_over_stack_transit(self):
+        """Test to ensure that hosts can be connected over stack transit switches"""
+        self.set_up()
+        self.verify_stack_up()
+        self.verify_intervlan_routing()


### PR DESCRIPTION
L2 could fail when a transit switch did not know the right VLANs
Fixes #3383 