### PR TITLE
delete all meters on cold start and add slowpath meter

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -220,7 +220,11 @@ string names given to the datapath, or the OFP datapath id.
     * - packetin_pps
       - integer
       - None
-      - Ask switch to rate limit packet pps.
+      - Ask switch to rate limit packetin in pps.
+    * - slowpath_pps
+      - integer
+      - None
+      - Ask switch to rate limit slowpath in pps.
     * - priority_offset
       - integer
       - 0

--- a/docs/tutorials/first_time.rst
+++ b/docs/tutorials/first_time.rst
@@ -268,6 +268,7 @@ of a single switch with two ports.
              'nd_neighbor_timeout': 30,
              'ofchannel_log': None,
              'packetin_pps': None,
+             'slowpath_pps': None,
              'priority_offset': 0,
              'proactive_learn_v4': True,
              'proactive_learn_v6': True,

--- a/faucet/dp.py
+++ b/faucet/dp.py
@@ -97,7 +97,9 @@ configuration.
         'max_resolve_backoff_time': 64,
         # Max number of seconds to back off to when resolving nexthops.
         'packetin_pps': None,
-        # Ask switch to rate limit packet pps. TODO: Not supported by OVS in 2.7.0
+        # Ask switch to rate limit packetin pps. TODO: Not supported by OVS in 2.7.0
+        'slowpath_pps': None,
+        # Ask switch to rate limit slowpath pps. TODO: Not supported by OVS in 2.7.0
         'learn_jitter': 0,
         # Jitter learn timeouts by up to this many seconds
         'learn_ban_timeout': 0,
@@ -176,6 +178,7 @@ configuration.
         'max_host_fib_retry_count': int,
         'max_resolve_backoff_time': int,
         'packetin_pps': int,
+        'slowpath_pps': int,
         'learn_jitter': int,
         'learn_ban_timeout': int,
         'advertise_interval': int,
@@ -284,6 +287,7 @@ configuration.
         self.ofchannel_log = None
         self.output_only_ports = None
         self.packetin_pps = None
+        self.slowpath_pps = None
         self.ports = None
         self.priority_offset = None
         self.proactive_learn_v4 = None

--- a/faucet/valve_of.py
+++ b/faucet/valve_of.py
@@ -857,6 +857,7 @@ def meteradd(meter_conf, command=ofp.OFPMC_ADD):
     noop_dp.msg.datapath = None
     return noop_dp.msg
 
+
 def controller_pps_meteradd(datapath=None, pps=0):
     """Add a PPS meter towards controller."""
     return parser.OFPMeterMod(
@@ -874,6 +875,25 @@ def controller_pps_meterdel(datapath=None):
         command=ofp.OFPMC_DELETE,
         flags=ofp.OFPMF_PKTPS,
         meter_id=ofp.OFPM_CONTROLLER)
+
+
+def slowpath_pps_meteradd(datapath=None, pps=0):
+    """Add a PPS meter towards controller."""
+    return parser.OFPMeterMod(
+        datapath=datapath,
+        command=ofp.OFPMC_ADD,
+        flags=ofp.OFPMF_PKTPS,
+        meter_id=ofp.OFPM_SLOWPATH,
+        bands=[parser.OFPMeterBandDrop(rate=pps)])
+
+
+def slowpath_pps_meterdel(datapath=None):
+    """Delete a PPS meter towards controller."""
+    return parser.OFPMeterMod(
+        datapath=datapath,
+        command=ofp.OFPMC_DELETE,
+        flags=ofp.OFPMF_PKTPS,
+        meter_id=ofp.OFPM_SLOWPATH)
 
 
 def is_global_flowdel(ofmsg):

--- a/tests/fuzzer/dict/config.dict
+++ b/tests/fuzzer/dict/config.dict
@@ -26,6 +26,7 @@
 "name: test"
 "ofchannel_log: logname"
 "packetin_pps: 56"
+"slowpath_pps: 56"
 "port_acl_table: "
 "priority_offset: 8"
 "stack: "

--- a/tests/unit/faucet/valve_test_lib.py
+++ b/tests/unit/faucet/valve_test_lib.py
@@ -168,6 +168,7 @@ BASE_DP_CONFIG = """
         ignore_learn_ins: 100
         ofchannel_log: '/dev/null'
         packetin_pps: 99
+        slowpath_pps: 99
         lldp_beacon:
             send_interval: 1
             max_per_interval: 1


### PR DESCRIPTION
Current faucet doesn't clear all types of meters when doing cold restart. (only deletes DP meters).
Also added slowpath meter as per OFv1.3 specification.