### PR TITLE
update() -> _update() for prom pollers

### DIFF
--- a/faucet/gauge.py
+++ b/faucet/gauge.py
@@ -137,12 +137,12 @@ class Gauge(RyuAppBase):
             for i, watcher in enumerate(watchers_by_name):
                 is_active = i == 0
                 watcher.report_dp_status(1)
+                watcher.start(ryu_dp, is_active)
                 if isinstance(watcher, GaugePortStatePoller):
                     for port in ryu_dp.ports.values():
                         msg = parser.OFPPortStatus(
                             ryu_dp, desc=port, reason=ofp.OFPPR_ADD)
                         watcher.update(timestamp, msg)
-                watcher.start(ryu_dp, is_active)
 
     @kill_on_exception(exc_logname)
     def _datapath_connect(self, ryu_event):

--- a/faucet/gauge_pollers.py
+++ b/faucet/gauge_pollers.py
@@ -76,7 +76,12 @@ class GaugePoller:
 
     def no_response(self):
         """Called when a polling cycle passes without receiving a response."""
-        self.logger.info('no response to %s' % self.req)
+
+        dpid_str = ''
+        if self.req and 'datapath' in self.req:
+            dpid_str = 'DPID %s (%s)' % (self.req.datapath.id, hex(self.req.datapath.id))
+
+        self.logger.info('%s no response to %s', dpid_str, self.req)
 
     def update(self, rcv_time, msg):
         """Handle the responses to requests.

--- a/faucet/gauge_prom.py
+++ b/faucet/gauge_prom.py
@@ -108,7 +108,7 @@ class GaugePortStatsPrometheusPoller(GaugePortStatsPoller):
             for prom_var in PROM_PORT_VARS)
         return self._format_stats(delim, stat_pairs)
 
-    def update(self, rcv_time, msg):
+    def _update(self, rcv_time, msg):
         for stat in msg.body:
             port_labels = self.dp.port_labels(stat.port_no)
             for stat_name, stat_val in self._format_stat_pairs(
@@ -136,7 +136,7 @@ class GaugeMeterStatsPrometheusPoller(GaugePortStatsPoller):
         )
         return self._format_stats(delim, stat_pairs)
 
-    def update(self, rcv_time, msg):
+    def _update(self, rcv_time, msg):
         for stat in msg.body:
             meter_labels = self.dp.base_prom_labels()
             meter_labels.update({'meter_id': stat.meter_id})
@@ -149,7 +149,7 @@ class GaugeMeterStatsPrometheusPoller(GaugePortStatsPoller):
 class GaugePortStatePrometheusPoller(GaugePortStatePoller):
     """Export port state changes to Prometheus."""
 
-    def update(self, rcv_time, msg):
+    def _update(self, rcv_time, msg):
         port_no = msg.desc.port_no
         port = self.dp.ports.get(port_no, None)
         if port is None:
@@ -164,7 +164,7 @@ class GaugePortStatePrometheusPoller(GaugePortStatePoller):
 class GaugeFlowTablePrometheusPoller(GaugeFlowTablePoller):
     """Export flow table entries to Prometheus."""
 
-    def update(self, rcv_time, msg):
+    def _update(self, rcv_time, msg):
         jsondict = msg.to_jsondict()
         for stats_reply in jsondict['OFPFlowStatsReply']['body']:
             stats = stats_reply['OFPFlowStats']

--- a/tests/unit/gauge/test_gauge.py
+++ b/tests/unit/gauge/test_gauge.py
@@ -285,6 +285,7 @@ class GaugePrometheusTests(unittest.TestCase): # pytype: disable=module-attr
                         )
 
         prom_poller = gauge_prom.GaugePortStatsPrometheusPoller(conf, '__name__', self.prom_client)
+        prom_poller._running = True
         msg = port_stats_msg(datapath)
         prom_poller.update(time.time(), msg)
 
@@ -316,6 +317,7 @@ class GaugePrometheusTests(unittest.TestCase): # pytype: disable=module-attr
                         )
 
         prom_poller = gauge_prom.GaugePortStatePrometheusPoller(conf, '__name__', self.prom_client)
+        prom_poller._running = True
         reasons = [ofproto.OFPPR_ADD, ofproto.OFPPR_DELETE, ofproto.OFPPR_MODIFY]
         for i in range(1, len(conf.dp.ports) + 1):
 


### PR DESCRIPTION
Prevents the internal poller update() from shadowing the one in GaugePoller which sets the response as received. This PR will fix spurious "no response" log messages showing up despite data being actually logged.

Seems to be a problem since f0bd3b982fe6d439cef4b2d658654ac56a9a31aa