### PR TITLE
Modify LACP state machine

### DIFF
--- a/faucet/conf.py
+++ b/faucet/conf.py
@@ -28,7 +28,7 @@ class InvalidConfigError(Exception):
 
 
 def test_config_condition(cond, msg):
-    """Evaluate condition and raise InvalidConfigError if condition not True."""
+    """Evaluate condition and raise InvalidConfigError if condition True."""
     if cond:
         raise InvalidConfigError(msg)
 

--- a/tests/integration/mininet_multidp_tests.py
+++ b/tests/integration/mininet_multidp_tests.py
@@ -143,7 +143,7 @@ class FaucetStringOfDPLACPUntaggedTest(FaucetMultiDPTest):
 
     def wait_for_lacp_port_none(self, port_no, dpid, dp_name):
         """Wait for LACP state NONE"""
-        self.wait_for_lacp_state(port_no, -1, dpid, dp_name)
+        self.wait_for_lacp_state(port_no, 0, dpid, dp_name)
 
     def wait_for_lacp_port_init(self, port_no, dpid, dp_name):
         """Wait for LACP state INIT"""
@@ -153,8 +153,8 @@ class FaucetStringOfDPLACPUntaggedTest(FaucetMultiDPTest):
         """Wait for LACP state UP"""
         self.wait_for_lacp_state(port_no, 3, dpid, dp_name)
 
-    def wait_for_lacp_port_noact(self, port_no, dpid, dp_name):
-        """Wait for LACP state NOACT"""
+    def wait_for_lacp_port_nosync(self, port_no, dpid, dp_name):
+        """Wait for LACP state NOSYNC"""
         self.wait_for_lacp_state(port_no, 5, dpid, dp_name)
 
     # We sort non_host_links by port because FAUCET sorts its ports

--- a/tests/unit/faucet/test_valve.py
+++ b/tests/unit/faucet/test_valve.py
@@ -359,6 +359,7 @@ vlans:
 
     def setUp(self):
         self.setup_valve(self.CONFIG)
+        self.activate_all_ports()
 
     def test_lacp(self):
         """Test LACP comes up."""
@@ -558,6 +559,7 @@ vlans:
 
     def setUp(self):
         self.setup_valve(self.CONFIG)
+        self.activate_all_ports()
 
     def test_lacp(self):
         """Test LACP comes up."""

--- a/tests/unit/faucet/test_valve_stack.py
+++ b/tests/unit/faucet/test_valve_stack.py
@@ -111,7 +111,7 @@ dps:
             nominated_dpid, 0x1,
             'Expected nominated DPID %s but found %s' % (0x1, nominated_dpid))
         # Choose DP with most UP LAG ports
-        lacp_ports[0x1][0].actor_noact()
+        lacp_ports[0x1][0].actor_nosync()
         nominated_dpid = valve.get_lacp_dpid_nomination(1, other_valves)[0]
         self.assertEqual(
             nominated_dpid, 0x2,
@@ -167,15 +167,15 @@ dps:
         self.activate_all_ports()
         main_valve = self.valves_manager.valves[0x1]
         main_other_valves = self.get_other_valves(main_valve)
-        # Start with all LAG links NOACT & UNSELECTED
-        self.validate_flood(2, 0, 3, False, 'Flooded out UNSELECTED & NOACT LAG port')
-        self.validate_flood(2, 0, 4, False, 'Flooded out UNSELECTED & NOACT LAG port')
+        # Start with all LAG links INIT & UNSELECTED
+        self.validate_flood(2, 0, 3, False, 'Flooded out UNSELECTED & INIT LAG port')
+        self.validate_flood(2, 0, 4, False, 'Flooded out UNSELECTED & INIT LAG port')
         # Set UP & SELECTED one s1 LAG link
         port3 = main_valve.dp.ports[3]
         port4 = main_valve.dp.ports[4]
         self.apply_ofmsgs(main_valve.lacp_update(port4, True, 1, 1, main_other_valves))
         self.apply_ofmsgs(main_valve.lacp_update(port3, False, 1, 1, main_other_valves))
-        self.validate_flood(2, 0, 3, False, 'Flooded out NOACT LAG port')
+        self.validate_flood(2, 0, 3, False, 'Flooded out NOSYNC LAG port')
         self.validate_flood(2, 0, 4, True, 'Did not flood out SELECTED LAG port')
         # Set UP & SELECTED s2 LAG links
         valve = self.valves_manager.valves[0x2]
@@ -185,7 +185,7 @@ dps:
                 valve.lacp_update(port, True, 1, 1, other_valves)
         self.apply_ofmsgs(main_valve.lacp_update(port4, True, 1, 1, main_other_valves))
         self.apply_ofmsgs(main_valve.lacp_update(port3, False, 1, 1, main_other_valves))
-        self.validate_flood(2, 0, 3, False, 'Flooded out UNSELECTED & NOACT LAG port')
+        self.validate_flood(2, 0, 3, False, 'Flooded out UNSELECTED & NOSYNC LAG port')
         self.validate_flood(2, 0, 4, False, 'Flooded out UNSELECTED LAG port')
         # Set UP & SELECTED both s1 LAG links
         self.apply_ofmsgs(main_valve.lacp_update(port3, True, 1, 1, main_other_valves))
@@ -200,16 +200,16 @@ dps:
         main_other_valves = self.get_other_valves(main_valve)
         # Packet initially rejected
         self.validate_flood(
-            3, 0, None, False, 'Packet incoming through UNSELECTED & NOACT port was accepted')
+            3, 0, None, False, 'Packet incoming through UNSELECTED & INIT port was accepted')
         self.validate_flood(
-            4, 0, None, False, 'Packet incoming through UNSELECTED & NOACT port was accepted')
+            4, 0, None, False, 'Packet incoming through UNSELECTED & INIT port was accepted')
         # Set one s1 LAG port 4 to SELECTED & UP
         port3 = main_valve.dp.ports[3]
         port4 = main_valve.dp.ports[4]
         self.apply_ofmsgs(main_valve.lacp_update(port4, True, 1, 1, main_other_valves))
         self.apply_ofmsgs(main_valve.lacp_update(port3, False, 1, 1, main_other_valves))
         self.validate_flood(
-            3, 0, None, False, 'Packet incoming through NOACT port was accepted')
+            3, 0, None, False, 'Packet incoming through NOSYNC port was accepted')
         self.validate_flood(
             4, 0, None, True, 'Packet incoming through SELECTED port was not accepted')
         # Set UP & SELECTED s2 LAG links, set one s1 port down
@@ -221,7 +221,7 @@ dps:
         self.apply_ofmsgs(main_valve.lacp_update(port4, True, 1, 1, main_other_valves))
         self.apply_ofmsgs(main_valve.lacp_update(port3, False, 1, 1, main_other_valves))
         self.validate_flood(
-            3, 0, None, False, 'Packet incoming through UNSELECTED & NOACT port was accepted')
+            3, 0, None, False, 'Packet incoming through UNSELECTED & NOSYNC port was accepted')
         self.validate_flood(
             4, 0, None, False, 'Packet incoming through UNSELECTED port was accepted')
         # Set UP & SELECTED both s1 LAG links


### PR DESCRIPTION
- LACP actor & port selection states on yet to be configured/unconfigured ports will default to `LACP_ACTOR_NOTCONFIGURED` & `LACP_PORT_NOTCONFIGURED` respectively.
- Upon a port down, actor state will change to `LACP_ACTOR_NONE`.
- Upon cold starting a port, actor state & port selection state will revert back to `LACP_ACTOR_NOTCONFIGURED` & `LACP_PORT_NOTCONFIGURED` respectively.
- `LACP_ACTOR_NOACT` renamed to `LACP_ACTOR_NOSYNC`.
- Added `lacp_unselected`, `lacp_selected` & `lacp_standby` config options to force a port's LACP selection state.