### PR TITLE
Ordered ACL output actions

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -910,6 +910,9 @@ and actions. Matches are key/values based on the `ryu RESTFul API.
 <https://ryu.readthedocs.io/en/latest/app/ofctl_rest.html#reference-description-of-match-and-actions>`_
 Actions is a dictionary of actions to apply upon match.
 
+.. note:: When setting allow to true, the packet will be submitted to the
+    next table AFTER having the output actions applied to it.
+
 .. list-table:: : acls: <acl name>: - rule: actions: {}
     :widths: 30 15 15 40
     :header-rows: 1
@@ -940,11 +943,20 @@ Actions is a dictionary of actions to apply upon match.
       - None
       - Copy the packet, before any modifications, to the specified port (NOTE: ACL mirroring is done in input direction only)
     * - output
-      - dictionary
+      - dictionary or list
       - None
-      - Used to output a packet directly. Details below.
+      - Used to apply more specific output actions for an ACL
 
 The output action contains a dictionary with the following elements:
+
+.. note:: When using the dictionary format, Faucet will
+    build the actions in the following order: pop_vlans, vlan_vids, swap_vid,
+    vlan_vids, set_fields, port, ports and then failover.
+  The ACL dictionary format also restricts using port & ports, vlan_vid & vlan_vids
+    at the same time.
+
+.. note:: When using the list format, the output actions will be applied in the
+    user defined order.
 
 .. list-table:: : acls: <acl name>: - rule: actions: output: {}
     :widths: 30 15 15 40
@@ -986,6 +998,10 @@ The output action contains a dictionary with the following elements:
       - dictionary
       - None
       - Output with a failover port (see below).
+    * - Tunnel
+      - dictionary
+      - None
+      - Generic port output to any port in the stack
 
 Failover is an experimental option, but can be configured as follows:
 
@@ -1005,6 +1021,35 @@ Failover is an experimental option, but can be configured as follows:
       - list
       - None
       - The list of ports the packet can be output through.
+
+A tunnel ACL will encapsulate a packet before sending it through the stack topology
+
+.. note:: Currently tunnel ACLs only support VLAN encapsulation.
+
+.. list-table:: : acls: <acl name>: - rule: actions: output: tunnel: {}
+    :widths: 30 15 15 40
+    :header-rows: 1
+
+    * - Attribute
+      - Type
+      - Default
+      - Description
+    * - type
+      - str
+      - 'vlan'
+      - The encapsulation type for the packet. Default is to encapsulate using QinQ.
+    * - tunnel_id
+      - int/str
+      - VID that is greater than the largest configured VID
+      - The ID for the encapsulation type
+    * - dp
+      - int/str
+      - None
+      - The name or dp_id of the dp where the output port belongs
+    * - port
+      - int/str
+      - None
+      - The name or port number of the interface on the remote DP to output the packet
 
 .. _gauge-configuration:
 

--- a/docs/tutorials/acls.rst
+++ b/docs/tutorials/acls.rst
@@ -266,14 +266,14 @@ There is also the 'output' action which can be used to achieve the same thing.
             actions:
                 allow: False
                 output:
-                    port: 4
+                    - port: 4
         - rule:
             dl_type: 0x86dd
             ip_proto: 58
             actions:
                 allow: False
                 output:
-                    port: 4
+                    - port: 4
 
 
 The output action also allows us to change the packet by setting fields
@@ -302,7 +302,7 @@ Let's create a new ACL for host2's port that will change the MAC source address.
                 actions:
                     allow: True
                     output:
-                        set_fields:
+                        - set_fields:
                             - eth_src: "00:00:00:00:00:02"
     ...
 
@@ -356,16 +356,16 @@ To do this we will use both the 'port' & 'vlan_vid' output fields.
             actions:
                 allow: False
                 output:
-                    vlan_vid: 3
-                    port: 4
+                    - vlan_vid: 3
+                    - port: 4
         - rule:
             dl_type: 0x86dd
             ip_proto: 58
             actions:
                 allow: False
                 output:
-                    vlan_vid: 3
-                    port: 4
+                    - vlan_vid: 3
+                    - port: 4
 
 
 Again reload Faucet, start a tcpdump on host4, and ping from host1 to host3.

--- a/faucet/dp.py
+++ b/faucet/dp.py
@@ -1561,7 +1561,8 @@ configuration.
                 deleted_meters (set): deleted Meter IDs.
                 changed_meters (set): changed/added Meter IDs.
         """
-        all_meters_changed, deleted_meters, added_meters, changed_meters, _, _ = self._get_conf_changes(
+        (all_meters_changed, deleted_meters, 
+         added_meters, changed_meters, _, _) = self._get_conf_changes(
             logger, 'METERS', self.meters, new_dp.meters)
 
         return (all_meters_changed, deleted_meters, added_meters, changed_meters)
@@ -1594,7 +1595,8 @@ configuration.
             logger.info('Stack root change - requires cold start')
         elif new_dp.routers != self.routers:
             logger.info('DP routers config changed - requires cold start')
-        elif not self.ignore_subconf(new_dp, ignore_keys=['interfaces', 'interfaces_range', 'routers']):
+        elif not self.ignore_subconf(
+                new_dp, ignore_keys=['interfaces', 'interfaces_range', 'routers']):
             logger.info('DP config changed - requires cold start: %s' % self.conf_diff(new_dp))
         else:
             changed_acls = self._get_acl_config_changes(logger, new_dp)

--- a/faucet/dp.py
+++ b/faucet/dp.py
@@ -1561,9 +1561,9 @@ configuration.
                 deleted_meters (set): deleted Meter IDs.
                 changed_meters (set): changed/added Meter IDs.
         """
-        (all_meters_changed, deleted_meters, 
+        (all_meters_changed, deleted_meters,
          added_meters, changed_meters, _, _) = self._get_conf_changes(
-            logger, 'METERS', self.meters, new_dp.meters)
+             logger, 'METERS', self.meters, new_dp.meters)
 
         return (all_meters_changed, deleted_meters, added_meters, changed_meters)
 

--- a/faucet/dp.py
+++ b/faucet/dp.py
@@ -1135,11 +1135,11 @@ configuration.
                                if not vlan.reserved_internal_vlan]
                     vlan_offset = sorted(non_res)[-1]
                     # Also need to account for the potential number of tunnels
-                    ordered_acls = sorted(self.acls.values(), key=lambda x: x._id)
-                    acl_tunnels = [acl.get_num_tunnels() for acl in ordered_acls]
-                    index = ordered_acls.index(self.acls[acl_in])
+                    ordered_acls = sorted(self.acls)
+                    index = ordered_acls.index(acl_in) + 1
+                    acl_tunnels = [self.acls[name].get_num_tunnels() for name in ordered_acls]
                     tunnel_offset = sum(acl_tunnels[:index])
-                    start_pos = vlan_offset + tunnel_offset + 1
+                    start_pos = vlan_offset + tunnel_offset
                     tunnel_vid = first_unused_vlan_id(start_pos)
                     tunnel_vlan = create_vlan(tunnel_vid)
                     tunnel_vlan.reserved_internal_vlan = True

--- a/faucet/port.py
+++ b/faucet/port.py
@@ -459,6 +459,18 @@ class Port(Conf):
             return False
         return True
 
+    def contains_tunnel_acl(self, tunnel_id=None):
+        """Searches through acls_in for a tunnel ACL with a matching tunnel_id"""
+        if self.acls_in:
+            for acl in self.acls_in:
+                if acl.is_tunnel_acl():
+                    if tunnel_id:
+                        if acl.get_tunnel_rules(tunnel_id):
+                            return True
+                    else:
+                        return True
+        return False
+
     # LACP functions
     def lacp_actor_update(self, lacp_up, now=None, lacp_pkt=None, cold_start=False):
         """

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -646,13 +646,12 @@ class Valve:
             self.logger.info('%u stack ports changed state' % stack_changes)
             notify_dps = {}
             for valve in stacked_valves:
-                valve.update_tunnel_flowrules()
                 if not valve.dp.dyn_running:
                     continue
-                ofmsgs_by_valve[valve].extend(valve.get_tunnel_flowmods())
                 ofmsgs_by_valve[valve].extend(valve.add_vlans(valve.dp.vlans.values()))
                 for port in valve.dp.stack_ports:
                     ofmsgs_by_valve[valve].extend(valve.host_manager.del_port(port))
+                ofmsgs_by_valve[valve].extend(valve.get_tunnel_flowmods())
                 path_port = valve.dp.shortest_path_port(valve.dp.stack_root_name)
                 path_port_number = path_port.number if path_port else 0.0
                 self._set_var(
@@ -670,23 +669,53 @@ class Valve:
                             'dps': notify_dps
                             }})
                     break
-
         return ofmsgs_by_valve
 
-    def update_tunnel_flowrules(self):
-        """Update tunnel ACL rules because the stack topology has changed"""
-        if self.dp.tunnel_acls:
-            for tunnel_id, tunnel_acl in self.dp.tunnel_acls.items():
-                updated = tunnel_acl.update_tunnel_acl_conf(self.dp)
-                if updated:
-                    self.dp.tunnel_updated_flags[tunnel_id] = True
-                    self.logger.info('updated tunnel %s' % tunnel_id)
+    def acl_update_tunnel(self, acl):
+        """Return ofmsgs for a ACL with a tunnel rule"""
+        ofmsgs = []
+        source_vids = {}
+        for _id, info in acl.tunnel_info.items():
+            # Update the tunnel rules for each tunnel action specified
+            updated_sources = []
+            for i, source in enumerate(acl.tunnel_sources):
+                # Update each tunnel rule for each tunnel source
+                src_dp = source['dp']
+                dst_dp, dst_port = info['dst_dp'], info['dst_port']
+                out_port = None
+                shortest_path = self.dp.shortest_path(dst_dp, src_dp=src_dp)
+                if self.dp.name in shortest_path:
+                    # We are in the path, so we need to update
+                    if self.dp.name == dst_dp:
+                        out_port = dst_port
+                    if not out_port:
+                        out_port = self.dp.shortest_path_port(dst_dp).number
+                    updated = acl.update_source_tunnel_rules(
+                        self.dp.name, i, _id, out_port)
+                    if updated:
+                        if self.dp.name == src_dp:
+                            source_vids.setdefault(i, [])
+                            source_vids[i].append(_id)
+                        else:
+                            updated_sources.append(i)
+            if updated_sources:
+                for source_id in updated_sources:
+                    ofmsgs.extend(self.acl_manager.build_tunnel_rules_ofmsgs(
+                        source_id, _id, acl))
+        if source_vids:
+            for source_id, vids in source_vids.items():
+                for vid in vids:
+                    ofmsgs.extend(self.acl_manager.build_tunnel_acl_rule_ofmsgs(
+                        source_id, vid, acl))
+        return ofmsgs
 
     def get_tunnel_flowmods(self):
-        """Returns flowmods for the tunnels"""
-        if self.acl_manager:
-            return self.acl_manager.create_acl_tunnel(self.dp)
-        return []
+        """Return ofmsgs for all tunnel ACLs in the DP"""
+        ofmsgs = []
+        if self.dp.tunnel_acls:
+            for acl in self.dp.tunnel_acls:
+                ofmsgs.extend(self.acl_update_tunnel(acl))
+        return ofmsgs
 
     def fast_state_expire(self, now, other_valves):
         """Called periodically to verify the state of stack ports."""

--- a/tests/unit/faucet/test_valve_stack.py
+++ b/tests/unit/faucet/test_valve_stack.py
@@ -1725,28 +1725,28 @@ acls:
             ip_proto: 1
             actions:
                 output:
-                    - tunnel: {dp: s2, port: 1}
+                    - tunnel: {dp: s2, port: 1, tunnel_id: 5}
     dst_acl:
         - rule:
             dl_type: 0x0800
             ip_proto: 1
             actions:
                 output:
-                    - tunnel: {dp: s1, port: 1}
+                    - tunnel: {dp: s1, port: 1, tunnel_id: 2}
     same_acl:
         - rule:
             dl_type: 0x0800
             ip_proto: 1
             actions:
                 output:
-                    - tunnel: {dp: s1, port: 1}
+                    - tunnel: {dp: s1, port: 1, tunnel_id: 4}
     none_acl:
         - rule:
             dl_type: 0x0800
             ip_proto: 1
             actions:
                 output:
-                    - tunnel: {dp: s2, port: 1}
+                    - tunnel: {dp: s2, port: 1, tunnel_id: 3}
 vlans:
     vlan100:
         vid: 1

--- a/tests/unit/faucet/test_valve_stack.py
+++ b/tests/unit/faucet/test_valve_stack.py
@@ -1357,28 +1357,28 @@ acls:
             ip_proto: 1
             actions:
                 output:
-                    tunnel: {dp: s2, port: 1}
+                    tunnel: {dp: s2, port: 1, tunnel_id: 5}
     dst_acl:
         - rule:
             dl_type: 0x0800
             ip_proto: 1
             actions:
                 output:
-                    tunnel: {dp: s1, port: 1}
+                    tunnel: {dp: s1, port: 1, tunnel_id: 2}
     same_acl:
         - rule:
             dl_type: 0x0800
             ip_proto: 1
             actions:
                 output:
-                    tunnel: {dp: s1, port: 1}
+                    tunnel: {dp: s1, port: 1, tunnel_id: 4}
     none_acl:
         - rule:
             dl_type: 0x0800
             ip_proto: 1
             actions:
                 output:
-                    tunnel: {dp: s2, port: 1}
+                    tunnel: {dp: s2, port: 1, tunnel_id: 3}
 vlans:
     vlan100:
         vid: 1

--- a/tests/unit/faucet/test_valve_stack.py
+++ b/tests/unit/faucet/test_valve_stack.py
@@ -1357,28 +1357,28 @@ acls:
             ip_proto: 1
             actions:
                 output:
-                    tunnel: {dp: s2, port: 1, tunnel_id: 5}
+                    tunnel: {dp: s2, port: 1}
     dst_acl:
         - rule:
             dl_type: 0x0800
             ip_proto: 1
             actions:
                 output:
-                    tunnel: {dp: s1, port: 1, tunnel_id: 2}
+                    tunnel: {dp: s1, port: 1}
     same_acl:
         - rule:
             dl_type: 0x0800
             ip_proto: 1
             actions:
                 output:
-                    tunnel: {dp: s1, port: 1, tunnel_id: 4}
+                    tunnel: {dp: s1, port: 1}
     none_acl:
         - rule:
             dl_type: 0x0800
             ip_proto: 1
             actions:
                 output:
-                    tunnel: {dp: s2, port: 1, tunnel_id: 3}
+                    tunnel: {dp: s2, port: 1}
 vlans:
     vlan100:
         vid: 1
@@ -1725,28 +1725,28 @@ acls:
             ip_proto: 1
             actions:
                 output:
-                    - tunnel: {dp: s2, port: 1, tunnel_id: 5}
+                    - tunnel: {dp: s2, port: 1}
     dst_acl:
         - rule:
             dl_type: 0x0800
             ip_proto: 1
             actions:
                 output:
-                    - tunnel: {dp: s1, port: 1, tunnel_id: 2}
+                    - tunnel: {dp: s1, port: 1}
     same_acl:
         - rule:
             dl_type: 0x0800
             ip_proto: 1
             actions:
                 output:
-                    - tunnel: {dp: s1, port: 1, tunnel_id: 4}
+                    - tunnel: {dp: s1, port: 1}
     none_acl:
         - rule:
             dl_type: 0x0800
             ip_proto: 1
             actions:
                 output:
-                    - tunnel: {dp: s2, port: 1, tunnel_id: 3}
+                    - tunnel: {dp: s2, port: 1}
 vlans:
     vlan100:
         vid: 1


### PR DESCRIPTION
Allow ordered ACL output actions as mentioned in #3468 (Closes #3468).
```
acls:
    ordered_acl:
        - rule:
            dl_vlan: 100
            actions:
                output:
                    - port: 2
                    - pop_vlans: 1
                    - port: 3
```

Fix #3389 

Allow defining a tunnel without requiring a VLAN, Faucet will pick an unused VID that is larger than the configured VIDs (Closes #3314).
e.g.: The following config will create a tunnel that will be encapsulated with VID 101
```
vlans:
  vlans:
    vlan100:
      vid: 100
acls:
  tunnel-to-host1:
    - rule:
      actions:
      output:
        tunnel:
          dp: sw1
          port: 1
```

Tunnel ACLs will pop off the encapsulation after the output action so rules can now be applied after a tunnel action. e.g.: The output to port 6 will not have the tunnel VID applied
```
acls:
  tunnel_acl:
    - rule:
      ip_proto: 1
      dl_type: 0x0800
      actions:
        output:
          - port: 5
          - tunnel: {dp: sw2, port: 1}
          - port: 6
```