### PR TITLE
images now have multi-arch for x86_64/arm

### DIFF
--- a/docker-compose-pi.yaml
+++ b/docker-compose-pi.yaml
@@ -2,7 +2,7 @@ version: '2'
 services:
     influxdb:
         restart: always
-        image: 'arm32v7/influxdb:1.7'
+        image: 'influxdb:1.7'
         ports:
             - '8086'
             - '8083'
@@ -15,10 +15,7 @@ services:
 
     prometheus:
         restart: always
-        build:
-            context: https://github.com/faucetsdn/docker-prometheus.git
-            dockerfile: Dockerfile.pi
-        image: 'faucet/prometheus-pi:2.16.0'
+        image: 'prom/prometheus:v2.17.1'
         user: 'root'
         ports:
             - '9090:9090'
@@ -32,7 +29,7 @@ services:
 
     grafana:
         restart: always
-        image: 'grafana/grafana-arm32v7-linux:6.6.1'
+        image: 'grafana/grafana:6.7.2'
         user: 'root'
         ports:
             - '3000:3000'


### PR DESCRIPTION
This is really a stop gap until `docker-compose-pi.yaml` can be fully removed when the remaining faucet/gauge/etc images push to docker hub with multi-arch.  This also removes the need for the Dockerfile.pi in https://github.com/faucetsdn/docker-prometheus.git