### PR TITLE
Add option for integration test start port

### DIFF
--- a/clib/mininet_test_base.py
+++ b/clib/mininet_test_base.py
@@ -138,13 +138,15 @@ class FaucetTestBase(unittest.TestCase):
     faucet_config_path = None
     event_log = None
 
-    def __init__(self, name, config, root_tmpdir, ports_sock, max_test_load, port_order=None):
+    def __init__(self, name, config, root_tmpdir, ports_sock, max_test_load,
+                 port_order=None, start_port=None):
         super(FaucetTestBase, self).__init__(name)
         self.config = config
         self.root_tmpdir = root_tmpdir
         self.ports_sock = ports_sock
         self.max_test_load = max_test_load
         self.port_order = port_order
+        self.start_port = start_port
         self.start_time = None
         self.dpid_names = None
         self.event_log = None
@@ -404,7 +406,7 @@ class FaucetTestBase(unittest.TestCase):
         self._set_static_vars()
         self.topo_class = partial(
             mininet_test_topo.FaucetSwitchTopo, port_order=self.port_order,
-            switch_map=self.switch_map)
+            switch_map=self.switch_map, start_port=self.start_port)
         if self.hw_switch:
             self.hw_dpid = mininet_test_util.str_int_dpid(self.dpid)
             self.dpid = self.hw_dpid

--- a/clib/mininet_test_base_topo.py
+++ b/clib/mininet_test_base_topo.py
@@ -147,6 +147,7 @@ class FaucetTopoTestBase(FaucetTestBase):
             hw_dpid=self.hw_dpid,
             switch_map=self.switch_map,
             port_order=self.port_order,
+            start_port=self.start_port
         )
         self.port_maps = {dpid: self.create_port_map(dpid) for dpid in self.dpids}
         self.port_map = self.port_maps[self.dpid]

--- a/clib/mininet_test_topo.py
+++ b/clib/mininet_test_topo.py
@@ -23,7 +23,6 @@ from mininet.link import TCIntf, Link
 from clib import mininet_test_util
 
 
-# TODO: this should be configurable (e.g for randomization)
 SWITCH_START_PORT = 5
 
 


### PR DESCRIPTION
Specify a port number or 'random'. Random chooses a number from 1 to 10. Default is set to 'random'.
e.g:
```
sudo docker run --privileged --rm --net=host --cap-add=NET_ADMIN \
    -e FAUCET_TESTS="--port 25" \
    -ti faucet/tests
```