### PR TITLE
Prioritise selected link over standby

### DIFF
--- a/faucet/port.py
+++ b/faucet/port.py
@@ -518,18 +518,18 @@ class Port(Conf):
             # Cold starting, so revert to unconfigured state
             self.deconfigure_port()
         elif self.lacp_selected:
-            # Can configure LACP port to be forced SELECTED
+            # Configured LACP port option to be forced into SELECTED state
             self.select_port()
-        elif self.lacp_standby:
-            # Can configure LACP port to be forced STANDBY
-            self.standby_port()
         elif self.lacp_unselected:
-            # Can configure LACP port to be force UNSELECTED
+            # Configured LACP port option to be forced into UNSELECTED state
             self.deselect_port()
         else:
             if selected:
-                # Belongs on chosen DP for LAG, so SELECT port
+                # Port SELECTED so change state to SELECTED
                 self.select_port()
+            elif self.lacp_standby:
+                # Send port to STANDBY if not SELECTED
+                self.standby_port()
             else:
                 # Doesn't belong on chosen DP for LAG, DESELECT port
                 self.deselect_port()

--- a/tests/unit/faucet/test_port.py
+++ b/tests/unit/faucet/test_port.py
@@ -106,9 +106,10 @@ class FaucetLACPPortFunctions(unittest.TestCase):  # pytype: disable=module-attr
         port.lacp_port_update(True)
         self.assertEqual(port.dyn_lacp_port_selected, LACP_PORT_SELECTED)
         # Test option to force standby mode
+        # Option forces the statemachine to revert to STANDBY mode when not selected
         port.lacp_standby = True
         port.lacp_port_update(True)
-        self.assertEqual(port.dyn_lacp_port_selected, LACP_PORT_STANDBY)
+        self.assertEqual(port.dyn_lacp_port_selected, LACP_PORT_SELECTED)
         port.lacp_port_update(False)
         self.assertEqual(port.dyn_lacp_port_selected, LACP_PORT_STANDBY)
         # Test forcing selected port


### PR DESCRIPTION
`lacp_standby` forces port state to `STANDBY` when not `SELECTED`

superseeds #3500 