### PR TITLE
Add varz port_lacp_role to monitor LACP role

### DIFF
--- a/faucet/faucet_metrics.py
+++ b/faucet/faucet_metrics.py
@@ -148,6 +148,10 @@ class FaucetMetrics(PromClient):
             'learned_l2_port',
             'learned port of l2 entries',
             self.REQUIRED_LABELS + ['vid', 'eth_src'])
+        self.port_lacp_role = self._gauge(
+            'port_lacp_role',
+            'LACP role of a port',
+            self.PORT_REQUIRED_LABELS)
         self.port_lacp_state = self._gauge(
             'port_lacp_state',
             'state of LACP on a port',

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -1066,6 +1066,7 @@ class Valve:
             self.logger.info('LAG %u %s %s (previous state %s)' % (
                 port.lacp, port, port.port_role_name(new_state),
                 port.port_role_name(prev_state)))
+            self._set_var('port_lacp_role', new_state, labels=self.dp.port_labels(port.number))
         return new_state != prev_state
 
     def lacp_update_actor_state(self, port, lacp_up, now=None, lacp_pkt=None, cold_start=False):

--- a/tests/unit/faucet/test_valve_stack.py
+++ b/tests/unit/faucet/test_valve_stack.py
@@ -153,6 +153,20 @@ dps:
                 self.assertTrue(
                     valve.lacp_update_port_selection_state(port, other_valves),
                     'Port selection state not updated')
+
+                # Testing accuracy of varz port_lacp_role
+                port_labels = {
+                    'port': port.name,
+                    'port_description': port.description,
+                    'dp_name': valve.dp.name,
+                    'dp_id': '0x%x' % valve.dp.dp_id
+                }
+                lacp_role = self.get_prom('port_lacp_role', labels=port_labels, bare=True)
+                self.assertEqual(
+                    port.lacp_port_state(), lacp_role,
+                    'Port %s DP %s role %s differs from varz value %s'
+                    % (port, valve, port.lacp_port_state(), lacp_role))
+
                 if valve.dp.dp_id == 0x1:
                     self.assertEqual(
                         port.lacp_port_state(), LACP_PORT_SELECTED,


### PR DESCRIPTION
We currently monitor the LACP state of a port. The PR adds an additional metric that exposes the port role as well.