### PR TITLE
Ignore LACP churn metric.

### DIFF
--- a/clib/mininet_test_base_topo.py
+++ b/clib/mininet_test_base_topo.py
@@ -750,8 +750,8 @@ Slave queue ID: 0
 Aggregator ID: \d+
 Actor Churn State: monitoring
 Partner Churn State: monitoring
-Actor Churned Count: 0
-Partner Churned Count: 0
+Actor Churned Count: \d+
+Partner Churned Count: \d+
 details actor lacp pdu:
     system priority: 65535
     system mac address: 0e:00:00:00:00:99

--- a/tests/integration/mininet_tests.py
+++ b/tests/integration/mininet_tests.py
@@ -4071,8 +4071,8 @@ Slave queue ID: 0
 Aggregator ID: \d+
 Actor Churn State: monitoring
 Partner Churn State: monitoring
-Actor Churned Count: 0
-Partner Churned Count: 0
+Actor Churned Count: \d+
+Partner Churned Count: \d+
 details actor lacp pdu:
     system priority: 65535
     system mac address: 0e:00:00:00:00:99
@@ -4098,8 +4098,8 @@ Slave queue ID: 0
 Aggregator ID: \d+
 Actor Churn State: monitoring
 Partner Churn State: monitoring
-Actor Churned Count: 0
-Partner Churned Count: 0
+Actor Churned Count: \d+
+Partner Churned Count: \d+
 details actor lacp pdu:
     system priority: 65535
     system mac address: 0e:00:00:00:00:99


### PR DESCRIPTION
Linux occasionally returns a non-zero lacp churn metric during a test suite run.

I'm not entirely sure what metric means, but I think we can safely ignore it.