### PR TITLE
Trigger host learning from ICMP requests for faucet's VIP.

### DIFF
--- a/faucet/valve_route.py
+++ b/faucet/valve_route.py
@@ -886,7 +886,7 @@ class ValveIPv4RouteManager(ValveRouteManager):
         self.notify_learn(pkt_meta)
         return ofmsgs
 
-    def _control_plane_icmp_handler(self, pkt_meta, ipv4_pkt):
+    def _control_plane_icmp_handler(self, now, pkt_meta, ipv4_pkt):
         """Handle ICMP packets destined for the router"""
         ofmsgs = []
         if ipv4_pkt.proto != valve_of.inet.IPPROTO_ICMP:
@@ -897,6 +897,7 @@ class ValveIPv4RouteManager(ValveRouteManager):
             if icmp_pkt is None:
                 return ofmsgs
             if icmp_pkt.type == icmp.ICMP_ECHO_REQUEST:
+                ofmsgs.extend(self._resolve_vip_response(pkt_meta, pkt_meta.l3_dst, now))
                 ofmsgs.append(
                     pkt_meta.vlan.pkt_out_port(
                         valve_packet.echo_reply, pkt_meta.port,
@@ -915,7 +916,7 @@ class ValveIPv4RouteManager(ValveRouteManager):
             if ipv4_pkt is None:
                 return []
             icmp_replies = self._control_plane_icmp_handler(
-                pkt_meta, ipv4_pkt)
+                now, pkt_meta, ipv4_pkt)
             if icmp_replies:
                 return icmp_replies
         return super(ValveIPv4RouteManager, self).control_plane_handler(now, pkt_meta)


### PR DESCRIPTION
In the FaucetUntaggedIPv4RouteTests we have a pattern where we:

  1. ping from host to faucet vip
  2. check faucet learned the host route (/32)

In v4, faucet currently only learns host routes from ARP packets (we trigger this in the test suite with `one_ipv4_controller_ping()`), however you can occasionally run into a situation where a test host has a primed arp cache when `one_ipv4_controller_ping()` is run which means only an ICMP request message is sent to the faucet VIP (no ARP message so the host route isn't installed).

If we don't want to learn from ICMP requests (maybe there is a technical reason not to) an alternative fix is to clear the ARP cache on the test host before `one_ipv4_controller_ping()` is run. I have also tested this fix and it works fine.