### PR TITLE
Flush arp cache before pinging faucet VIP.

### DIFF
--- a/clib/mininet_test_base.py
+++ b/clib/mininet_test_base.py
@@ -2312,8 +2312,13 @@ dbs:
             require_host_learned=require_host_learned,
             expected_result=expected_result)
 
+    def flush_arp_cache(self, host):
+        """Flush the ARP cache for a host."""
+        host.cmd("ip -s neigh flush all")
+
     def one_ipv4_controller_ping(self, host):
         """Ping the controller from a host with IPv4."""
+        self.flush_arp_cache(host)
         self.one_ipv4_ping(host, self.FAUCET_VIPV4.ip)
         self.verify_ipv4_host_learned_mac(
             host, self.FAUCET_VIPV4.ip, self.FAUCET_MAC)


### PR DESCRIPTION
Solves a test flake in FaucetUntaggedIPv4RouteTests.

For FaucetUntaggedIPv4RouteTests, we have a pattern where we:

    1. ping from host to faucet vip
    2. check faucet learned the host route (/32)

Faucet currently only learns host routes from ARP packets (we trigger this in the test suite with one_ipv4_controller_ping()), however you can occasionally run into a situation where a test host has a primed ARP cache when one_ipv4_controller_ping() is run which means only an ICMP request message is sent to the faucet VIP (no ARP message so the host route isn't installed).

This change ensures the ARP packet is generated by explicitly clearning the ARP cache on the test host before one_ipv4_controller_ping() is run.

superseeds #3525 
