### PR TITLE
Run unit tests on python3.8.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,10 @@ jobs:
       python: 3.7
       env: MATRIX_SHARD=unittest
     - stage: test
+      language: python
+      python: 3.8
+      env: MATRIX_SHARD=unittest
+    - stage: test
       env: MATRIX_SHARD=sanity
       language: bash
       services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,9 @@ jobs:
     - stage: test
       language: python
       python: 3.5
-      env: MATRIX_SHARD=unittest
+      env:
+        - MATRIX_SHARD=unittest
+        - PYTYPE=true
     - stage: test
       language: python
       python: 3.6
@@ -31,14 +33,20 @@ jobs:
         - MATRIX_SHARD=unittest
         - BUILD_DOCS=true
         - CODECOV_UPLOAD=true
+        - PYLINT=true
+        - PYTYPE=true
     - stage: test
       language: python
       python: 3.7
-      env: MATRIX_SHARD=unittest
+      env:
+        - MATRIX_SHARD=unittest
+        - PYTYPE=true
     - stage: test
       language: python
       python: 3.8
-      env: MATRIX_SHARD=unittest
+      env:
+        - MATRIX_SHARD=unittest
+        - PYTYPE=true
     - stage: test
       env: MATRIX_SHARD=sanity
       language: bash

--- a/travis/runtests.sh
+++ b/travis/runtests.sh
@@ -42,6 +42,18 @@ if [ "${MATRIX_SHARD}" == "unittest" ] ; then
     cd ..
   fi
 
+  if [ "${PYLINT}" == "true" ] ; then
+    cd ./tests/codecheck
+    ./pylint.sh || exit 1
+    cd ../..
+  fi
+
+  if [ "${PYTYPE}" == "true" ] ; then
+    cd ./tests/codecheck
+    ./pytype.sh || exit 1
+    cd ../..
+  fi
+
   exit 0
 elif [ "${MATRIX_SHARD}" == "sanity" ] ; then
   FAUCET_TESTS="-u FaucetSanityTest"
@@ -94,9 +106,9 @@ if [ "${MATRIX_SHARD}" == "sanity" ] ; then
   # Simulate hardware test switch
   # TODO: run a standalone DP and also a stacked DP test to test hardware linkages.
   sudo docker run $SHARDARGS -e FAUCET_TESTS="-ni FaucetSanityTest FaucetStackStringOfDPUntaggedTest" -e HWTESTS="1" -t ${FAUCET_TEST_IMG} || exit 1
+else
+  sudo docker run $SHARDARGS -e FAUCET_TESTS="${FAUCET_TESTS}" -t ${FAUCET_TEST_IMG} || exit 1
 fi
-
-sudo docker run $SHARDARGS -e PY_FILES_CHANGED="${PY_FILES_CHANGED}" -e FAUCET_TESTS="${FAUCET_TESTS}" -t ${FAUCET_TEST_IMG} || exit 1
 
 if ls -1 /var/tmp/core* >/dev/null 2>&1 ; then
   echo coredumps found after tests run.

--- a/travis/runtests.sh
+++ b/travis/runtests.sh
@@ -120,8 +120,6 @@ if [ "${FILES_CHANGED}" != "all" ]; then
 fi
 
 docker build --pull -t ${FAUCET_TEST_IMG} -f Dockerfile.tests . || exit 1
-docker rmi faucet/test-base
-docker images
 
 SHARDARGS="--privileged --sysctl net.ipv6.conf.all.disable_ipv6=0 \
   --ulimit core=99999999999:99999999999 \


### PR DESCRIPTION
Ubuntu 20.04 uses python3.8, we should make sure faucet works with that version.

Also makes pytype and pylint run outside of docker.

fixes #2655 