### PR TITLE
Revert back to serialisable form of stack graph

### DIFF
--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -671,7 +671,7 @@ class Valve:
                     self.notify(
                         {'STACK_TOPO_CHANGE': {
                             'stack_root': valve.dp.stack_root_name,
-                            'graph': valve.dp.stack_graph,
+                            'graph': valve.dp.get_node_link_data(),
                             'dps': notify_dps
                             }})
                     break

--- a/tests/integration/mininet_multidp_tests.py
+++ b/tests/integration/mininet_multidp_tests.py
@@ -1818,5 +1818,5 @@ class FaucetStackTopoChangeTest(FaucetMultiDPTest):
                     self.assertTrue(graph)
                     nodeCount = len(graph.get('nodes'))
                     self.assertEqual(nodeCount, 3,
-                                'Number of nodes in graph object is %s (!=3)' % nodeCount)
+                                     'Number of nodes in graph object is %s (!=3)' % nodeCount)
         self.assertTrue(stack_event_found)

--- a/tests/integration/mininet_multidp_tests.py
+++ b/tests/integration/mininet_multidp_tests.py
@@ -3,6 +3,7 @@
 import os
 import time
 import networkx
+import json
 
 from mininet.log import error
 
@@ -1794,3 +1795,28 @@ class FaucetSingleMCLAGComplexTest(FaucetTopoTestBase):
         self.assertEqual(
             except_count, 1,
             'Number of links detecting the broadcast ARP %s (!= 1)' % except_count)
+
+
+class FaucetStackTopoChangeTest(FaucetMultiDPTest):
+    """Test STACK_TOPO_CHANGE event structure"""
+
+    NUM_DPS = 3
+
+    def test_graph_object(self):
+        """Parse event log and validate graph object in event."""
+        self.set_up(
+            stack=True, n_dps=self.NUM_DPS, n_tagged=self.NUM_HOSTS, switch_to_switch_links=2)
+        self._enable_event_log()
+        self.verify_stack_up()
+        stack_event_found = False
+        with open(self.event_log, 'r') as event_log_file:
+            for event_log_line in event_log_file.readlines():
+                event = json.loads(event_log_line.strip())
+                if 'STACK_TOPO_CHANGE' in event:
+                    stack_event_found = True
+                    graph = event.get('STACK_TOPO_CHANGE').get('graph')
+                    self.assertTrue(graph)
+                    nodeCount = len(graph.get('nodes'))
+                    self.assertEqual(nodeCount, 3,
+                                'Number of nodes in graph object is %s (!=3)' % nodeCount)
+        self.assertTrue(stack_event_found)


### PR DESCRIPTION
The content of STACK_TOPO_CHANGE was changed recently as part of [fec52f](https://github.com/faucetsdn/faucet/commit/fec52f905b12046b95e32bdf5cc4fc859485ab31) However, the MultiGraph() object is not serializable and hence the STACK_TOPO_CHANGE event is emitted with 'graph' field empty. 

Currently, faucet tests dont check for the content of an emitted event. Please let me know if the tests are needed.