### PR TITLE
WIP: Consider lacp ports with NO_SYNC status to nominate active LACP link

### DIFF
--- a/faucet/dp.py
+++ b/faucet/dp.py
@@ -682,6 +682,10 @@ configuration.
         """Return ports that have LACP up."""
         return tuple([port for port in self.lacp_ports() if port.is_actor_up()])
 
+    def lacp_nosync_ports(self):
+        """Return ports that have LACP status NO SYNC."""
+        return tuple([port for port in self.lacp_ports() if port.is_actor_nosync()])
+
     def lags(self):
         """Return dict of LAGs mapped to member ports."""
         lags = defaultdict(list)
@@ -693,6 +697,13 @@ configuration.
         """Return dict of LAGs mapped to member ports that have LACP up."""
         lags = defaultdict(list)
         for port in self.lacp_up_ports():
+            lags[port.lacp].append(port)
+        return lags
+
+    def lags_nosync(self):
+        """Return dict of LAGs mapped to member ports that have LACP in NO SYNC."""
+        lags = defaultdict(list)
+        for port in self.lacp_nosync_ports():
             lags[port.lacp].append(port)
         return lags
 

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -929,7 +929,7 @@ class Valve:
                 if lacp_id in all_lags:
                     ports[valve.dp.dp_id] += len(nosync_lags[lacp_id])
                 else:
-                     ports[valve.dp.dp_id] = len(nosync_lags[lacp_id])
+                    ports[valve.dp.dp_id] = len(nosync_lags[lacp_id])
             if valve.dp.is_stack_root():
                 root_dpid = valve.dp.dp_id
         # Order by number of ports

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -924,6 +924,12 @@ class Valve:
             all_lags = valve.dp.lags_up()
             if lacp_id in all_lags:
                 ports[valve.dp.dp_id] = len(all_lags[lacp_id])
+            nosync_lags = valve.dp.lags_nosync()
+            for lacp_id in nosync_lags:
+                if lacp_id in all_lags:
+                    ports[valve.dp.dp_id] += len(nosync_lags[lacp_id])
+                else:
+                     ports[valve.dp.dp_id] = len(nosync_lags[lacp_id])
             if valve.dp.is_stack_root():
                 root_dpid = valve.dp.dp_id
         # Order by number of ports


### PR DESCRIPTION
Currently, Faucet does not set SYNC bit on backup links by default. So if the Active link goes down, the nomination process still selects the now down ACTIVE link and hence failover doesn't take place. 

This is because, currently in valve.get_lacp_dpid_nomination, we only consider dp.lags_up() or links with ACTIVE actor state while calculating the nomination. Expanding it to include links with NO_SYNC state ensures that should the ACTIVE link go down, the DP with a NO_SYNC backup link gets higher priority and gets nominated, ensuring failover.

TODO: tests for changes.

