### PR TITLE
Use a calculated combination of dp_id and port number for lacp port num instead of the port number

### DIFF
--- a/faucet/dp.py
+++ b/faucet/dp.py
@@ -1324,7 +1324,7 @@ configuration.
 
         # Populate port.lacp_port_id if it wasn't set in config
         for port in self.ports.values():
-            if port.lacp and not port.lacp_port_id:
+            if port.lacp and port.lacp_port_id == -1:
                 dp_index = dps.index(self)
                 port.lacp_port_id = dp_index * 100 + port.number
 

--- a/faucet/dp.py
+++ b/faucet/dp.py
@@ -1322,6 +1322,12 @@ configuration.
             port for port in self.ports.values() if port.loop_protect_external}
         self.has_externals = bool(loop_protect_external_ports)
 
+        # Populate port.lacp_port_id if it wasn't set in config
+        for port in self.ports.values():
+            if port.lacp and not port.lacp_port_id:
+                dp_index = dps.index(self)
+                port.lacp_port_id = dp_index * 100 + port.number
+
         resolve_stack_dps()
         resolve_mirror_destinations()
         resolve_acls()

--- a/faucet/faucet_metrics.py
+++ b/faucet/faucet_metrics.py
@@ -193,6 +193,10 @@ class FaucetMetrics(PromClient):
             'port_dot1x_logoff',
             'number of eap-logoff events on port',
             self.PORT_REQUIRED_LABELS)
+        self.lacp_port_id = self._gauge(
+            'lacp_port_id',
+            'lacp port ID for for port',
+            self.PORT_REQUIRED_LABELS)
 
     def _counter(self, var, var_help, labels):
         return Counter(var, var_help, labels, registry=self._reg) # pylint: disable=unexpected-keyword-arg

--- a/faucet/port.py
+++ b/faucet/port.py
@@ -107,7 +107,7 @@ class Port(Conf):
         # Min time since last LACP response. Used to control rate of response for LACP
         'lacp_port_priority': 255,
         # Sets port priority value sent out in lacp packet
-        'lacp_port_id': 0,
+        'lacp_port_id': -1,
         # Sets port id value sent out in lacp packet
         'loop_protect': False,
         # if True, do simple (host/access port) loop protection on this port.

--- a/faucet/port.py
+++ b/faucet/port.py
@@ -107,6 +107,8 @@ class Port(Conf):
         # Min time since last LACP response. Used to control rate of response for LACP
         'lacp_port_priority': 255,
         # Sets port priority value sent out in lacp packet
+        'lacp_port_id': 0,
+        # Sets port id value sent out in lacp packet
         'loop_protect': False,
         # if True, do simple (host/access port) loop protection on this port.
         'loop_protect_external': False,
@@ -164,6 +166,7 @@ class Port(Conf):
         'lacp_passthrough': list,
         'lacp_resp_interval': int,
         'lacp_port_priority': int,
+        'lacp_port_id': int,
         'loop_protect': bool,
         'loop_protect_external': bool,
         'output_only': bool,
@@ -225,6 +228,7 @@ class Port(Conf):
         self.lacp_passthrough = None
         self.lacp_resp_interval = None
         self.lacp_port_priority = None
+        self.lacp_port_id = None
         self.loop_protect = None
         self.loop_protect_external = None
         self.max_hosts = None
@@ -260,7 +264,6 @@ class Port(Conf):
         self.dyn_lacp_port_selected = LACP_PORT_NOTCONFIGURED
         self.dyn_lacp_actor_state = LACP_ACTOR_NOTCONFIGURED
         self.dyn_stack_probe_info = {}
-        self.dyn_lacp_port_id = None
 
         self.tagged_vlans = []
         self.lldp_beacon = {}

--- a/faucet/port.py
+++ b/faucet/port.py
@@ -260,6 +260,7 @@ class Port(Conf):
         self.dyn_lacp_port_selected = LACP_PORT_NOTCONFIGURED
         self.dyn_lacp_actor_state = LACP_ACTOR_NOTCONFIGURED
         self.dyn_stack_probe_info = {}
+        self.dyn_lacp_port_id = None
 
         self.tagged_vlans = []
         self.lldp_beacon = {}

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -828,13 +828,14 @@ class Valve:
                 continue
 
             if port.lacp:
-                port.dyn_lacp_port_id = ((self.dp.dp_id % 1000) * 100 + port.number) % 65535
                 if cold_start:
                     self.lacp_update_actor_state(port, False, cold_start=cold_start)
                     self.lacp_update_port_selection_state(port, cold_start=cold_start)
                 ofmsgs.extend(self.lacp_update(port, False))
                 if port.lacp_active:
                     ofmsgs.extend(self._lacp_actions(port.dyn_last_lacp_pkt, port))
+                self._set_var('lacp_port_id',
+                              port.lacp_port_id, labels=self.dp.port_labels(port.number))
 
             if port.stack:
                 port_vlans = self.dp.vlans.values()
@@ -1077,7 +1078,7 @@ class Valve:
         if lacp_pkt:
             pkt = valve_packet.lacp_reqreply(
                 self.dp.faucet_dp_mac, self.dp.faucet_dp_mac,
-                port.lacp, port.dyn_lacp_port_id, port.lacp_port_priority,
+                port.lacp, port.lacp_port_id, port.lacp_port_priority,
                 actor_state_sync, actor_state_activity,
                 actor_state_col, actor_state_dist,
                 lacp_pkt.actor_system, lacp_pkt.actor_key, lacp_pkt.actor_port,
@@ -1093,7 +1094,7 @@ class Valve:
         else:
             pkt = valve_packet.lacp_reqreply(
                 self.dp.faucet_dp_mac, self.dp.faucet_dp_mac,
-                port.lacp, port.dyn_lacp_port_id, port.lacp_port_priority,
+                port.lacp, port.lacp_port_id, port.lacp_port_priority,
                 actor_state_synchronization=actor_state_sync,
                 actor_state_activity=actor_state_activity,
                 actor_state_collecting=actor_state_col,

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -828,6 +828,7 @@ class Valve:
                 continue
 
             if port.lacp:
+                port.dyn_lacp_port_id = ((self.dp.dp_id % 1000) * 100 + port.number) % 65535
                 if cold_start:
                     self.lacp_update_actor_state(port, False, cold_start=cold_start)
                     self.lacp_update_port_selection_state(port, cold_start=cold_start)
@@ -1076,7 +1077,7 @@ class Valve:
         if lacp_pkt:
             pkt = valve_packet.lacp_reqreply(
                 self.dp.faucet_dp_mac, self.dp.faucet_dp_mac,
-                port.lacp, port.number, port.lacp_port_priority,
+                port.lacp, port.dyn_lacp_port_id, port.lacp_port_priority,
                 actor_state_sync, actor_state_activity,
                 actor_state_col, actor_state_dist,
                 lacp_pkt.actor_system, lacp_pkt.actor_key, lacp_pkt.actor_port,
@@ -1092,7 +1093,7 @@ class Valve:
         else:
             pkt = valve_packet.lacp_reqreply(
                 self.dp.faucet_dp_mac, self.dp.faucet_dp_mac,
-                port.lacp, port.number, port.lacp_port_priority,
+                port.lacp, port.dyn_lacp_port_id, port.lacp_port_priority,
                 actor_state_synchronization=actor_state_sync,
                 actor_state_activity=actor_state_activity,
                 actor_state_collecting=actor_state_col,

--- a/tests/integration/mininet_tests.py
+++ b/tests/integration/mininet_tests.py
@@ -4020,12 +4020,12 @@ vlans:
                 native_vlan: 100
                 lacp: 1
                 lacp_port_priority: 1
-                lacp_port_id: 101
+                lacp_port_id: 100
             %(port_2)d:
                 native_vlan: 100
                 lacp: 1
                 lacp_port_priority: 2
-                lacp_port_id: 102
+                lacp_port_id: 101
             %(port_3)d:
                 native_vlan: 100
             %(port_4)d:

--- a/tests/integration/mininet_tests.py
+++ b/tests/integration/mininet_tests.py
@@ -4042,7 +4042,9 @@ vlans:
         first_host = self.hosts_name_ordered()[0]
 
         def get_lacp_port_id(port):
-            return ((int(self.dpid) % 1000) * 100 + port) % 65535
+            port_labels = self.port_labels(port)
+            lacp_port_id = self.scrape_prometheus_var('lacp_port_id', port_labels, default=0)
+            return lacp_port_id
 
         bond = 'bond0'
         # Linux driver should have this state (0x3f/63)

--- a/tests/integration/mininet_tests.py
+++ b/tests/integration/mininet_tests.py
@@ -4040,6 +4040,10 @@ vlans:
 
     def test_untagged(self):
         first_host = self.hosts_name_ordered()[0]
+
+        def get_lacp_port_id(port):
+            return ((int(self.dpid) % 1000) * 100 + port) % 65535
+
         bond = 'bond0'
         # Linux driver should have this state (0x3f/63)
         #
@@ -4120,7 +4124,7 @@ details partner lacp pdu:
     port priority: 2
     port number: %d
     port state: 62
-""".strip() % tuple([self.port_map['port_%u' % i] for i in lag_ports])
+""".strip() % tuple([get_lacp_port_id(self.port_map['port_%u' % i]) for i in lag_ports])
 
         lacp_timeout = 5
 

--- a/tests/integration/mininet_tests.py
+++ b/tests/integration/mininet_tests.py
@@ -4020,10 +4020,12 @@ vlans:
                 native_vlan: 100
                 lacp: 1
                 lacp_port_priority: 1
+                lacp_port_id: 101
             %(port_2)d:
                 native_vlan: 100
                 lacp: 1
                 lacp_port_priority: 2
+                lacp_port_id: 102
             %(port_3)d:
                 native_vlan: 100
             %(port_4)d:


### PR DESCRIPTION
Currently, we set the lacp port id to the DP port number. However, this sends the same value on separate links if the same ports are configured. The PR combines the DP ID and the port number to generate a port ID that is used as the LACP port number instead. 

The PR has a test that tests for the LACP port num using the same algorithm.