### PR TITLE
Downgrade pylint.

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -7,7 +7,7 @@ exabgp==4.2.6
 importlab>=0.3.1
 netifaces
 packaging
-pylint
+pylint==2.4.4
 pytest-cov
 pytype==2020.4.22
 requests


### PR DESCRIPTION
Pylint 2.5+ gives `faucet/valve_switch.py` a negative score for some reason which breaks `min_pylint.sh`

```
pylint /faucet-src/faucet/valve_switch.py
************* Module faucet.valve_switch
faucet/valve_switch.py:65:11: E1120: No value for argument 'stack_ports' in constructor call (no-value-for-parameter)
faucet/valve_switch.py:65:11: E1120: No value for argument 'dp_shortest_path_to_root' in constructor call (no-value-for-parameter)
faucet/valve_switch.py:65:11: E1120: No value for argument 'shortest_path_port' in constructor call (no-value-for-parameter)
faucet/valve_switch.py:65:11: E1120: No value for argument 'is_stack_root' in constructor call (no-value-for-parameter)
faucet/valve_switch.py:65:11: E1120: No value for argument 'is_stack_root_candidate' in constructor call (no-value-for-parameter)
faucet/valve_switch.py:65:11: E1120: No value for argument 'is_stack_edge' in constructor call (no-value-for-parameter)
faucet/valve_switch.py:65:11: E1120: No value for argument 'graph' in constructor call (no-value-for-parameter)

----------------------------------------------------------------------
Your code has been rated at -10.59/10
```

Downgrading so we can get the travis tests passing again so that we can track down what the actual issue is. 