### PR TITLE
Add lacp port role to LAG_CHANGE event in addition to actor state

### DIFF
--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -898,9 +898,10 @@ class Valve:
 
     def _reset_lacp_status(self, port):
         lacp_state = port.actor_state()
+        lacp_role = port.lacp_port_state()
         self._set_var('port_lacp_state', lacp_state, labels=self.dp.port_labels(port.number))
         self.notify(
-            {'LAG_CHANGE': {'port_no': port.number, 'state': lacp_state}})
+            {'LAG_CHANGE': {'port_no': port.number, 'state': lacp_state, 'role': lacp_role}})
 
     def get_lacp_dpid_nomination(self, lacp_id, other_valves):
         """

--- a/tests/integration/mininet_multidp_tests.py
+++ b/tests/integration/mininet_multidp_tests.py
@@ -212,15 +212,14 @@ class FaucetStringOfDPLACPUntaggedTest(FaucetMultiDPTest):
             self.verify_stack_hosts()
             self.flap_all_switch_ports()
         # Check for presence of LAG_CHANGE event in event socket log and check for it's structure
-        lag_event_found = False
+        lag_event_found = None
         with open(self.event_log, 'r') as event_log_file:
             for event_log_line in event_log_file.readlines():
                 event = json.loads(event_log_line.strip())
                 if 'LAG_CHANGE' in event:
-                    lag_event_found = True
-                    lag_event = event.get('LAG_CHANGE')
-                    self.assertTrue(lag_event.get('state') and lag_event.get('role'))
+                    lag_event_found = event.get('LAG_CHANGE')
         self.assertTrue(lag_event_found)
+        self.assertTrue(lag_event_found.get('state') and lag_event_found.get('role'))
 
     def test_dyn_fail(self):
         """Test lacp fail on reload with dynamic lacp status."""

--- a/tests/integration/mininet_multidp_tests.py
+++ b/tests/integration/mininet_multidp_tests.py
@@ -211,8 +211,16 @@ class FaucetStringOfDPLACPUntaggedTest(FaucetMultiDPTest):
             self.wait_for_all_lacp_up()
             self.verify_stack_hosts()
             self.flap_all_switch_ports()
-        # Check for presence of LAG_CHANGE event in event socket log
-        self.wait_until_matching_lines_from_file(r'.+LAG_CHANGE.+', self.event_log)
+        # Check for presence of LAG_CHANGE event in event socket log and check for it's structure
+        lag_event_found = False
+        with open(self.event_log, 'r') as event_log_file:
+            for event_log_line in event_log_file.readlines():
+                event = json.loads(event_log_line.strip())
+                if 'LAG_CHANGE' in event:
+                    lag_event_found = True
+                    lag_event = event.get('LAG_CHANGE')
+                    self.assertTrue(lag_event.get('state') and lag_event.get('role'))
+        self.assertTrue(lag_event_found)
 
     def test_dyn_fail(self):
         """Test lacp fail on reload with dynamic lacp status."""

--- a/tests/integration/mininet_multidp_tests.py
+++ b/tests/integration/mininet_multidp_tests.py
@@ -219,7 +219,8 @@ class FaucetStringOfDPLACPUntaggedTest(FaucetMultiDPTest):
                 if 'LAG_CHANGE' in event:
                     lag_event_found = event.get('LAG_CHANGE')
         self.assertTrue(lag_event_found)
-        self.assertTrue(lag_event_found.get('state') and lag_event_found.get('role'))
+        if lag_event_found:
+            self.assertTrue(lag_event_found.get('state') and lag_event_found.get('role'))
 
     def test_dyn_fail(self):
         """Test lacp fail on reload with dynamic lacp status."""


### PR DESCRIPTION
The PR helps track the lacp port role in addition to actor state in events. It modifies an existing check for the existence of the LAG_CHANGE event in the event logs to check for the presence of actor state and port role as well.