### PR TITLE
Don't take stack ports down when warm starting

### DIFF
--- a/clib/config_generator.py
+++ b/clib/config_generator.py
@@ -512,7 +512,7 @@ class FaucetTopoGenerator(Topo):
         if include:
             config['include'] = list(include)
         if include_optional:
-            config['include_optional'] = list(include_optional)
+            config['include-optional'] = list(include_optional)
         if acl_options:
             config['acls'] = self.get_acls_config(acl_options)
         config['vlans'] = self.get_vlans_config(n_vlans, vlan_options)

--- a/faucet/conf.py
+++ b/faucet/conf.py
@@ -132,7 +132,7 @@ class Conf:
                     continue
                 if isinstance(value, (tuple, list, set)) and isinstance(value[0], Conf):
                     continue
-            conf_keys.append((key, value))
+            conf_keys.append((key, self._str_conf(value)))
         return conf_keys
 
     @staticmethod

--- a/faucet/port.py
+++ b/faucet/port.py
@@ -26,6 +26,14 @@ STACK_STATE_BAD = 2
 STACK_STATE_UP = 3
 STACK_STATE_GONE = 4
 STACK_STATE_NONE = -1
+STACK_DISPLAY_DICT = {
+    STACK_STATE_ADMIN_DOWN: 'ADMIN_DOWN',
+    STACK_STATE_INIT: 'INITIALIZING',
+    STACK_STATE_BAD: 'BAD',
+    STACK_STATE_UP: 'UP',
+    STACK_STATE_GONE: 'GONE',
+    STACK_STATE_NONE: 'NONE'
+}
 
 # LACP not configured
 LACP_ACTOR_NOTCONFIGURED = -1
@@ -686,3 +694,7 @@ class Port(Conf):
     def stack_gone(self):
         """Change the current stack state to GONE."""
         self.dyn_stack_current_state = STACK_STATE_GONE
+
+    def stack_state_name(self, state):
+        """Return stack state name"""
+        return STACK_DISPLAY_DICT[state]

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -1203,7 +1203,7 @@ class Valve:
             if remote_port_state:
                 self.logger.info('LLDP on %s, %s from %s (remote %s, port %u) state %s' % (
                     chassis_id, port, pkt_meta.eth_src, valve_util.dpid_log(remote_dp_id),
-                    remote_port_id, remote_port_state))
+                    remote_port_id, port.stack_state_name(remote_port_state)))
             port.dyn_lldp_beacon_recv_state = remote_port_state
 
         peer_mac_src = self.dp.ports[port.number].lldp_peer_mac

--- a/tests/integration/mininet_multidp_tests.py
+++ b/tests/integration/mininet_multidp_tests.py
@@ -149,7 +149,7 @@ class FaucetMultiDPTest(FaucetTopoTestBase):
         # Create VLAN configuration options
         vlan_options = {}
         if routers:
-            for vlans in self.routers():
+            for vlans in routers:
                 for vlan in vlans:
                     if vlan not in vlan_options:
                         vlan_options[vlan] = {
@@ -492,7 +492,7 @@ class FaucetSingleStackStringOfDPExtLoopProtUntaggedTest(FaucetMultiDPTest):
         conf['dps'][dp_name]['interfaces'][loop_intf]['loop_protect_external'] = protect_external
         self.reload_conf(
             conf, self.faucet_config_path,
-            restart=True, cold_start=False, change_expected=True)
+            restart=True, cold_start=False, change_expected=True, dpid=self.topo.dpids_by_id[1])
 
     def test_missing_ext(self):
         """Test stacked dp with all external ports down on a switch"""
@@ -894,7 +894,7 @@ class FaucetSingleStackOrderedAclControlTest(FaucetMultiDPTest):
 class FaucetStringOfDPACLOverrideTest(FaucetMultiDPTest):
     """Test overriding ACL rules"""
 
-    NUM_DPS = 1
+    NUM_DPS = 2
     NUM_HOSTS = 2
     SOFTWARE_ONLY = True
 
@@ -966,12 +966,16 @@ class FaucetStringOfDPACLOverrideTest(FaucetMultiDPTest):
         }
 
     def include_optional(self):
+        if self.acls_config is None:
+            self.acls_config = os.path.join(self.tmpdir, 'acls.yaml')
+        if self.missing_config is None:
+            self.missing_config = os.path.join(self.tmpdir, 'missing_config.yaml')
         return [self.acls_config, self.missing_config]
 
     def setUp(self):  # pylint: disable=invalid-name
         """Setup network & create configuration file"""
-        self.acls_config = os.path.join(self.tmpdir, 'acls.yaml')
-        self.missing_config = os.path.join(self.tmpdir, 'missing_config.yaml')
+        self.acls_config = None
+        self.missing_config = None
         super(FaucetStringOfDPACLOverrideTest, self).set_up(
             n_dps=self.NUM_DPS,
             n_untagged=self.NUM_HOSTS)
@@ -982,10 +986,10 @@ class FaucetStringOfDPACLOverrideTest(FaucetMultiDPTest):
         first_host, second_host = self.hosts_name_ordered()[0:2]
         self.verify_tp_dst_notblocked(5001, first_host, second_host)
         with open(self.acls_config, 'w') as config_file:
-            config_file.write(self.topo.get_config(n_vlans=1, acl_options=self.acls_override()))
+            self.configuration_options['acl_options'] = self.acls_override()
+            config_file.write(self.topo.get_config(n_vlans=1, **self.configuration_options))
         self.verify_faucet_reconf(cold_start=False, change_expected=True)
         self.verify_tp_dst_blocked(5001, first_host, second_host)
-        self.verify_no_cable_errors()
 
     def test_port5002_notblocked(self):
         """Test that TCP port 5002 is not blocked."""
@@ -993,10 +997,10 @@ class FaucetStringOfDPACLOverrideTest(FaucetMultiDPTest):
         first_host, second_host = self.hosts_name_ordered()[0:2]
         self.verify_tp_dst_blocked(5002, first_host, second_host)
         with open(self.acls_config, 'w') as config_file:
-            config_file.write(self.topo.get_config(n_vlans=1, acl_options=self.acls_override()))
+            self.configuration_options['acl_options'] = self.acls_override()
+            config_file.write(self.topo.get_config(n_vlans=1, **self.configuration_options))
         self.verify_faucet_reconf(cold_start=False, change_expected=True)
         self.verify_tp_dst_notblocked(5002, first_host, second_host)
-        self.verify_no_cable_errors()
 
 
 class FaucetTunnelSameDpTest(FaucetMultiDPTest):
@@ -2096,3 +2100,215 @@ class FaucetStackTopoChangeTest(FaucetMultiDPTest):
                     self.assertEqual(node_count, 3,
                                      'Number of nodes in graph object is %s (!=3)' % node_count)
         self.assertTrue(stack_event_found)
+
+
+class FaucetStackWarmStartTest(FaucetTopoTestBase):
+    """Test various stack warm starting conditions to ensure stack port stays UP"""
+
+    NUM_DPS = 3
+    NUM_HOSTS = 1
+    NUM_VLANS = 2
+    SOFTWARE_ONLY = True
+
+    def setUp(self):
+        """Ignore to allow for setting up network in each test"""
+
+    def set_up(self, host_links=None, host_vlans=None, switch_to_switch_links=1):
+        """
+        Args:
+            host_links (dict): Host index map to list of DPs it is connected to
+            host_vlans (dict): Host index map to list of vlans it belongs to
+        """
+        super().setUp()
+        network_graph = networkx.path_graph(self.NUM_DPS)
+        dp_options = {}
+        for dp_i in network_graph.nodes():
+            dp_options.setdefault(dp_i, {
+                'group_table': self.GROUP_TABLE,
+                'ofchannel_log': self.debug_log_path + str(dp_i) if self.debug_log_path else None,
+                'hardware': self.hardware if dp_i == 0 and self.hw_dpid else 'Open vSwitch'
+            })
+            if dp_i == 0:
+                dp_options[0]['stack'] = {'priority': 1}
+        switch_links = list(network_graph.edges()) * switch_to_switch_links
+        link_vlans = {edge: None for edge in switch_links}
+        if host_links is None:
+            host_links = {0: [0], 1: [1], 2: [2]}
+        if host_vlans is None:
+            host_vlans = {h_i: 0 for h_i in host_links.keys()}
+        self.build_net(
+            host_links=host_links,
+            host_vlans=host_vlans,
+            switch_links=switch_links,
+            link_vlans=link_vlans,
+            n_vlans=self.NUM_VLANS,
+            dp_options=dp_options,
+        )
+        self.start_net()
+
+    def test_native_vlan(self):
+        """Test warm starting changing host native VLAN"""
+        host_vlans = {0: 0, 1: 0, 2: 1}
+        self.set_up(host_vlans=host_vlans)
+        self.verify_stack_up()
+        self.verify_intervlan_routing()
+        conf = self._get_faucet_conf()
+        interfaces_conf = conf['dps'][self.topo.switches_by_id[2]]['interfaces']
+        interfaces_conf[self.host_port_maps[2][2][0]]['native_vlan'] = self.topo.vlan_name(0)
+        self.reload_conf(
+            conf, self.faucet_config_path, restart=True,
+            cold_start=False, change_expected=True, dpid=self.topo.dpids_by_id[2])
+        self.verify_stack_up(timeout=1)
+        self.verify_intervlan_routing()
+
+    def test_vlan_change(self):
+        """Test warm starting changing a VLAN option"""
+        host_vlans = {0: 0, 1: 0, 2: 1}
+        self.set_up(host_vlans=host_vlans)
+        self.verify_stack_up()
+        self.verify_intervlan_routing()
+        conf = self._get_faucet_conf()
+        conf['vlans'][self.topo.vlan_name(0)]['edge_learn_stack_root'] = False
+        self.reload_conf(
+            conf, self.faucet_config_path, restart=True,
+            cold_start=False, change_expected=True)
+        self.verify_stack_up(timeout=1)
+        self.verify_intervlan_routing()
+
+    def test_transit_vlan_change(self):
+        """Test warm starting changing host native VLAN with a transit stack switch"""
+        import ipaddress
+        host_links = {0: [0], 1: [0], 2: [2], 3: [2]}
+        host_vlans = {0: 0, 1: 0, 2: 0, 3: 1}
+        self.set_up(host_links=host_links, host_vlans=host_vlans)
+        self.verify_stack_up()
+        self.verify_intervlan_routing()
+        conf = self._get_faucet_conf()
+        interfaces_conf = conf['dps'][self.topo.switches_by_id[0]]['interfaces']
+        interfaces_conf[self.host_port_maps[0][0][0]]['native_vlan'] = self.topo.vlan_name(1)
+        self.host_information[0]['vlan'] = 1
+        self.reload_conf(
+            conf, self.faucet_config_path, restart=True,
+            cold_start=False, change_expected=True, dpid=self.topo.dpids_by_id[0])
+        self.verify_stack_up(timeout=1)
+        ip_intf = ipaddress.ip_interface(self.host_ip_address(0, 1))
+        self.host_information[0]['ip'] = ip_intf
+        self.set_host_ip(self.host_information[0]['host'], ip_intf)
+        self.verify_intervlan_routing()
+
+    def test_del_seconday_stack_port(self):
+        """Test deleting stack port"""
+        self.set_up(switch_to_switch_links=2)
+        self.verify_stack_up()
+        self.verify_intervlan_routing()
+        conf = self._get_faucet_conf()
+        del conf['dps'][self.topo.switches_by_id[1]]['interfaces'][self.link_port_maps[(1, 2)][0]]
+        del conf['dps'][self.topo.switches_by_id[2]]['interfaces'][self.link_port_maps[(2, 1)][0]]
+        self.reload_conf(
+            conf, self.faucet_config_path, restart=True,
+            cold_start=False, change_expected=True, dpid=self.topo.dpids_by_id[1])
+        self.verify_stack_up(timeout=1)
+        self.verify_intervlan_routing()
+
+    def test_del_primary_stack_port(self):
+        """Test deleting lowest/primary stack port"""
+        self.set_up(switch_to_switch_links=2)
+        self.verify_stack_up()
+        self.verify_intervlan_routing()
+        conf = self._get_faucet_conf()
+        del conf['dps'][self.topo.switches_by_id[1]]['interfaces'][self.link_port_maps[(1, 2)][1]]
+        del conf['dps'][self.topo.switches_by_id[2]]['interfaces'][self.link_port_maps[(2, 1)][1]]
+        self.reload_conf(
+            conf, self.faucet_config_path, restart=True,
+            cold_start=False, change_expected=True, dpid=self.topo.dpids_by_id[1])
+        self.verify_stack_up(timeout=1)
+        self.verify_intervlan_routing()
+
+    def test_del_host(self):
+        """Test removing a port/host from Faucet"""
+        host_links = {0: [0], 1: [0], 2: [1], 3: [2]}
+        self.set_up(host_links=host_links)
+        self.verify_stack_up()
+        self.verify_intervlan_routing()
+        conf = self._get_faucet_conf()
+        interfaces_conf = conf['dps'][self.topo.switches_by_id[0]]['interfaces']
+        del interfaces_conf[self.host_port_maps[0][0][0]]
+        self.reload_conf(
+            conf, self.faucet_config_path, restart=True,
+            cold_start=False, change_expected=True, dpid=self.topo.dpids_by_id[0])
+        self.verify_stack_up(timeout=1)
+        del self.host_information[0]
+        self.verify_intervlan_routing()
+
+    def test_root_add_stack_link(self):
+        """Add a redundant stack link between two switches (one a root)"""
+        host_links = {0: [0], 1: [0], 2: [1], 3: [1], 4: [2], 5: [2]}
+        self.set_up(host_links=host_links)
+        self.verify_stack_up()
+        self.verify_intervlan_routing()
+        conf = self._get_faucet_conf()
+        # Create an additional link between S1-S2
+        port_num = self.topo._create_next_port(self.topo.switches_by_id[0])
+        rev_port_num = self.topo._create_next_port(self.topo.switches_by_id[1])
+        interfaces_conf = conf['dps'][self.topo.switches_by_id[0]]['interfaces']
+        interfaces_conf[port_num] = {
+            'name': 'b%u' % port_num,
+            'stack': {'dp': self.topo.switches_by_id[1], 'port': rev_port_num}}
+        interfaces_conf = conf['dps'][self.topo.switches_by_id[1]]['interfaces']
+        interfaces_conf[rev_port_num] = {
+            'name': 'b%u' % rev_port_num,
+            'stack': {'dp': self.topo.switches_by_id[0], 'port': port_num}}
+        self.reload_conf(
+            conf, self.faucet_config_path, restart=True,
+            cold_start=False, change_expected=True, dpid=self.topo.dpids_by_id[1])
+        self.verify_stack_up()
+        self.verify_intervlan_routing()
+
+    def test_add_stack_link(self):
+        """Add a redundant stack link between two non-root switches"""
+        host_links = {0: [0], 1: [0], 2: [1], 3: [1], 4: [2], 5: [2]}
+        self.set_up(host_links=host_links)
+        self.verify_stack_up()
+        self.verify_intervlan_routing()
+        conf = self._get_faucet_conf()
+        # Create an additional link between S1-S2
+        port_num = self.topo._create_next_port(self.topo.switches_by_id[1])
+        rev_port_num = self.topo._create_next_port(self.topo.switches_by_id[2])
+        interfaces_conf = conf['dps'][self.topo.switches_by_id[1]]['interfaces']
+        interfaces_conf[port_num] = {
+            'name': 'b%u' % port_num,
+            'stack': {'dp': self.topo.switches_by_id[2], 'port': rev_port_num}}
+        interfaces_conf = conf['dps'][self.topo.switches_by_id[2]]['interfaces']
+        interfaces_conf[rev_port_num] = {
+            'name': 'b%u' % rev_port_num,
+            'stack': {'dp': self.topo.switches_by_id[1], 'port': port_num}}
+        self.reload_conf(
+            conf, self.faucet_config_path, restart=True,
+            cold_start=False, change_expected=True, dpid=self.topo.dpids_by_id[1])
+        self.verify_stack_up()
+        self.verify_intervlan_routing()
+
+    def test_add_stack_link_transit(self):
+        """Add a redundant stack link between two non-root switches (with a transit switch)"""
+        host_links = {0: [0], 1: [0], 4: [2], 5: [2]}
+        self.set_up(host_links=host_links)
+        self.verify_stack_up()
+        self.verify_intervlan_routing()
+        conf = self._get_faucet_conf()
+        # Create an additional link between S1-S2
+        port_num = self.topo._create_next_port(self.topo.switches_by_id[1])
+        rev_port_num = self.topo._create_next_port(self.topo.switches_by_id[2])
+        interfaces_conf = conf['dps'][self.topo.switches_by_id[1]]['interfaces']
+        interfaces_conf[port_num] = {
+            'name': 'b%u' % port_num,
+            'stack': {'dp': self.topo.switches_by_id[2], 'port': rev_port_num}}
+        interfaces_conf = conf['dps'][self.topo.switches_by_id[2]]['interfaces']
+        interfaces_conf[rev_port_num] = {
+            'name': 'b%u' % rev_port_num,
+            'stack': {'dp': self.topo.switches_by_id[1], 'port': port_num}}
+        # Expected cold start as topology changed with all ports being stack ports
+        self.reload_conf(
+            conf, self.faucet_config_path, restart=True,
+            cold_start=True, change_expected=True, dpid=self.topo.dpids_by_id[1])
+        self.verify_stack_up()
+        self.verify_intervlan_routing()

--- a/tests/unit/faucet/valve_test_lib.py
+++ b/tests/unit/faucet/valve_test_lib.py
@@ -642,6 +642,7 @@ class ValveTestBases:
             self.update_config(orig_config, reload_type)
             final_table_state = str(self.table)
             diff = difflib.unified_diff(before_table_state.splitlines(), str(final_table_state).splitlines())
+            self.maxDiff = None
             self.assertEqual(before_table_state, final_table_state, msg='\n'.join(diff))
 
         def connect_dp(self):
@@ -947,7 +948,9 @@ class ValveTestBases:
             port.dyn_stack_current_state = status
             valve.switch_manager.update_stack_topo(True, valve.dp, port)
             for valve_vlan in valve.dp.vlans.values():
-                self.apply_ofmsgs(valve.switch_manager.add_vlan(valve_vlan))
+                ofmsgs = valve.switch_manager.add_vlan(valve_vlan)
+                if valve is self.valve:
+                    self.apply_ofmsgs(ofmsgs)
 
         def set_stack_port_up(self, port_no, valve=None):
             """Set stack port up recalculating topology as necessary."""


### PR DESCRIPTION
Fix #3523

- Stop stack ports from always being detected as changed. This keeps stack ports up during warm starts.
- Restart stack ports on a topology change, topology changes detected with a stack graph hash.