### PR TITLE
Tidy up msgpack requirement.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -12,7 +12,7 @@ Build-Depends: debhelper (>=9),
                python3-pbr (>=1.9),
                python3-bitstring,
                python3-influxdb,
-               python3-msgpack,
+               python3-msgpack (>= 0.4.6), python3-msgpack (<< 1.0.0),
                python3-networkx,
                python3-prometheus-client,
                python3-yaml,
@@ -30,7 +30,7 @@ Vcs-Browser: https://github.com/faucetsdn/faucet
 Package: python3-faucet
 Architecture: all
 Depends: python3-influxdb (>= 2.12.0),
-         python3-msgpack (>= 0.4.2),
+         python3-msgpack (>= 0.4.6), python3-msgpack (<< 1.0.0),
          python3-networkx (>= 1.9),
          python3-pbr (>= 1.9),
          python3-prometheus-client (>= 0.7.1), python3-prometheus-client (<< 0.7.2),

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,7 @@
 chewie==0.0.21
 eventlet==0.25.1
 influxdb
-msgpack
-msgpack-python
+msgpack>=0.4.6,<1.0.0
 networkx
 pbr>=1.9
 prometheus_client==0.7.1

--- a/tests/unit/packaging/test_packaging.py
+++ b/tests/unit/packaging/test_packaging.py
@@ -40,7 +40,6 @@ class CheckDebianPackageTestCase(unittest.TestCase): # pytype: disable=module-at
         self.requirements_file = os.path.join(src_dir, 'requirements.txt')
 
         self.dpkg_name = {
-            'msgpack-python': 'python3-msgpack',
             'pyyaml': 'python3-yaml'
             }
 


### PR DESCRIPTION
Transitional requirement msgpack-python no longer required.

Allow msgpack from 0.4.6 onwards (ubuntu xenial), but don't allow msgpack 1.0.0 due to ryu not supporting it yet.