### PR TITLE
Update docker per https://docs.travis-ci.com/user/docker/#installing-…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,11 @@ env:
   global:
     - FAUCET_TEST_IMG=faucet/tests
     - MATRIX_SHARDS=6
+before_install:
+  - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+  - sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+  - sudo apt-get update
+  - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
 script:
   - ./travis/runtests.sh
 jobs:


### PR DESCRIPTION
…a-newer-docker-version.

Default docker version is very old:

docker version:

32Client:
33 Version:           18.06.0-ce
34 API version:       1.38
35 Go version:        go1.10.3
36 Git commit:        0ffa825
37 Built:             Wed Jul 18 19:09:54 2018
38 OS/Arch:           linux/amd64
39 Experimental:      false
40
41Server:
42 Engine:
43  Version:          18.06.0-ce
44  API version:      1.38 (minimum version 1.12)
45  Go version:       go1.10.3
46  Git commit:       0ffa825
47  Built:            Wed Jul 18 19:07:56 2018
48  OS/Arch:          linux/amd64
49  Experimental:     false