### PR TITLE
Revert "Temporarily disable unit tests on package builds."

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -16,3 +16,6 @@ override_dh_auto_install:
 
 override_dh_auto_build:
 	dh_auto_build
+
+override_dh_auto_test:
+	dh_auto_test -- --system=custom --test-args='{interpreter} -m unittest discover tests/unit/faucet/ && {interpreter} -m unittest discover tests/unit/gauge/'

--- a/docker/install-faucet.sh
+++ b/docker/install-faucet.sh
@@ -1,25 +1,24 @@
-#!/bin/sh
+#!/bin/ash
 
-set -e
+set -euo pipefail
 
 APK="apk -q"
 BUILDDEPS="gcc python3-dev musl-dev parallel yaml-dev"
 TESTDEPS="bitstring pytest wheel virtualenv"
 PIP3="pip3 -q --no-cache-dir install --upgrade"
-FROOT=/faucet-src
+FROOT="/faucet-src"
 
-dir=`dirname $0`
+dir=$(dirname "$0")
 
 # Clean up
 rm -r "$FROOT/docs"
+${APK} add -U git ${BUILDDEPS}
+"${dir}/retrycmd.sh" "${PIP3} pip"
+"${dir}/retrycmd.sh" "${PIP3} setuptools ${TESTDEPS}"
+"${dir}/retrycmd.sh" "${PIP3} -r ${FROOT}/requirements.txt"
+${PIP3} ${FROOT}
 
-$APK add -U git $BUILDDEPS && \
-  $dir/retrycmd.sh "$PIP3 pip" && \
-  $dir/retrycmd.sh "$PIP3 setuptools $TESTDEPS" && \
-  $dir/retrycmd.sh "$PIP3 -r $FROOT/requirements.txt" && \
-  $PIP3 $FROOT
-
-if [ "$(uname -m)" == "x86_64" ]; then
+if [ "$(uname -m)" = "x86_64" ]; then
   (
   echo "Running unit tests"
   cd "${FROOT}"
@@ -30,9 +29,9 @@ else
   echo "Skipping tests on $(uname -m) platform"
 fi
 
-pip3 uninstall -y $TESTDEPS || exit 1
-for i in $BUILDDEPS ; do
-  $APK del $i || exit 1
+pip3 uninstall -y ${TESTDEPS} || exit 1
+for i in ${BUILDDEPS} ; do
+  ${APK} del "$i" || exit 1
 done
 
 # Smoke test

--- a/docker/install-faucet.sh
+++ b/docker/install-faucet.sh
@@ -10,8 +10,6 @@ FROOT="/faucet-src"
 
 dir=$(dirname "$0")
 
-# Clean up
-rm -r "$FROOT/docs"
 ${APK} add -U git ${BUILDDEPS}
 "${dir}/retrycmd.sh" "${PIP3} pip"
 "${dir}/retrycmd.sh" "${PIP3} setuptools ${TESTDEPS}"
@@ -33,6 +31,9 @@ pip3 uninstall -y ${TESTDEPS} || exit 1
 for i in ${BUILDDEPS} ; do
   ${APK} del "$i" || exit 1
 done
+
+# Clean up
+rm -r "${FROOT}"
 
 # Smoke test
 faucet -V || exit 1

--- a/docker/install-faucet.sh
+++ b/docker/install-faucet.sh
@@ -20,7 +20,12 @@ $APK add -U git $BUILDDEPS && \
   $PIP3 $FROOT
 
 if [ "$(uname -m)" == "x86_64" ]; then
-  echo $FROOT/tests/unit/faucet/test_*.py $FROOT/tests/unit/gauge/test_*.py | xargs realpath | shuf | parallel --delay 1 --bar --halt now,fail=1 -j 2 python3 -m pytest
+  (
+  echo "Running unit tests"
+  cd "${FROOT}"
+  python3 -m unittest discover "tests/unit/faucet/"
+  python3 -m unittest discover "tests/unit/gauge/"
+  )
 else
   echo "Skipping tests on $(uname -m) platform"
 fi

--- a/docker/install-faucet.sh
+++ b/docker/install-faucet.sh
@@ -19,7 +19,11 @@ $APK add -U git $BUILDDEPS && \
   $dir/retrycmd.sh "$PIP3 -r $FROOT/requirements.txt" && \
   $PIP3 $FROOT
 
-echo "Skipping tests on $(uname -m) platform"
+if [ "$(uname -m)" == "x86_64" ]; then
+  echo $FROOT/tests/unit/faucet/test_*.py $FROOT/tests/unit/gauge/test_*.py | xargs realpath | shuf | parallel --delay 1 --bar --halt now,fail=1 -j 2 python3 -m pytest
+else
+  echo "Skipping tests on $(uname -m) platform"
+fi
 
 pip3 uninstall -y $TESTDEPS || exit 1
 for i in $BUILDDEPS ; do


### PR DESCRIPTION
Reverts temporary work around faucetsdn/faucet#3603 now that #3606 fixes the actual issue.