### PR TITLE
Run parallel pytype for ~50% reduction in worst case run time.

### DIFF
--- a/faucet/config_parser.py
+++ b/faucet/config_parser.py
@@ -328,5 +328,5 @@ def get_config_for_api(valves):
         valve_conf = valve.get_config_dict()
         for i in V2_TOP_CONFS:
             if i in valve_conf:
-                config[i].update(valve_conf[i])
+                config[i].update(valve_conf[i])  # pytype: disable=attribute-error
     return config

--- a/faucet/valve_switch.py
+++ b/faucet/valve_switch.py
@@ -88,4 +88,4 @@ def valve_switch_factory(logger, dp, pipeline, acl_manager):  # pylint: disable=
     switch_class = ValveSwitchManager
     if dp.use_idle_timeout:
         switch_class = ValveSwitchFlowRemovedManager
-    return switch_class(**switch_args)
+    return switch_class(**switch_args)  # pytype: disable=wrong-keyword-args

--- a/faucet/valve_switch_stack.py
+++ b/faucet/valve_switch_stack.py
@@ -223,7 +223,7 @@ class ValveSwitchStackManagerBase(ValveSwitchManager):
                     first_peer_dp = first_peer_port.stack['dp'].name
                 self.towards_root_stack_ports = {
                     port for port in self.all_towards_root_stack_ports
-                    if port.stack['dp'].name == first_peer_dp}
+                    if port.stack['dp'].name == first_peer_dp}  # pytype: disable=attribute-error
             self.away_from_root_stack_ports = all_peer_ports - self.all_towards_root_stack_ports
             if self.towards_root_stack_ports:
                 self.logger.info(

--- a/tests/codecheck/pytype.sh
+++ b/tests/codecheck/pytype.sh
@@ -9,5 +9,5 @@ SRCFILES="$FAUCETHOME/tests/codecheck/src_files.sh $*"
 echo
 echo "Using $PYTYPE (header $PYHEADER)"
 
-python3 $PYTYPE --config $CONFIG -o $TMPDIR/{/} `$SRCFILES | shuf` || exit 1
+python3 $PYTYPE -j 2 --config $CONFIG -o $TMPDIR/{/} `$SRCFILES | shuf` || exit 1
 rm -rf $TMPDIR


### PR DESCRIPTION
Unfortunately no -j "auto" option, so using 2 as a default.

Before (no -j):

faucet@faucet:~/faucet$ PYTHONPATH=. time ./tests/codecheck/pytype.sh
Using /usr/local/bin/pytype (header #!/usr/bin/python3)
Computing dependencies
Analyzing 87 sources with 1 local dependencies
ninja: Entering directory `/var/tmp/tmp.GaQQHv4nCQ/{/}'
[88/88] check tests.fuzzer.display_packet_crash
Success: no errors found
141.93user 2.83system 2:24.06elapsed 100%CPU (0avgtext+0avgdata 210224maxresident)k
0inputs+1824outputs (0major+1020565minor)pagefaults 0swaps

After (-j 2):

faucet@faucet:~/faucet$ PYTHONPATH=. time ./tests/codecheck/pytype.sh
Using /usr/local/bin/pytype (header #!/usr/bin/python3)
Computing dependencies
Analyzing 87 sources with 1 local dependencies
ninja: Entering directory `/var/tmp/tmp.47Ly6zix8P/{/}'
[88/88] check tests.unit.faucet.test_config
Success: no errors found
146.26user 3.01system 1:16.58elapsed 194%CPU (0avgtext+0avgdata 210124maxresident)k
0inputs+1776outputs (0major+1016684minor)pagefaults 0swaps