### PR TITLE
Coprocessor shouldn't be subject to VLAN ACL, because it's intended t…

### DIFF
--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -53,6 +53,14 @@ VLAN Table
     - Interception of L2 control traffic (e.g. LACP, LLDP if configured).
     - Unknown traffic is dropped
 
+
+Coprocessor Table
+~~~~~~~~~~~~~~~~~
+- Match fields: ``in_port, eth_type, vlan_vid``
+- Operations:
+    - For coprocessed ports only - allow an external NFV processor to output directly specific port, or ethernet destination address.
+
+
 VLAN_ACL Table
 ~~~~~~~~~~~~~~
 - Apply user supplied ACLs to a VLAN and send to next table

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -739,6 +739,9 @@ or a name. The following attributes can be configured:
       - None
       - The acl to be applied to all packets arriving on this vlan.
         ACLs listed first take priority over those later in the list.
+        NOTE: packets from coprocessor port are not subject to vlan acls,
+        because coprocessors intentionally bypass normal input processing
+        including vlan acls and switch/route learning.
     * - description
       - string
       - None

--- a/faucet/dp.py
+++ b/faucet/dp.py
@@ -529,10 +529,6 @@ configuration.
         if 'egress_acl' in included_tables:
             table_configs['eth_dst'].miss_goto = 'egress_acl'
 
-        if 'copro' in included_tables:
-            if 'vlan_acl' in included_tables:
-                table_configs['copro'].miss_goto = 'vlan_acl'
-
         oxm_fields = set(valve_of.MATCH_FIELDS.keys())
 
         for table_name, table_config in table_configs.items():


### PR DESCRIPTION
…o directly output (eth dst or port).

Update documentation and add test.

Fixes https://github.com/faucetsdn/faucet/issues/3329.