### PR TITLE
Don't hardcode python_version for pytype.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,6 @@ console_scripts =
     fctl = faucet.fctl:main
 
 [pytype]
-python_version = 3.6
 pythonpath =
     .:
     faucet:


### PR DESCRIPTION
Actually make the per-python pytype runners added in #3570 work.