### PR TITLE
Update lacp varz when LACP port role is updated

### DIFF
--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -833,7 +833,7 @@ class Valve:
         select_updated = self.switch_manager.lacp_update_port_selection_state(
             port, self, other_valves, cold_start=False)
         if updated or select_updated:
-            if updated:
+            if updated or select_updated:
                 self._reset_lacp_status(port)
             if port.is_port_selected() and port.is_actor_up():
                 ofmsgs.extend(self.switch_manager.enable_forwarding(port))

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -833,8 +833,7 @@ class Valve:
         select_updated = self.switch_manager.lacp_update_port_selection_state(
             port, self, other_valves, cold_start=False)
         if updated or select_updated:
-            if updated or select_updated:
-                self._reset_lacp_status(port)
+            self._reset_lacp_status(port)
             if port.is_port_selected() and port.is_actor_up():
                 ofmsgs.extend(self.switch_manager.enable_forwarding(port))
                 ofmsgs.extend(self.add_vlans(port.vlans()))

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -833,6 +833,7 @@ class Valve:
         select_updated = self.switch_manager.lacp_update_port_selection_state(
             port, self, other_valves, cold_start=False)
         if updated or select_updated:
+            # Reset status for both role and state change
             self._reset_lacp_status(port)
             if port.is_port_selected() and port.is_actor_up():
                 ofmsgs.extend(self.switch_manager.enable_forwarding(port))

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -833,6 +833,7 @@ class Valve:
         select_updated = self.switch_manager.lacp_update_port_selection_state(
             port, self, other_valves, cold_start=False)
         if updated or select_updated:
+            # Update varz and send out event if role/state are updated
             if updated or select_updated:
                 self._reset_lacp_status(port)
             if port.is_port_selected() and port.is_actor_up():

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -833,7 +833,6 @@ class Valve:
         select_updated = self.switch_manager.lacp_update_port_selection_state(
             port, self, other_valves, cold_start=False)
         if updated or select_updated:
-            # Reset status for both role and state change
             self._reset_lacp_status(port)
             if port.is_port_selected() and port.is_actor_up():
                 ofmsgs.extend(self.switch_manager.enable_forwarding(port))

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -833,7 +833,6 @@ class Valve:
         select_updated = self.switch_manager.lacp_update_port_selection_state(
             port, self, other_valves, cold_start=False)
         if updated or select_updated:
-            # Update varz and send out event if role/state are updated
             if updated or select_updated:
                 self._reset_lacp_status(port)
             if port.is_port_selected() and port.is_actor_up():

--- a/tests/unit/faucet/test_valve_stack.py
+++ b/tests/unit/faucet/test_valve_stack.py
@@ -152,8 +152,7 @@ dps:
         for valve, ports in lacp_ports.items():
             other_valves = self.get_other_valves(valve)
             for port in ports:
-                valve.switch_manager.lacp_update_port_selection_state(port, valve, other_valves)
-                valve._reset_lacp_status(port)
+                valve.lacp_update(port, True, 1, 1, other_valves)
                 # Testing accuracy of varz port_lacp_role
                 port_labels = {
                     'port': port.name,


### PR DESCRIPTION
Currently, we only update varz and send out an event when the port state is changed. However, this leaves out corner cases during controller failover and in some cases, LACP link failover, where the role is updated internally but isn't reflected in the monitoring varz. 

The PR also updates test_nominated_dpid_port_selection to check for the varz after calling lacp_update instead of explicitly calling _reset_lacp_status.