### PR TITLE
Refactor stacking into ValveStackManager & Stack classes

### DIFF
--- a/clib/fakeoftable.py
+++ b/clib/fakeoftable.py
@@ -1020,7 +1020,7 @@ class FlowMod:
             name = 'output'
             if action.port == CONTROLLER_PORT:
                 value = 'CONTROLLER'
-            if action.port == IN_PORT:
+            elif action.port == IN_PORT:
                 value = 'IN_PORT'
             else:
                 value = str(action.port)

--- a/clib/valve_test_lib.py
+++ b/clib/valve_test_lib.py
@@ -1077,7 +1077,7 @@ class ValveTestBases:
             """Bring all the ports in a stack fully up"""
             for valve in self.valves_manager.valves.values():
                 valve.dp.dyn_running = True
-                for port in valve.dp.stack_ports:
+                for port in valve.dp.stack_ports():
                     port.stack_up()
 
         def up_stack_port(self, port, dp_id=None):
@@ -1121,7 +1121,7 @@ class ValveTestBases:
                 valve.dp.dyn_running = True
                 for port in valve.dp.ports.values():
                     port.dyn_phys_up = True
-                for port in valve.dp.stack_ports:
+                for port in valve.dp.stack_ports():
                     self.up_stack_port(port, dp_id=valve.dp.dp_id)
                     self._update_port_map(port, True)
             self.trigger_all_ports(packets=packets)
@@ -1161,7 +1161,7 @@ class ValveTestBases:
                 valve = self.valves_manager.valves[self.DP_ID]
             port = valve.dp.ports[port_no]
             port.dyn_stack_current_state = status
-            valve.switch_manager.update_stack_topo(True, valve.dp, port)
+            valve.stack_manager.update_stack_topo(True, valve.dp, port)
             for valve_vlan in valve.dp.vlans.values():
                 ofmsgs = valve.switch_manager.add_vlan(valve_vlan, cold_start=False)
                 self.apply_ofmsgs(ofmsgs, dp_id=valve.dp.dp_id)
@@ -2379,6 +2379,8 @@ meters:
                     native_vlan: vlan200
                 3:
                     stack: {dp: s2, port: 3}
+                4:
+                    stack: {dp: s5, port: 4}
         s2:
             dp_id: 2
             hardware: 'GenericTFM'
@@ -2413,6 +2415,20 @@ meters:
                     native_vlan: vlan200
                 3:
                     stack: {dp: s3, port: 4}
+                4:
+                    stack: {dp: s5, port: 3}
+        s5:
+            dp_id: 5
+            hardware: 'GenericTFM'
+            interfaces:
+                1:
+                    native_vlan: vlan100
+                2:
+                    native_vlan: vlan200
+                3:
+                    stack: {dp: s4, port: 4}
+                4:
+                    stack: {dp: s1, port: 4}
     """
 
         def create_config(self):
@@ -2436,13 +2452,7 @@ meters:
             """Create a stacking config file."""
             self.create_config()
             self.setup_valves(self.CONFIG)
-            for valve in self.valves_manager.valves.values():
-                valve.dp.dyn_running = True
-                for port in valve.dp.ports.values():
-                    port.dyn_finalized = False
-                    port.enabled = True
-                    port.dyn_phys_up = True
-                    port.dyn_finalized = True
+            self.trigger_stack_ports()
 
         @staticmethod
         def create_mac(vindex, host):
@@ -2486,7 +2496,7 @@ meters:
                 self.assertEqual(eth_match, nexthop.eth_src)
                 if host_valve != valve:
                     # Check the proper nexthop port is cached
-                    expected_port = valve.dp.shortest_path_port(host_valve.dp.name)
+                    expected_port = valve.stack_manager.relative_port_towards(host_valve.dp.name)
                     self.assertEqual(expected_port, nexthop.port)
 
         def test_router_cache_learn_hosts(self):

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -276,7 +276,14 @@ within the configuration block 'stack':
       - integer
       - 0
       - Setting any value for stack priority indicates that this datapath
-        should be the root for the stacking topology.
+        should be the root for the stacking topology. When multiple stack DPs
+        have a priority value applied, the root will be chosen as the DP with
+        the lowest priority
+    * - down_time_multiple
+      - integer
+      - 3
+      - The down_time_multiple value determines the number of root update time
+        intervals for a stack node to be considered healthy when not running.
 
 LLDP (DP)
 #########
@@ -1140,6 +1147,11 @@ such as paths for configuration files and port numbers.
       - | /etc/faucet/faucet.yaml:
         | /etc/ryu/faucet/faucet.yaml
       - Faucet will load its configuration from the first valid file in list
+    * - FAUCET_STACK_ROOT_STATE_UPDATE_TIME
+      - int
+      - 10
+      - Configures the number of seconds to wait before checking stack root health. If the current root is unhealthy, a new root will be nominated.
+        If set to 0, Faucet will not check root node health.
     * - FAUCET_CONFIG_AUTO_REVERT
       - boolean
       - False

--- a/faucet/conf.py
+++ b/faucet/conf.py
@@ -49,12 +49,14 @@ class Conf:
         if self.defaults is not None and self.defaults_types is not None:
             diff = set(self.defaults.keys()).symmetric_difference(set(self.defaults_types.keys()))
             assert not diff, diff
-        # TODO: handle conf as a sequence. # pylint: disable=fixme
         if isinstance(conf, dict):
             self.update(conf)
             self.set_defaults()
         self.check_config()
         self.orig_conf = {k: self.__dict__[k] for k in self.defaults}
+        for k, conf_v in self.orig_conf.items():
+            if isinstance(conf_v, Conf):
+                self.orig_conf[k] = conf_v.orig_conf
 
     def __setattr__(self, name, value):
         if not self.dyn_finalized or name.startswith('dyn') or name in self.mutable_attrs:

--- a/faucet/dp.py
+++ b/faucet/dp.py
@@ -16,13 +16,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from collections import defaultdict, Counter
+from collections import defaultdict
 import copy
 import random
 import math
 import netaddr
-
-import networkx
 
 from faucet import faucet_pipeline
 from faucet import valve_of
@@ -33,6 +31,7 @@ from faucet.conf import Conf, test_config_condition
 from faucet.faucet_pipeline import ValveTableConfig
 from faucet.valve import SUPPORTED_HARDWARE
 from faucet.valve_table import ValveTable, ValveGroupTable
+from faucet.stack import Stack
 
 
 # Documentation generated using documentation_generator.py
@@ -45,7 +44,7 @@ configuration.
 """
     DEFAULT_LLDP_SEND_INTERVAL = 5
     DEFAULT_LLDP_MAX_PER_INTERVAL = 5
-    mutable_attrs = frozenset(['stack', 'vlans'])
+    mutable_attrs = frozenset(['vlans'])
 
     # Values that are set to None will be set using set_defaults
     # they are included here for testing and informational purposes
@@ -220,10 +219,6 @@ configuration.
         'flood': int,
     }
 
-    stack_defaults_types = {
-        'priority': int,
-    }
-
     lldp_beacon_defaults_types = {
         'send_interval': int,
         'max_per_interval': int,
@@ -239,7 +234,6 @@ configuration.
         'auth_acl': str,
         'noauth_acl': str,
     }
-
 
     def __init__(self, _id, dp_id, conf):
         """Constructs a new DP object"""
@@ -308,17 +302,12 @@ configuration.
         self.strict_packet_in_cookie = None
         self.multi_out = None
         self.idle_dst = None
-        self.stack_root_name = None
-        self.stack_roots_names = None
-        self.stack_route_learning = None
-        self.stack_root_flood_reflection = None
         self.has_acls = None
 
         self.acls = {}
         self.vlans = {}
         self.ports = {}
         self.routers = {}
-        self.stack_ports = []
         self.hairpin_ports = []
         self.output_only_ports = []
         self.lldp_beacon_ports = []
@@ -330,7 +319,6 @@ configuration.
         self.dyn_up_port_nos = set()
         self.has_externals = None
         self.tunnel_acls = []
-        self.stack_graph = None
 
         super(DP, self).__init__(_id, dp_id, conf)
 
@@ -380,13 +368,12 @@ configuration.
             self.learn_jitter = int(max(math.sqrt(self.timeout) * 3, 1))
         if self.learn_ban_timeout == 0:
             self.learn_ban_timeout = self.learn_jitter
-        if self.stack:
-            self._check_conf_types(self.stack, self.stack_defaults_types)
         if self.lldp_beacon:
             self._lldp_defaults()
         if self.dot1x:
             self._check_conf_types(self.dot1x, self.dot1x_defaults_types)
         self._check_conf_types(self.table_sizes, self.default_table_sizes_types)
+        self.stack = Stack('stack', self.dp_id, self.name, self.canonical_port_order, self.stack)
 
     def _lldp_defaults(self):
         self._check_conf_types(self.lldp_beacon, self.lldp_beacon_defaults_types)
@@ -659,9 +646,15 @@ configuration.
     def non_vlan_ports(self):
         """Ports that don't have VLANs on them."""
         ports = set()
-        for non_vlan in (self.output_only_ports, self.stack_ports, self.coprocessor_ports()):
+        for non_vlan in (self.output_only_ports, self.stack_ports(), self.coprocessor_ports()):
             ports.update(set(non_vlan))
         return ports
+
+    def stack_ports(self):
+        """Return list of stack ports"""
+        if self.stack:
+            return tuple(self.stack.ports)
+        return []
 
     def coprocessor_ports(self):
         """Return list of coprocessor ports."""
@@ -678,6 +671,10 @@ configuration.
     def lacp_up_ports(self):
         """Return ports that have LACP up."""
         return tuple([port for port in self.lacp_ports() if port.is_actor_up()])
+
+    def lacp_down_ports(self):
+        """Return ports that have LACP not UP"""
+        return tuple([port for port in self.lacp_ports() if not port.is_actor_up()])
 
     def lags(self):
         """Return dict of LAGs mapped to member ports."""
@@ -697,13 +694,6 @@ configuration.
         """Return True if all LAGs have at least one port up."""
         return set(self.lags()) == set(self.lags_up())
 
-    def any_stack_port_up(self):
-        """Return True if any stack port is up."""
-        for port in self.stack_ports:
-            if port.is_stack_up():
-                return True
-        return False
-
     def add_acl(self, acl_ident, acl):
         """Add an ACL to this DP."""
         self.acls[acl_ident] = acl
@@ -719,7 +709,7 @@ configuration.
         if port.output_only:
             self.output_only_ports.append(port)
         if port.stack:
-            self.stack_ports.append(port)
+            self.stack.add_port(port)
         if port.lldp_beacon_enabled():
             self.lldp_beacon_ports.append(port)
         if port.hairpin or port.hairpin_unicast:
@@ -732,7 +722,7 @@ configuration.
         send_ports = []
         if self.lldp_beacon:
             priority_ports = {
-                port for port in self.stack_ports
+                port for port in self.stack_ports()
                 if port.running() and port.lldp_beacon_enabled()}
             cutoff_beacon_time = now - self.lldp_beacon['send_interval']
             nonpriority_ports = {
@@ -748,142 +738,17 @@ configuration.
             send_ports.extend(nonpriority_ports)
         return send_ports
 
-    @staticmethod
-    def modify_stack_topology(graph, dp, port, add=True):  # pylint: disable=invalid-name
-        """Add/remove an edge to the stack graph which originates from this dp and port."""
-
-        def canonical_edge(dp, port):  # pylint: disable=invalid-name
-            peer_dp = port.stack['dp']
-            peer_port = port.stack['port']
-            sort_edge_a = (
-                dp.name, port.name, dp, port)
-            sort_edge_z = (
-                peer_dp.name, peer_port.name, peer_dp, peer_port)
-            sorted_edge = sorted((sort_edge_a, sort_edge_z))
-            edge_a, edge_b = sorted_edge[0][2:], sorted_edge[1][2:]
-            return edge_a, edge_b
-
-        def make_edge_name(edge_a, edge_z):
-            edge_a_dp, edge_a_port = edge_a
-            edge_z_dp, edge_z_port = edge_z
-            return '%s:%s-%s:%s' % (
-                edge_a_dp.name, edge_a_port.name,
-                edge_z_dp.name, edge_z_port.name)
-
-        def make_edge_attr(edge_a, edge_z):
-            edge_a_dp, edge_a_port = edge_a
-            edge_z_dp, edge_z_port = edge_z
-            return {
-                'dp_a': edge_a_dp, 'port_a': edge_a_port,
-                'dp_z': edge_z_dp, 'port_z': edge_z_port}
-
-        edge = canonical_edge(dp, port)
-        edge_a, edge_z = edge
-        edge_name = make_edge_name(edge_a, edge_z)
-        edge_attr = make_edge_attr(edge_a, edge_z)
-        edge_a_dp, _ = edge_a
-        edge_z_dp, _ = edge_z
-        if add:
-            graph.add_edge(
-                edge_a_dp.name, edge_z_dp.name,
-                key=edge_name, port_map=edge_attr)
-        elif (edge_a_dp.name, edge_z_dp.name, edge_name) in graph.edges:
-            graph.remove_edge(edge_a_dp.name, edge_z_dp.name, edge_name)
-
-        return edge_name
-
-    @classmethod
-    def add_stack_link(cls, graph, dp, port):  # pylint: disable=invalid-name
-        """Add a stack link to the stack graph."""
-        return cls.modify_stack_topology(graph, dp, port)
-
-    @classmethod
-    def remove_stack_link(cls, graph, dp, port):  # pylint: disable=invalid-name
-        """Remove a stack link to the stack graph."""
-        return cls.modify_stack_topology(graph, dp, port, False)
-
-    @staticmethod
-    def hash_graph(graph):
-        """Return hash of a topology graph"""
-        # Using the degree of the topology is a quick way to get an estimate on
-        #   whether a graph is isomorphic which is what we would really want when comparing
-        #   two graphs.
-        return hash(tuple(sorted(graph.degree())))
-
     def resolve_stack_topology(self, dps, meta_dp_state):
-        """Resolve inter-DP config for stacking."""
-        stack_dps = [dp for dp in dps if dp.stack is not None]
-        stack_priority_dps = [dp for dp in stack_dps if 'priority' in dp.stack]
-        stack_port_dps = [dp for dp in dps if dp.stack_ports]
-
-        if not stack_priority_dps:
-            test_config_condition(stack_dps, 'stacking enabled but no root DP')
-            return
-
-        if not self.stack_ports:
-            return
-
-        for dp in stack_priority_dps:  # pylint: disable=invalid-name
-            test_config_condition(not isinstance(dp.stack['priority'], int), (
-                'stack priority must be type %s not %s' % (
-                    int, type(dp.stack['priority']))))
-            test_config_condition(dp.stack['priority'] <= 0, (
-                'stack priority must be > 0'))
-        stack_priority_dps = sorted(stack_priority_dps, key=lambda x: x.stack['priority'])
-
-        self.stack_roots_names = [dp.name for dp in stack_priority_dps]
-        self.stack_root_name = self.stack_roots_names[0]
-        if meta_dp_state:
-            if meta_dp_state.stack_root_name in self.stack_roots_names:
-                self.stack_root_name = meta_dp_state.stack_root_name
-
-        self.stack_route_learning = False
-        for dp in stack_port_dps:  # pylint: disable=invalid-name
-            # Must set externals flag for entire stack.
-            if dp.has_externals:
-                self.has_externals = True
-            for vlan in dp.vlans.values():
-                if vlan.faucet_vips:
-                    self.stack_route_learning = True
-
-        edge_count = Counter()
-        graph = networkx.MultiGraph()
-        for dp in stack_port_dps:  # pylint: disable=invalid-name
-            graph.add_node(dp.name)
-            for port in dp.stack_ports:
-                edge_name = self.add_stack_link(graph, dp, port)
-                edge_count[edge_name] += 1
-        for edge_name, count in edge_count.items():
-            test_config_condition(count != 2, '%s defined only in one direction' % edge_name)
-        if graph.size() and self.name in graph:
-            if self.stack is None:
-                self.stack = {}
-            self.stack_graph = graph
-            for dp in graph.nodes():  # pylint: disable=invalid-name
-                path_to_root_len = len(self.shortest_path(self.stack_root_name, src_dp=dp))
-                test_config_condition(
-                    path_to_root_len == 0, '%s not connected to stack' % dp)
-
-            if self.stack_longest_path_to_root_len() > 2:
-                self.stack_root_flood_reflection = True
-
+        """Resolve inter-DP config for stacking"""
+        if self.stack:
+            self.stack.resolve_topology(dps, meta_dp_state)
+            for dp in dps:
+                # Must set externals flag for entire stack.
+                if dp.stack and dp.has_externals:
+                    self.has_externals = True
+                    break
         if self.tunnel_acls:
             self.finalize_tunnel_acls(dps)
-
-    def get_node_link_data(self):
-        """Return network stacking graph as a node link representation"""
-        return networkx.json_graph.node_link_data(self.stack_graph)
-
-    def stack_longest_path_to_root_len(self):
-        """Return length of the longest path to root in the stack."""
-        if not self.stack_graph or not self.stack_root_name:
-            return None
-        len_paths_to_root = [
-            len(self.shortest_path(self.stack_root_name, src_dp=dp))
-            for dp in self.stack_graph.nodes()]
-        if len_paths_to_root:
-            return max(len_paths_to_root)
-        return None
 
     def finalize_tunnel_acls(self, dps):
         """Resolve each tunnels sources"""
@@ -902,92 +767,9 @@ configuration.
                 if not source:
                     self.tunnel_acls.remove(tunnel_acl)
 
-    def shortest_path(self, dest_dp, src_dp=None):
-        """Return shortest path to a DP, as a list of DPs."""
-        if src_dp is None:
-            src_dp = self.name
-        if self.stack_graph:
-            try:
-                return sorted(networkx.all_shortest_paths(self.stack_graph, src_dp, dest_dp))[0]
-            except (networkx.exception.NetworkXNoPath, networkx.exception.NodeNotFound):
-                pass
-        return []
-
-    def shortest_path_to_root(self, src_dp=None):
-        """Return shortest path to root DP, as list of DPs."""
-        return self.shortest_path(self.stack_root_name, src_dp=src_dp)
-
-    def is_stack_root(self):
-        """Return True if this DP is the root of the stack."""
-        return self.stack_root_name == self.name
-
-    def is_stack_root_candidate(self):
-        """Return True if this DP could be a root of the stack."""
-        return self.name in self.stack_roots_names
-
-    def is_stack_edge(self):
-        """Return True if this DP is a stack edge."""
-        return (not self.is_stack_root() and
-                self.stack_longest_path_to_root_len() == len(self.shortest_path_to_root()))
-
     @staticmethod
     def canonical_port_order(ports):
         return sorted(ports, key=lambda x: x.number)
-
-    def peer_stack_up_ports(self, peer_dp):
-        """Return list of stack ports that are up towards a peer."""
-        return self.canonical_port_order([
-            port for port in self.stack_ports if port.running() and (
-                port.stack['dp'].name == peer_dp)])
-
-    def shortest_path_port(self, dest_dp):
-        """Return first port on our DP, that is the shortest path towards dest DP."""
-        shortest_path = self.shortest_path(dest_dp)
-        if len(shortest_path) > 1:
-            peer_dp = shortest_path[1]
-            peer_dp_ports = self.peer_stack_up_ports(peer_dp)
-            if peer_dp_ports:
-                return peer_dp_ports[0]
-        return None
-
-    def is_in_path(self, src_dp, dst_dp):
-        """Return True if the current DP is in the path from src_dp to dst_dp
-        Args:
-            src_dp (str): DP name
-            dst_dp (str): DP name
-        Returns:
-            bool: True if self is in the path from the src_dp to the dst_dp.
-        """
-        path = self.shortest_path(dst_dp, src_dp=src_dp)
-        return self.name in path
-
-    def peer_symmetric_up_ports(self, peer_dp):
-        """Return list of stack ports that are up towards us from a peer"""
-        # Sort adjacent ports by canonical port order
-        return self.canonical_port_order([
-            port.stack['port'] for port in self.stack_ports if port.running() and (
-                port.stack['dp'].name == peer_dp)])
-
-    def shortest_symmetric_path_port(self, adj_dp):
-        """Return port on our DP that is the first port of the adjacent DP towards us"""
-        shortest_path = self.shortest_path(self.name, src_dp=adj_dp)
-        if len(shortest_path) == 2:
-            adjacent_up_ports = self.peer_symmetric_up_ports(adj_dp)
-            if adjacent_up_ports:
-                return adjacent_up_ports[0].stack['port']
-        return None
-
-    def is_transit_stack_switch(self):
-        """
-        Return true if this is a stack switch
-            in reset_refs self.stack might not be configured yet
-        """
-        if self.stack:
-            return True
-        for port in self.ports.values():
-            if port.stack:
-                return True
-        return False
 
     def reset_refs(self, vlans=None):
         """Resets VLAN references."""
@@ -1001,7 +783,7 @@ configuration.
             vlan.reset_ports(self.ports.values())
             if (vlan.get_ports() or vlan.reserved_internal_vlan or
                     vlan.dot1x_assigned or vlan._id in router_vlans or
-                    self.is_transit_stack_switch() or self.is_stack_root()):
+                    self.stack_ports() or self.stack.is_root()):
                 self.vlans[vlan.vid] = vlan
 
     def resolve_port(self, port_name):
@@ -1066,9 +848,9 @@ configuration.
 
         def resolve_stack_dps():
             """Resolve DP references in stacking config."""
-            if self.stack_ports:
+            if self.stack_ports():
                 port_stack_dp = {}
-                for port in self.stack_ports:
+                for port in self.stack_ports():
                     stack_dp = port.stack['dp']
                     test_config_condition(stack_dp not in dp_by_name, (
                         'stack DP %s not defined' % stack_dp))
@@ -1158,7 +940,9 @@ configuration.
                     else:
                         # Create a VLAN using the first unused VLAN ID
                         # Get highest non-reserved VLAN
-                        vlan_offset = max([vlan.vid for vlan in self.vlans.values() if not vlan.reserved_internal_vlan])
+                        vlan_offset = max([
+                            vlan.vid for vlan in self.vlans.values()
+                            if not vlan.reserved_internal_vlan])
                         # Also need to account for the potential number of tunnels
                         ordered_acls = sorted(self.acls)
                         index = ordered_acls.index(acl_in) + 1
@@ -1324,11 +1108,15 @@ configuration.
                 test_config_condition(
                     len(bgp_ports) != 1, 'BGP ports must all be the same: %s' % bgp_ports)
 
-        if self.stack_ports or self.stack:
+        if not self.stack_ports():
+            # Revert back to None if there are no stack ports
+            self.stack = None
+        if self.stack:
+            # Set LLDP defaults for when stacking is configured
             self._lldp_defaults()
 
         test_config_condition(
-            not self.vlans and not self.stack_ports,
+            not self.vlans and not self.stack_ports(),
             'no VLANs referenced by interfaces in %s' % self.name)
         dp_by_name = {dp.name: dp for dp in dps}
         vlan_by_name = {vlan.name: vlan for vlan in self.vlans.values()}
@@ -1486,12 +1274,12 @@ configuration.
         all_ports_changed = False
 
         topology_changed = False
-        if self.stack_graph:
-            topology_changed = bool(self.hash_graph(self.stack_graph) != self.hash_graph(new_dp.stack_graph))
+        if self.stack:
+            topology_changed = bool(self.stack.hash() != new_dp.stack.hash())
         if topology_changed:
             # Topology changed so restart stack ports just to be safe
             stack_ports = [
-                port.number for port in new_dp.stack_ports
+                port.number for port in new_dp.stack_ports()
                 if port.number not in deleted_ports and
                 port.number not in added_ports]
             changed_ports.update(set(stack_ports))
@@ -1646,7 +1434,7 @@ configuration.
         """
         if new_dp._table_configs() != self._table_configs():
             logger.info('pipeline table config change - requires cold start')
-        elif new_dp.stack_root_name != self.stack_root_name:
+        elif new_dp.stack and self.stack and new_dp.stack.root_name != self.stack.root_name:
             logger.info('Stack root change - requires cold start')
         elif new_dp.routers != self.routers:
             logger.info('DP routers config changed - requires cold start')

--- a/faucet/faucet.py
+++ b/faucet/faucet.py
@@ -87,7 +87,6 @@ class Faucet(RyuAppBase):
         }
     _VALVE_SERVICES = {
         EventFaucetMetricUpdate: (None, 5),
-        EventFaucetMaintainStackRoot: (None, valves_manager.STACK_ROOT_STATE_UPDATE_TIME),
         EventFaucetResolveGateways: ('resolve_gateways', 2),
         EventFaucetStateExpire: ('state_expire', 5),
         EventFaucetFastStateExpire: ('fast_state_expire', 2),
@@ -117,6 +116,9 @@ class Faucet(RyuAppBase):
         self.event_sock_hrtbeat_time = int(self.get_setting('EVENT_SOCK_HEARTBEAT') or 0)
         if self.event_sock_hrtbeat_time > 0:
             self._VALVE_SERVICES[EventFaucetEventSockHeartbeat] = ('event_sock_heartbeat', self.event_sock_hrtbeat_time)
+        self.stack_root_state_update_time = int(self.get_setting('STACK_ROOT_STATE_UPDATE_TIME') or 0)
+        if self.stack_root_state_update_time:
+            self._VALVE_SERVICES[EventFaucetMaintainStackRoot] = (None, self.stack_root_state_update_time)
 
     @kill_on_exception(exc_logname)
     def _check_thread_exception(self):
@@ -211,7 +213,7 @@ class Faucet(RyuAppBase):
     @set_ev_cls(EventFaucetMaintainStackRoot, MAIN_DISPATCHER)
     @kill_on_exception(exc_logname)
     def _maintain_stack_root(self, _):
-        self.valves_manager.maintain_stack_root(time.time())
+        self.valves_manager.maintain_stack_root(time.time(), self.stack_root_state_update_time)
 
     @set_ev_cls(EventFaucetEventSockHeartbeat, MAIN_DISPATCHER)
     @kill_on_exception(exc_logname)

--- a/faucet/stack.py
+++ b/faucet/stack.py
@@ -1,0 +1,345 @@
+
+"""Configuration for a stack."""
+
+# Copyright (C) 2015 Brad Cowie, Christopher Lorier and Joe Stringer.
+# Copyright (C) 2015 Research and Education Advanced Network New Zealand Ltd.
+# Copyright (C) 2015--2019 The Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections import Counter
+import networkx
+
+from faucet.conf import Conf, test_config_condition
+
+
+class Stack(Conf):
+    """Stores state related to DP stack information, this includes the current elected root as that
+is technically a fixed allocation for this DP Stack instance."""
+
+    defaults = {
+        'priority': None,
+        # Sets the root priority value of the current DP with stacking
+        'route_learning': False,
+        # Use the stack route algorithms, will be forced true if routing is enabled
+        'down_time_multiple': 3,
+        # Number of update time intervals for a down stack node to still be considered healthy
+    }
+
+    defaults_types = {
+        'priority': int,
+        'route_learning': bool,
+        'down_time_multiple': int,
+    }
+
+    def __init__(self, _id, dp_id, name, canonical_port_order, conf):
+        """
+        Constructs a new stack object
+
+        Args:
+            _id (str): Name of the configuration key
+            dp_id (int): DP ID of the DP that holds this stack instance
+            name (str): Name of the DP that holds this stack instance
+            canonical_port_order (func): Function to order ports in a standardized way
+            conf (dict): Stack configuration
+        """
+        self.name = name
+
+        # Function to order ports in a standardized way
+        self.canonical_port_order = canonical_port_order
+
+        # Stack configuration options
+        self.priority = None
+        self.route_learning = None
+        self.down_time_multiple = None
+
+        # Ports that have stacking configured
+        self.ports = []
+
+        # Stack graph containing all the DPs & ports in the stacking topology
+        self.graph = None
+
+        # Additional stacking information
+        self.root_name = None
+        self.roots_names = None
+        self.root_flood_reflection = None
+
+        # Whether the stack node is currently healthy
+        self.dyn_healthy = False
+
+        super(Stack, self).__init__(_id, dp_id, conf)
+
+    def health_timeout(self, now, update_time):
+        """Return stack node's health_timeout, the time before a timeout is recognized"""
+        down_time = self.down_time_multiple * update_time
+        health_timeout = now - down_time
+        return health_timeout
+
+    def update_health(self, now, dp_last_live_time, update_time, down_lacp_ports, down_stack_ports):
+        """
+        Determines whether the current stack node is healthy
+
+        Args:
+            now (float):
+            dp_last_live_time (dict): Last live time value for each DP
+            update_time (int): Stack root update interval time
+            down_lacp_ports (tuple): Tuple of LACP ports that are not UP
+            down_stack_ports (tuple): Tuple of stack ports that are not UP
+        Return:
+            bool: Current stack node health state,
+            str: Reason for the current state
+        """
+        last_live_time = dp_last_live_time.get(self.name, 0)
+        health_timeout = self.health_timeout(now, update_time)
+        if last_live_time < health_timeout:
+            # Too long since DP last running
+            reason = 'last running %us ago (timeout %us)' % (last_live_time, health_timeout)
+            self.dyn_healthy = False
+        elif down_lacp_ports:
+            # Not all LAG ports are UP
+            reason = 'LACP ports %s not up' % list(down_lacp_ports)
+            self.dyn_healthy = False
+        elif down_stack_ports:
+            # Not all stack ports are UP
+            reason = 'stack ports %s not up' % list(down_stack_ports)
+            self.dyn_healthy = False
+        else:
+            # Nothing wrong with stack node
+            reason = 'running, all stack and lacp ports UP'
+            self.dyn_healthy = True
+        return self.dyn_healthy, reason
+
+    def nominate_stack_root(self, stacks):
+        """Return stack names in priority order and the chosen root"""
+        stack_priorities = sorted(stacks, key=lambda x: x.priority)
+        priority_names = tuple(stack.name for stack in stack_priorities)
+        nominated_name = priority_names[0]
+        return priority_names, nominated_name
+
+    def resolve_topology(self, dps, meta_dp_state):
+        """
+        Resolve & verify correct inter-DP stacking config
+
+        Args:
+            dps (list): List of configured DPs
+            meta_dp_state (MetaDPState): Provided if reloading when choosing a new root DP
+        """
+        stack_dps = [dp for dp in dps if dp.stack is not None]
+        stack_priority_dps = [dp for dp in stack_dps if dp.stack.priority]
+        stack_port_dps = [dp for dp in dps if dp.stack_ports()]
+
+        if not stack_priority_dps:
+            test_config_condition(stack_dps, 'stacking enabled but no root DP')
+            return
+
+        if not self.ports:
+            return
+
+        for dp in stack_priority_dps:  # pylint: disable=invalid-name
+            test_config_condition(not isinstance(dp.stack.priority, int), (
+                'stack priority must be type %s not %s' % (
+                    int, type(dp.stack.priority))))
+            test_config_condition(dp.stack.priority <= 0, (
+                'stack priority must be > 0'))
+
+        self.roots_names, self.root_name = self.nominate_stack_root(
+            [dp.stack for dp in stack_priority_dps])
+
+        if meta_dp_state:
+            # If meta_dp_state exists, then we are reloading a new instance of the stack
+            #   for a new 'dynamically' chosen root
+            if meta_dp_state.stack_root_name in self.roots_names:
+                self.root_name = meta_dp_state.stack_root_name
+
+        for dp in stack_port_dps:  # pylint: disable=invalid-name
+            for vlan in dp.vlans.values():
+                if vlan.faucet_vips:
+                    self.route_learning = True
+
+        edge_count = Counter()
+        graph = networkx.MultiGraph()
+        for dp in stack_port_dps:  # pylint: disable=invalid-name
+            graph.add_node(dp.name)
+            for port in dp.stack_ports():
+                edge_name = Stack.modify_topology(graph, dp, port)
+                edge_count[edge_name] += 1
+        for edge_name, count in edge_count.items():
+            test_config_condition(count != 2, '%s defined only in one direction' % edge_name)
+        if graph.size() and self.name in graph:
+            self.graph = graph
+            for dp in graph.nodes():  # pylint: disable=invalid-name
+                path_to_root_len = len(self.shortest_path(self.root_name, src_dp=dp))
+                test_config_condition(
+                    path_to_root_len == 0, '%s not connected to stack' % dp)
+            if self.longest_path_to_root_len() > 2:
+                self.root_flood_reflection = True
+
+    @staticmethod
+    def modify_topology(graph, dp, port, add=True):  # pylint: disable=invalid-name
+        """Add/remove an edge to the stack graph which originates from this dp and port."""
+
+        def canonical_edge(dp, port):  # pylint: disable=invalid-name
+            peer_dp = port.stack['dp']
+            peer_port = port.stack['port']
+            sort_edge_a = (
+                dp.name, port.name, dp, port)
+            sort_edge_z = (
+                peer_dp.name, peer_port.name, peer_dp, peer_port)
+            sorted_edge = sorted((sort_edge_a, sort_edge_z))
+            edge_a, edge_b = sorted_edge[0][2:], sorted_edge[1][2:]
+            return edge_a, edge_b
+
+        def make_edge_name(edge_a, edge_z):
+            edge_a_dp, edge_a_port = edge_a
+            edge_z_dp, edge_z_port = edge_z
+            return '%s:%s-%s:%s' % (
+                edge_a_dp.name, edge_a_port.name,
+                edge_z_dp.name, edge_z_port.name)
+
+        def make_edge_attr(edge_a, edge_z):
+            edge_a_dp, edge_a_port = edge_a
+            edge_z_dp, edge_z_port = edge_z
+            return {
+                'dp_a': edge_a_dp, 'port_a': edge_a_port,
+                'dp_z': edge_z_dp, 'port_z': edge_z_port}
+
+        edge = canonical_edge(dp, port)
+        edge_a, edge_z = edge
+        edge_name = make_edge_name(edge_a, edge_z)
+        edge_attr = make_edge_attr(edge_a, edge_z)
+        edge_a_dp, _ = edge_a
+        edge_z_dp, _ = edge_z
+        if add:
+            graph.add_edge(
+                edge_a_dp.name, edge_z_dp.name,
+                key=edge_name, port_map=edge_attr)
+        elif (edge_a_dp.name, edge_z_dp.name, edge_name) in graph.edges:
+            graph.remove_edge(edge_a_dp.name, edge_z_dp.name, edge_name)
+
+        return edge_name
+
+    def modify_link(self, dp, port, add=True):
+        """Update the stack topology according to the event"""
+        return Stack.modify_topology(self.graph, dp, port, add)
+
+    def hash(self):
+        """Return hash of a topology graph"""
+        return hash(tuple(sorted(self.graph.degree())))
+
+    def get_node_link_data(self):
+        """Return network stacking graph as a node link representation"""
+        return networkx.readwrite.json_graph.node_link_data(self.graph)
+
+    def add_port(self, port):
+        """Add a port to this stack"""
+        self.ports.append(port)
+
+    def any_port_up(self):
+        """Return true if any stack port is UP"""
+        for port in self.ports:
+            if port.is_stack_up():
+                return True
+        return False
+
+    def down_ports(self):
+        """Return tuple of not running stack ports"""
+        return tuple([port for port in self.ports if not port.is_stack_up()])
+
+    def canonical_up_ports(self, ports=None):
+        """Obtains list of UP stack ports in canonical order"""
+        if ports is None:
+            ports = self.ports
+        return self.canonical_port_order([port for port in ports if port.is_stack_up()])
+
+    def shortest_path(self, dest_dp, src_dp=None):
+        """Return shortest path to a DP, as a list of DPs."""
+        if src_dp is None:
+            src_dp = self.name
+        if self.graph:
+            try:
+                return sorted(networkx.all_shortest_paths(self.graph, src_dp, dest_dp))[0]
+            except (networkx.exception.NetworkXNoPath, networkx.exception.NodeNotFound):
+                pass
+        return []
+
+    def shortest_path_to_root(self, src_dp=None):
+        """Return shortest path to root DP, as list of DPs."""
+        return self.shortest_path(self.root_name, src_dp=src_dp)
+
+    def is_root(self):
+        """Return True if this DP is the root of the stack."""
+        return self.name == self.root_name
+
+    def is_root_candidate(self):
+        """Return True if this DP could be a root of the stack."""
+        return self.name in self.roots_names
+
+    def is_edge(self):
+        """Return True if this DP is a stack edge."""
+        return (not self.is_root() and
+                self.longest_path_to_root_len() == len(self.shortest_path_to_root()))
+
+    def shortest_path_port(self, dest_dp):
+        """Return first port on our DP, that is the shortest path towards dest DP."""
+        shortest_path = self.shortest_path(dest_dp)
+        if len(shortest_path) > 1:
+            peer_dp = shortest_path[1]
+            peer_dp_ports = self.peer_up_ports(peer_dp)
+            if peer_dp_ports:
+                return peer_dp_ports[0]
+        return None
+
+    def peer_up_ports(self, peer_dp):
+        """Return list of stack ports that are up towards a peer."""
+        return self.canonical_port_order([
+            port for port in self.ports if port.running() and (
+                port.stack['dp'].name == peer_dp)])
+
+    def longest_path_to_root_len(self):
+        """Return length of the longest path to root in the stack."""
+        if not self.graph or not self.root_name:
+            return None
+        len_paths_to_root = [
+            len(self.shortest_path(self.root_name, src_dp=dp))
+            for dp in self.graph.nodes()]
+        if len_paths_to_root:
+            return max(len_paths_to_root)
+        return None
+
+    def is_in_path(self, src_dp, dst_dp):
+        """Return True if the current DP is in the path from src_dp to dst_dp
+
+        Args:
+            src_dp (str): DP name
+            dst_dp (str): DP name
+        Returns:
+            bool: True if self is in the path from the src_dp to the dst_dp.
+        """
+        path = self.shortest_path(dst_dp, src_dp=src_dp)
+        return self.name in path
+
+    def peer_symmetric_up_ports(self, peer_dp):
+        """Return list of stack ports that are up towards us from a peer"""
+        # Sort adjacent ports by canonical port order
+        return self.canonical_port_order([
+            port.stack['port'] for port in self.ports if port.running() and (
+                port.stack['dp'].name == peer_dp)])
+
+    def shortest_symmetric_path_port(self, peer_dp):
+        """Return port on our DP that is the first port of the adjacent DP towards us"""
+        shortest_path = self.shortest_path(self.name, src_dp=peer_dp)
+        if len(shortest_path) == 2:
+            adjacent_up_ports = self.peer_symmetric_up_ports(peer_dp)
+            if adjacent_up_ports:
+                return adjacent_up_ports[0].stack['port']
+        return None

--- a/faucet/valve_lldp.py
+++ b/faucet/valve_lldp.py
@@ -17,6 +17,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
+from collections import defaultdict
+
+from faucet import valve_util
 from faucet import valve_of
 from faucet import valve_packet
 from faucet.valve_manager_base import ValveManagerBase
@@ -25,9 +29,16 @@ from faucet.valve_manager_base import ValveManagerBase
 class ValveLLDPManager(ValveManagerBase):
     """Manage LLDP."""
 
-    def __init__(self, vlan_table, highest_priority):
+    def __init__(self, vlan_table, highest_priority, logger,
+                 notify, inc_var, set_var, set_port_var, stack_manager):
         self.vlan_table = vlan_table
         self.highest_priority = highest_priority
+        self.logger = logger
+        self.notify = notify
+        self._set_var = set_var
+        self._inc_var = inc_var
+        self._set_port_var = set_port_var
+        self.stack_manager = stack_manager
 
     def add_port(self, port):
         ofmsgs = []
@@ -41,3 +52,117 @@ class ValveLLDPManager(ValveManagerBase):
                 priority=self.highest_priority,
                 max_len=128))
         return ofmsgs
+
+    def _verify_lldp(self, port, now, valve, other_valves,
+                     remote_dp_id, remote_dp_name,
+                     remote_port_id, remote_port_state):
+        """
+        Verify correct LLDP cabling, then update port to next state
+
+        Args:
+            port (Port): Port that received the LLDP
+            now (float): Current time
+            other_valves (list): Other valves in the topology
+            remote_dp_id (int): Received LLDP remote DP ID
+            remote_dp_name (str): Received LLDP remote DP name
+            remote_port_id (int): Recevied LLDP port ID
+            remote_port_state (int): Received LLDP port state
+        Returns:
+            dict: Ofmsgs by valve
+        """
+        if not port.stack:
+            return {}
+        remote_dp = port.stack['dp']
+        remote_port = port.stack['port']
+        stack_correct = True
+        self._inc_var('stack_probes_received')
+        if (remote_dp_id != remote_dp.dp_id or
+                remote_dp_name != remote_dp.name or
+                remote_port_id != remote_port.number):
+            self.logger.error(
+                'Stack %s cabling incorrect, expected %s:%s:%u, actual %s:%s:%u' % (
+                    port,
+                    valve_util.dpid_log(remote_dp.dp_id),
+                    remote_dp.name,
+                    remote_port.number,
+                    valve_util.dpid_log(remote_dp_id),
+                    remote_dp_name,
+                    remote_port_id))
+            stack_correct = False
+            self._inc_var('stack_cabling_errors')
+        port.dyn_stack_probe_info = {
+            'last_seen_lldp_time': now,
+            'stack_correct': stack_correct,
+            'remote_dp_id': remote_dp_id,
+            'remote_dp_name': remote_dp_name,
+            'remote_port_id': remote_port_id,
+            'remote_port_state': remote_port_state
+        }
+        return self.update_stack_link_state([port], now, valve, other_valves)
+
+    def update_stack_link_state(self, ports, now, valve, other_valves):
+        """
+        Update the stack link states of the set of provided stack ports
+
+        Args:
+            ports (list): List of stack ports to update the state of
+            now (float): Current time
+            valve (Valve): Valve that owns this LLDPManager instance
+            other_valves (list): List of other valves
+        Returns:
+            dict: ofmsgs by valve
+        """
+        stack_changes = 0
+        ofmsgs_by_valve = defaultdict(list)
+        stacked_valves = set()
+        if self.stack_manager:
+            stacked_valves = {valve}.union(self.stack_manager.stacked_valves(other_valves))
+        for port in ports:
+            before_state = port.stack_state()
+            after_state, reason = port.stack_port_update(now)
+            if before_state != after_state:
+                self._set_port_var('port_stack_state', after_state, port)
+                self.notify({'STACK_STATE': {
+                    'port': port.number,
+                    'state': after_state}})
+                stack_changes += 1
+                self.logger.info('Stack %s state %s (previous state %s): %s' % (
+                    port, port.stack_state_name(after_state),
+                    port.stack_state_name(before_state), reason))
+                port_up = False
+                if port.is_stack_up():
+                    port_up = True
+                elif port.is_stack_init() and port.stack['port'].is_stack_up():
+                    port_up = True
+                for stack_valve in stacked_valves:
+                    stack_valve.stack_manager.update_stack_topo(port_up, valve.dp, port)
+        if stack_changes:
+            self.logger.info('%u stack ports changed state' % stack_changes)
+            notify_dps = {}
+            for stack_valve in stacked_valves:
+                if not stack_valve.dp.dyn_running:
+                    continue
+                ofmsgs_by_valve[stack_valve].extend(
+                    stack_valve.add_vlans(stack_valve.dp.vlans.values()))
+                for port in stack_valve.dp.stack_ports():
+                    ofmsgs_by_valve[stack_valve].extend(
+                        stack_valve.switch_manager.del_port(port))
+                ofmsgs_by_valve[stack_valve].extend(
+                    stack_valve.stack_manager.add_tunnel_acls())
+                path_port = stack_valve.stack_manager.default_port_towards(
+                    stack_valve.dp.stack.root_name)
+                path_port_number = path_port.number if path_port else 0.0
+                self._set_var(
+                    'dp_root_hop_port', path_port_number, labels=stack_valve.dp.base_prom_labels())
+                notify_dps.setdefault(stack_valve.dp.name, {})['root_hop_port'] = path_port_number
+            # Find the first valve with a valid stack and trigger notification.
+            for stack_valve in stacked_valves:
+                if stack_valve.dp.stack.graph:
+                    self.notify(
+                        {'STACK_TOPO_CHANGE': {
+                            'stack_root': stack_valve.dp.stack.root_name,
+                            'graph': stack_valve.dp.stack.get_node_link_data(),
+                            'dps': notify_dps
+                            }})
+                    break
+        return ofmsgs_by_valve

--- a/faucet/valve_stack.py
+++ b/faucet/valve_stack.py
@@ -1,0 +1,361 @@
+"""Manage higher level stack functions"""
+
+
+from collections import defaultdict
+
+from faucet.valve_manager_base import ValveManagerBase
+
+
+class ValveStackManager(ValveManagerBase):
+    """Implement stack manager, this handles the more higher-order stack functions.
+This includes port nominations and flood directionality."""
+
+    def __init__(self, logger, dp, stack, tunnel_acls, acl_manager, **kwargs):
+        """
+        Initialize variables and set up peer distances
+
+        Args:
+            stack (Stack): Stack object of the DP on the Valve being managed
+        """
+        # Logger for logging
+        self.logger = logger
+        # DP instance for stack healthyness
+        self.dp = dp
+        # Stack instance
+        self.stack = stack
+
+        # Used the manage the tunnel ACLs which requires stack knowledge
+        self.tunnel_acls = tunnel_acls
+        self.acl_manager = acl_manager
+
+        # Ports that are the shortest distance to the root
+        self.towards_root_ports = None
+        # Ports on an adjacent DP that is the chosen shortest path to the root
+        self.chosen_towards_ports = None
+        # Single port on the adjacent shortest path DP
+        self.chosen_towards_port = None
+
+        # All ports that are not the shortest distance to the root
+        self.away_ports = None
+        # Ports whose peer DPs have a shorter path to root
+        self.inactive_away_ports = None
+        # Redundant ports for each adjacent DP
+        self.pruned_away_ports = None
+
+        self.reset_peer_distances()
+
+    @staticmethod
+    def stacked_valves(valves):
+        """Return set of valves that have stacking enabled"""
+        return {valve for valve in valves if valve.dp.stack and valve.dp.stack.root_name}
+
+    def reset_peer_distances(self):
+        """Recalculates the towards and away ports for this node"""
+        self.towards_root_ports = set()
+        self.chosen_towards_ports = set()
+        self.chosen_towards_port = None
+
+        self.away_ports = set()
+        self.inactive_away_ports = set()
+        self.pruned_away_ports = set()
+
+        all_peer_ports = set(self.stack.canonical_up_ports())
+        if self.stack.is_root():
+            self.away_ports = all_peer_ports
+        else:
+            port_peer_distances = {
+                port: len(port.stack['dp'].stack.shortest_path_to_root())
+                for port in all_peer_ports}
+            shortest_peer_distance = None
+            for port, port_peer_distance in port_peer_distances.items():
+                if shortest_peer_distance is None:
+                    shortest_peer_distance = port_peer_distance
+                    continue
+                shortest_peer_distance = min(shortest_peer_distance, port_peer_distance)
+            self.towards_root_ports = {
+                port for port, port_peer_distance in port_peer_distances.items()
+                if port_peer_distance == shortest_peer_distance}
+
+            self.away_ports = all_peer_ports - self.towards_root_ports
+
+            if self.towards_root_ports:
+                # Generate a shortest path to calculate the chosen connection to root
+                shortest_path = self.stack.shortest_path_to_root()
+                # Choose the port that is connected to peer DP
+                if shortest_path and len(shortest_path) > 1:
+                    first_peer_dp = shortest_path[1]
+                else:
+                    first_peer_port = self.stack.canonical_port_order(
+                        self.towards_root_ports)[0]
+                    first_peer_dp = first_peer_port.stack['dp'].name
+                # The chosen towards ports are the ports through the chosen peer DP
+                self.chosen_towards_ports = {
+                    port for port in self.towards_root_ports
+                    if port.stack['dp'].name == first_peer_dp}  # pytype: disable=attribute-error
+
+            if self.chosen_towards_ports:
+                self.chosen_towards_port = self.stack.canonical_up_ports(
+                    self.chosen_towards_ports)[0]
+
+            # Away ports are all the remaining (non-towards) ports
+            self.away_ports = all_peer_ports - self.towards_root_ports
+
+        if self.away_ports:
+            # Get inactive away ports, ports whose peers have a better path to root
+            self.inactive_away_ports = {
+                port for port in self.away_ports
+                if not self.stack.is_in_path(port.stack['dp'].name, self.stack.root_name)}
+
+            # Get pruned away ports, redundant ports for each adjacent DP
+            ports_by_dp = defaultdict(list)
+            for port in self.away_ports:
+                ports_by_dp[port.stack['dp']].append(port)
+            for ports in ports_by_dp.values():
+                remote_away_ports = self.stack.canonical_up_ports(
+                    [port.stack['port'] for port in ports])
+                self.pruned_away_ports.update([
+                    port.stack['port'] for port in remote_away_ports
+                    if port != remote_away_ports[0]])
+
+        return self.chosen_towards_ports
+
+    def update_stack_topo(self, event, dp, port):
+        """
+        Update the stack topo according to the event.
+
+        Args:
+            event (bool): True if the port is UP
+            dp (DP): DP object
+            port (Port): The port being brought UP/DOWN
+        """
+        self.stack.modify_link(dp, port, event)
+        towards_ports = self.reset_peer_distances()
+        if towards_ports:
+            self.logger.info('shortest path to root is via %s' % towards_ports)
+        else:
+            self.logger.info('no path available to root')
+
+    def default_port_towards(self, dp_name):
+        """
+        Default shortest path towards the provided destination, via direct shortest path
+
+        Args:
+            dp_name (str): Destination DP
+        Returns:
+           Port: port from current node that is shortest directly towards destination
+        """
+        return self.stack.shortest_path_port(dp_name)
+
+    def relative_port_towards(self, dp_name):
+        """
+        Returns the shortest path towards provided destination, via either the root or away paths
+
+        Args:
+            dp_name (str): Destination DP
+        Returns:
+            Port: port from current node that is towards/away the destination DP depending on
+                relative position of the current node
+        """
+        if not self.stack.shortest_path_to_root():
+            # No known path from current node to root, use default
+            return self.default_port_towards(dp_name)
+        if self.stack.name == dp_name:
+            # Current node is the destination node, use default
+            return self.default_port_towards(dp_name)
+        path_to_root = self.stack.shortest_path_to_root(dp_name)
+        if path_to_root and self.stack.name in path_to_root:
+            # Current node is a transit node between root & destination, direct path to destination
+            away_dp = path_to_root[path_to_root.index(self.stack.name) - 1]
+            for port in self.away_ports:
+                if port.stack['dp'].name == away_dp and not self.is_pruned_port(port):
+                    return port
+            return None
+        # Otherwise, head towards the root, path to destination via root
+        return self.chosen_towards_port
+
+    def edge_learn_port_towards(self, pkt_meta, edge_dp):
+        """
+        Returns the port towards the edge DP
+
+        Args:
+            pkt_meta (PacketMeta): Packet on the edge DP
+            edge_dp (DP): Edge DP that received the packet
+        Returns:
+            Port: Port towards the edge DP via some stack chosen metric
+        """
+        if pkt_meta.vlan.edge_learn_stack_root:
+            return self.relative_port_towards(edge_dp.name)
+        return self.default_port_towards(edge_dp.name)
+
+    def tunnel_outport(self, src_dp, dst_dp, dst_port):
+        """
+        Returns the output port for the current stack node for the tunnel path
+
+        Args:
+            src_dp (str): Source DP name of the tunnel
+            dst_dp (str): Destination DP name of the tunnel
+            dst_port (int): Destination port of the tunnel
+        Returns:
+            int: Output port number for the current node of the tunnel
+        """
+        if not self.stack.is_in_path(src_dp, dst_dp):
+            # No known path from the source to destination DP, so no port to output
+            return None
+        out_port = self.default_port_towards(dst_dp)
+        if self.stack.name == dst_dp:
+            # Current stack node is the destination, so output to the tunnel destination port
+            out_port = dst_port
+        elif out_port:
+            out_port = out_port.number
+        return out_port
+
+    def update_health(self, now, last_live_times, update_time):
+        """
+        Returns whether the current stack node is healthy, a healthy stack node
+            is one that attempted connected recently, or was known to be running
+            recently, has all LAGs UP and any stack port UP
+
+        Args:
+            now (float): Current time
+            last_live_times (dict): Last live time value for each DP
+            update_time (int): Stack root update interval time
+        Returns:
+            bool: True if current stack node is healthy
+        """
+        prev_health = self.stack.dyn_healthy
+        new_health, reason = self.stack.update_health(
+            now, last_live_times, update_time, self.dp.lacp_down_ports(),
+            self.stack.down_ports())
+        if prev_health != new_health:
+            health = 'HEALTHY' if new_health else 'UNHEALTHY'
+            self.logger.info('Stack node %s %s (%s)' % (self.stack.name, health, reason))
+        return new_health
+
+    def consistent_roots(self, expected_root_name, valve, other_valves):
+        """Returns true if all the stack nodes have the root configured correctly"""
+        stacked_valves = {valve}.union(self.stacked_valves(other_valves))
+        for stack_valve in stacked_valves:
+            if stack_valve.dp.stack.root_name != expected_root_name:
+                return False
+        return True
+
+    def nominate_stack_root(self, root_valve, other_valves, now, last_live_times, update_time):
+        """
+        Nominate a new stack root
+
+        Args:
+            root_valve (Valve): Previous/current root Valve object
+            other_valves (list): List of other valves (not including previous root)
+            now (float): Current time
+            last_live_times (dict): Last live time value for each DP
+            update_time (int): Stack root update interval time
+        Returns:
+            str: Name of the new elected stack root
+        """
+        stack_valves = {valve for valve in other_valves if valve.dp.stack}
+        if root_valve:
+            stack_valves = {root_valve}.union(stack_valves)
+
+        # Create lists of healthy and unhealthy root candidates
+        healthy_valves = []
+        unhealthy_valves = []
+        for valve in stack_valves:
+            if valve.dp.stack.is_root_candidate():
+                healthy = valve.stack_manager.update_health(now, last_live_times, update_time)
+                if healthy:
+                    healthy_valves.append(valve)
+                else:
+                    unhealthy_valves.append(valve)
+
+        if not healthy_valves and not unhealthy_valves:
+            # No root candidates/stack valves, so no nomination
+            return None
+
+        # Choose a candidate valve to be the root
+        if healthy_valves:
+            # Healthy valves exist, so pick a healthy valve as root
+            new_root_name = None
+            if root_valve:
+                new_root_name = root_valve.dp.name
+            if root_valve not in healthy_valves:
+                # Need to pick a new healthy root if current root not healthy
+                stacks = [valve.dp.stack for valve in healthy_valves]
+                _, new_root_name = stacks[0].nominate_stack_root(stacks)
+        else:
+            # No healthy stack roots, so forced to choose a bad root
+            stacks = [valve.dp.stack for valve in unhealthy_valves]
+            _, new_root_name = stacks[0].nominate_stack_root(stacks)
+
+        return new_root_name
+
+    def stack_ports(self):
+        """Yield the stack ports of this stack node"""
+        for port in self.stack.ports:
+            yield port
+
+    def is_stack_port(self, port):
+        """Return whether the port is a stack port"""
+        return bool(port.stack)
+
+    def is_away(self, port):
+        """Return whether the port is an away port for the node"""
+        return port in self.away_ports
+
+    def is_towards_root(self, port):
+        """Return whether the port is a port towards the root for the node"""
+        return port in self.towards_root_ports
+
+    def is_selected_towards_root_port(self, port):
+        """Return true if the port is the chosen towards root port"""
+        return port == self.chosen_towards_port
+
+    def is_pruned_port(self, port):
+        """Return true if the port is to be pruned"""
+        if self.is_towards_root(port):
+            return not self.is_selected_towards_root_port(port)
+        if self.is_away(port):
+            if self.pruned_away_ports:
+                return port in self.pruned_away_ports
+            return False
+        return True
+
+    def adjacent_stack_ports(self, peer_dp):
+        """Return list of ports that connect to an adjacent DP"""
+        return [port for port in self.stack.ports if port.stack['dp'] == peer_dp]
+
+    def acl_update_tunnel(self, acl):
+        """Return ofmsgs for all tunnels in an ACL with a tunnel rule"""
+        ofmsgs = []
+        source_vids = defaultdict(list)
+        for _id, info in acl.tunnel_info.items():
+            dst_dp, dst_port = info['dst_dp'], info['dst_port']
+            # Update the tunnel rules for each tunnel action specified
+            updated_sources = []
+            for i, source in enumerate(acl.tunnel_sources):
+                src_dp = source['dp']
+                out_port = self.tunnel_outport(
+                    src_dp, dst_dp, dst_port)
+                if out_port:
+                    updated = acl.update_source_tunnel_rules(
+                        self.stack.name, i, _id, out_port)
+                    if updated:
+                        if self.stack.name == src_dp:
+                            source_vids[i].append(_id)
+                        else:
+                            updated_sources.append(i)
+            for source_id in updated_sources:
+                ofmsgs.extend(self.acl_manager.build_tunnel_rules_ofmsgs(
+                    source_id, _id, acl))
+        for source_id, vids in source_vids.items():
+            for vid in vids:
+                ofmsgs.extend(self.acl_manager.build_tunnel_acl_rule_ofmsgs(
+                    source_id, vid, acl))
+        return ofmsgs
+
+    def add_tunnel_acls(self):
+        """Returns ofmsgs installing the tunnel path rules"""
+        ofmsgs = []
+        if self.tunnel_acls:
+            for acl in self.tunnel_acls:
+                ofmsgs.extend(self.acl_update_tunnel(acl))
+        return ofmsgs

--- a/faucet/valve_switch.py
+++ b/faucet/valve_switch.py
@@ -23,7 +23,7 @@ from faucet.valve_switch_stack import (
     ValveSwitchStackManagerNoReflection, ValveSwitchStackManagerReflection)
 
 
-def valve_switch_factory(logger, dp, pipeline, acl_manager):  # pylint: disable=invalid-name
+def valve_switch_factory(logger, dp, pipeline, acl_manager, stack_manager):  # pylint: disable=invalid-name
     """Return switch flood/learning manager based on datapath configuration.
 
         Args:
@@ -66,26 +66,15 @@ def valve_switch_factory(logger, dp, pipeline, acl_manager):  # pylint: disable=
         'faucet_dp_mac': dp.faucet_dp_mac,
     }
 
-    if dp.stack_graph:
+    if dp.stack:
         switch_class = ValveSwitchStackManagerNoReflection
-        if dp.stack_root_flood_reflection:
+        if dp.stack.root_flood_reflection:
             switch_class = ValveSwitchStackManagerReflection
             logger.info('Using stacking root flood reflection')
         else:
             logger.info('Not using stacking root flood reflection')
         switch_args.update({
-            'stack_ports': dp.stack_ports,
-            'dp_shortest_path_to_root': dp.shortest_path_to_root,
-            'shortest_path': dp.shortest_path,
-            'shortest_path_port': dp.shortest_path_port,
-            'is_stack_root': dp.is_stack_root,
-            'is_stack_root_candidate': dp.is_stack_root_candidate,
-            'is_stack_edge': dp.is_stack_edge,
-            'dp_name': dp.name,
-            'graph': dp.stack_graph,
-            'tunnel_acls': dp.tunnel_acls,
-            'stack_route_learning': dp.stack_route_learning,
-            'acl_manager': acl_manager,
+            'stack_manager': stack_manager,
         })
         return switch_class(**switch_args)
 

--- a/faucet/valve_switch_standalone.py
+++ b/faucet/valve_switch_standalone.py
@@ -425,11 +425,6 @@ class ValveSwitchManager(ValveManagerBase):  # pylint: disable=too-many-public-m
         return ofmsgs
 
     @staticmethod
-    def update_stack_topo(event, dp, port):  # pylint: disable=unused-argument,invalid-name
-        """Update the stack topology. It has nothing to do for non-stacking DPs."""
-        return
-
-    @staticmethod
     def edge_learn_port(_other_valves, pkt_meta):
         """Possibly learn a host on a port.
 

--- a/faucet/valve_util.py
+++ b/faucet/valve_util.py
@@ -72,6 +72,7 @@ DEFAULTS = {
         ':',
         _PREFIX,
         '/etc/ryu/faucet/faucet.yaml')),
+    'FAUCET_STACK_ROOT_STATE_UPDATE_TIME': 10,
     'FAUCET_CONFIG_STAT_RELOAD': False,
     'FAUCET_CONFIG_AUTO_REVERT': False,
     'FAUCET_LOG_LEVEL': 'INFO',

--- a/tests/unit/faucet/test_valve_stack.py
+++ b/tests/unit/faucet/test_valve_stack.py
@@ -36,8 +36,6 @@ from clib.fakeoftable import CONTROLLER_PORT
 from clib.valve_test_lib import (
     BASE_DP1_CONFIG, CONFIG, STACK_CONFIG, STACK_LOOP_CONFIG, ValveTestBases)
 
-import networkx
-
 
 class ValveEdgeVLANTestCase(ValveTestBases.ValveTestNetwork):
 
@@ -127,14 +125,14 @@ dps:
         self.update_config(self.CONFIG2, reload_type=None)
         self.activate_stack()
         s1 = self.valves_manager.valves[1].dp
-        self.assertTrue(s1.is_stack_root())
-        self.assertFalse(s1.is_stack_edge())
+        self.assertTrue(s1.stack.is_root())
+        self.assertFalse(s1.stack.is_edge())
         s2 = self.valves_manager.valves[2].dp
-        self.assertFalse(s2.is_stack_root())
-        self.assertFalse(s2.is_stack_edge())
+        self.assertFalse(s2.stack.is_root())
+        self.assertFalse(s2.stack.is_edge())
         s3 = self.valves_manager.valves[3].dp
-        self.assertFalse(s3.is_stack_root())
-        self.assertTrue(s3.is_stack_edge())
+        self.assertFalse(s3.stack.is_root())
+        self.assertTrue(s3.stack.is_edge())
         match = {'in_port': 2, 'vlan_vid': 0, 'eth_src': self.P2_V100_MAC}
         self.network.tables[3].is_output(match, port=3)
         match = {'in_port': 3, 'vlan_vid': 0, 'eth_src': self.P2_V100_MAC}
@@ -605,7 +603,7 @@ class ValveStackChainTest(ValveTestBases.ValveTestNetwork):
         table = self.network.tables[self.DP_ID]
         return table.is_output(ucast_match, port=out_port, trace=trace)
 
-    def _learning_from_bcast(self, in_port):
+    def _learning_from_bcast(self, in_port, trace=False):
         ucast_match = {
             'in_port': in_port,
             'eth_src': self.P1_V100_MAC,
@@ -614,7 +612,9 @@ class ValveStackChainTest(ValveTestBases.ValveTestNetwork):
             'eth_type': 0x800,
         }
         table = self.network.tables[self.DP_ID]
-        return table.is_output(ucast_match, port=CONTROLLER_PORT)
+        if trace:
+            self.network.print_table(2)
+        return table.is_output(ucast_match, port=CONTROLLER_PORT, trace=trace)
 
     def validate_edge_learn_ports(self):
         """Validate the switch behavior before learning, and then learn hosts"""
@@ -912,13 +912,16 @@ dps:
 
     def test_nonstack_dp_port(self):
         """Test that finding a path from a stack swithc to a non-stack switch cannot happen"""
-        self.assertEqual(None, self.valves_manager.valves[0x3].dp.shortest_path_port('s1'))
+        self.assertIsNone(None, self.valves_manager.valves[0x3].dp.stack)
+        self.assertEqual(None, self.valves_manager.valves[0x1].dp.stack.shortest_path_port('s3'))
 
 
 class ValveStackRedundancyTestCase(ValveTestBases.ValveTestNetwork):
     """Valve test for root selection."""
 
     CONFIG = STACK_CONFIG
+    STACK_ROOT_STATE_UPDATE_TIME = 10
+    STACK_ROOT_DOWN_TIME = STACK_ROOT_STATE_UPDATE_TIME * 3
 
     def setUp(self):
         self.setup_valves(self.CONFIG)
@@ -933,7 +936,7 @@ class ValveStackRedundancyTestCase(ValveTestBases.ValveTestNetwork):
     def set_stack_all_ports_status(self, dp_name, status):
         """Set all stack ports to status on dp"""
         dp = self.dp_by_name(dp_name)
-        for port in dp.stack_ports:
+        for port in dp.stack_ports():
             port.dyn_stack_current_state = status
 
     def test_redundancy(self):
@@ -947,52 +950,58 @@ class ValveStackRedundancyTestCase(ValveTestBases.ValveTestNetwork):
             self.set_stack_all_ports_status(dp.name, STACK_STATE_INIT)
         for valve in self.valves_manager.valves.values():
             self.assertFalse(valve.dp.dyn_running)
-            self.assertEqual('s1', valve.dp.stack_root_name)
-            root_hop_port = valve.dp.shortest_path_port('s1')
+            self.assertEqual('s1', valve.dp.stack.root_name)
+            root_hop_port = valve.dp.stack.shortest_path_port('s1')
             root_hop_port = root_hop_port.number if root_hop_port else 0
             self.assertEqual(root_hop_port, self.get_prom('dp_root_hop_port', dp_id=valve.dp.dp_id))
         # From a cold start - we pick the s1 as root.
         self.assertEqual(None, self.valves_manager.meta_dp_state.stack_root_name)
-        self.assertFalse(self.valves_manager.maintain_stack_root(now))
+        self.assertFalse(
+            self.valves_manager.maintain_stack_root(now, self.STACK_ROOT_STATE_UPDATE_TIME))
         self.assertEqual('s1', self.valves_manager.meta_dp_state.stack_root_name)
         self.assertEqual(1, self.get_prom('faucet_stack_root_dpid', bare=True))
         self.assertTrue(self.get_prom('is_dp_stack_root', dp_id=1))
         self.assertFalse(self.get_prom('is_dp_stack_root', dp_id=2))
-        now += (valves_manager.STACK_ROOT_DOWN_TIME * 2)
+        now += (self.STACK_ROOT_DOWN_TIME * 2)
         # Time passes, still no change, s1 is still the root.
-        self.assertFalse(self.valves_manager.maintain_stack_root(now))
+        self.assertFalse(
+            self.valves_manager.maintain_stack_root(now, self.STACK_ROOT_STATE_UPDATE_TIME))
         self.assertEqual('s1', self.valves_manager.meta_dp_state.stack_root_name)
         self.assertEqual(1, self.get_prom('faucet_stack_root_dpid', bare=True))
         self.assertTrue(self.get_prom('is_dp_stack_root', dp_id=1))
         self.assertFalse(self.get_prom('is_dp_stack_root', dp_id=2))
         # s2 has come up, but has all stack ports down and but s1 is still down.
         self.valves_manager.meta_dp_state.dp_last_live_time['s2'] = now
-        now += (valves_manager.STACK_ROOT_STATE_UPDATE_TIME * 2)
+        now += (self.STACK_ROOT_STATE_UPDATE_TIME * 2)
         # No change because s2 still isn't healthy.
-        self.assertFalse(self.valves_manager.maintain_stack_root(now))
+        self.assertFalse(
+            self.valves_manager.maintain_stack_root(now, self.STACK_ROOT_STATE_UPDATE_TIME))
         # We expect s2 to be the new root because now it has stack links up.
         self.set_stack_all_ports_status('s2', STACK_STATE_UP)
-        now += (valves_manager.STACK_ROOT_STATE_UPDATE_TIME * 2)
+        now += (self.STACK_ROOT_STATE_UPDATE_TIME * 2)
         self.valves_manager.meta_dp_state.dp_last_live_time['s2'] = now
-        self.assertTrue(self.valves_manager.maintain_stack_root(now))
+        self.assertTrue(
+            self.valves_manager.maintain_stack_root(now, self.STACK_ROOT_STATE_UPDATE_TIME))
         self.assertEqual('s2', self.valves_manager.meta_dp_state.stack_root_name)
         self.assertEqual(2, self.get_prom('faucet_stack_root_dpid', bare=True))
         self.assertFalse(self.get_prom('is_dp_stack_root', dp_id=1))
         self.assertTrue(self.get_prom('is_dp_stack_root', dp_id=2))
         # More time passes, s1 is still down, s2 is still the root.
-        now += (valves_manager.STACK_ROOT_DOWN_TIME * 2)
+        now += (self.STACK_ROOT_DOWN_TIME * 2)
         # s2 recently said something, s2 still the root.
         self.valves_manager.meta_dp_state.dp_last_live_time['s2'] = now - 1
         self.set_stack_all_ports_status('s2', STACK_STATE_UP)
-        self.assertFalse(self.valves_manager.maintain_stack_root(now))
+        self.assertFalse(
+            self.valves_manager.maintain_stack_root(now, self.STACK_ROOT_STATE_UPDATE_TIME))
         self.assertEqual('s2', self.valves_manager.meta_dp_state.stack_root_name)
         self.assertEqual(2, self.get_prom('faucet_stack_root_dpid', bare=True))
         self.assertFalse(self.get_prom('is_dp_stack_root', dp_id=1))
         self.assertTrue(self.get_prom('is_dp_stack_root', dp_id=2))
         # now s1 came up too, but we stay on s2 because it's healthy.
         self.valves_manager.meta_dp_state.dp_last_live_time['s1'] = now + 1
-        now += valves_manager.STACK_ROOT_STATE_UPDATE_TIME
-        self.assertFalse(self.valves_manager.maintain_stack_root(now))
+        now += self.STACK_ROOT_STATE_UPDATE_TIME
+        self.assertFalse(
+            self.valves_manager.maintain_stack_root(now, self.STACK_ROOT_STATE_UPDATE_TIME))
         self.assertEqual('s2', self.valves_manager.meta_dp_state.stack_root_name)
         self.assertEqual(2, self.get_prom('faucet_stack_root_dpid', bare=True))
         self.assertFalse(self.get_prom('is_dp_stack_root', dp_id=1))
@@ -1042,17 +1051,17 @@ class ValveRootStackTestCase(ValveTestBases.ValveTestNetwork):
         """
         self.update_config(SIMPLE_DP_CONFIG, reload_expected=True)
         dp = self.valves_manager.valves[self.DP_ID].dp
-        self.assertFalse(dp.is_stack_root())
+        self.assertFalse(dp.stack)
         self.update_config(CONFIG, reload_expected=True)
         self.set_stack_port_up(5)
         dp = self.valves_manager.valves[self.DP_ID].dp
-        self.assertTrue(dp.is_stack_root())
+        self.assertTrue(dp.stack.is_root())
 
     def test_topo(self):
         """Test DP is assigned appropriate edge/root states"""
         dp = self.valves_manager.valves[self.DP_ID].dp
-        self.assertTrue(dp.is_stack_root())
-        self.assertFalse(dp.is_stack_edge())
+        self.assertTrue(dp.stack.is_root())
+        self.assertFalse(dp.stack.is_edge())
 
 
 class ValveEdgeStackTestCase(ValveTestBases.ValveTestNetwork):
@@ -1102,8 +1111,8 @@ class ValveEdgeStackTestCase(ValveTestBases.ValveTestNetwork):
     def test_topo(self):
         """Test DP is assigned appropriate edge/root states"""
         dp = self.valves_manager.valves[self.DP_ID].dp
-        self.assertFalse(dp.is_stack_root())
-        self.assertTrue(dp.is_stack_edge())
+        self.assertFalse(dp.stack.is_root())
+        self.assertTrue(dp.stack.is_edge())
 
 
 class ValveStackProbeTestCase(ValveTestBases.ValveTestNetwork):
@@ -1182,7 +1191,7 @@ class ValveStackGraphUpdateTestCase(ValveTestBases.ValveTestNetwork):
                 valve = self.valves_manager.valves[dpid]
                 if not valve.dp.stack:
                     continue
-                graph = valve.dp.stack_graph
+                graph = valve.dp.stack.graph
                 self.assertEqual(num_edges, len(graph.edges()))
                 if test_func and edge:
                     test_func(edge in graph.edges(keys=True))
@@ -1203,6 +1212,20 @@ class ValveStackGraphUpdateTestCase(ValveTestBases.ValveTestNetwork):
 
 class ValveStackGraphBreakTestCase(ValveStackLoopTest):
     """Valve test for updating the stack graph."""
+
+    def validate_flooding(self, rerouted=False, portup=True):
+        """Validate the flooding state of the stack"""
+        vid = self.V100
+        self.validate_flood(1, vid, 1, False, 'flooded out input stack port')
+        self.validate_flood(1, vid, 2, portup, 'not flooded to stack root')
+        self.validate_flood(1, vid, 3, portup, 'not flooded to external host')
+        self.validate_flood(2, vid, 1, rerouted, 'flooded out other stack port')
+        self.validate_flood(2, vid, 2, False, 'flooded out input stack port')
+        self.validate_flood(2, vid, 3, True, 'not flooded to external host')
+        vid = 0
+        self.validate_flood(3, vid, 1, rerouted, 'flooded out inactive port')
+        self.validate_flood(3, vid, 2, True, 'not flooded to stack root')
+        self.validate_flood(3, vid, 3, False, 'flooded out hairpin')
 
     def test_update_stack_graph(self):
         """Test stack graph port UP and DOWN updates"""
@@ -1521,9 +1544,16 @@ vlans:
         self.setup_valves(self.CONFIG)
         self.trigger_stack_ports()
 
-    def switch_manager_flood_ports(self, switch_manager):
+    def stack_manager_flood_ports(self, stack_manager):
         """Return list of port numbers that will be flooded to"""
-        return [port.number for port in switch_manager._stack_flood_ports()]  # pylint: disable=protected-access
+        stack_manager.reset_peer_distances()
+        ports = list()
+        if stack_manager.stack.is_root():
+            ports = (stack_manager.away_ports - stack_manager.inactive_away_ports -
+                     stack_manager.pruned_away_ports)
+        else:
+            ports = [stack_manager.chosen_towards_port]
+        return sorted([port.number for port in ports])
 
     def route_manager_ofmsgs(self, route_manager, vlan):
         """Return ofmsgs for route stack link flooding"""
@@ -1538,7 +1568,7 @@ vlans:
         """Test intervlan flooding goes towards the root"""
         output_ports = [3]
         valve = self.valves_manager.valves[1]
-        ports = self.switch_manager_flood_ports(valve.switch_manager)
+        ports = self.stack_manager_flood_ports(valve.stack_manager)
         self.assertEqual(output_ports, ports, 'InterVLAN flooding does not match expected')
         route_manager = valve._route_manager_by_ipv.get(4, None)
         vlan = valve.dp.vlans[100]
@@ -1549,7 +1579,7 @@ vlans:
         """Test intervlan flooding goes away from the root"""
         output_ports = [3, 4]
         valve = self.valves_manager.valves[2]
-        ports = self.switch_manager_flood_ports(valve.switch_manager)
+        ports = self.stack_manager_flood_ports(valve.stack_manager)
         self.assertEqual(output_ports, ports, 'InterVLAN flooding does not match expected')
         route_manager = valve._route_manager_by_ipv.get(4, None)
         vlan = valve.dp.vlans[100]
@@ -1560,7 +1590,7 @@ vlans:
         """Test intervlan flooding only goes towards the root (s4 will get the reflection)"""
         output_ports = [3]
         valve = self.valves_manager.valves[3]
-        ports = self.switch_manager_flood_ports(valve.switch_manager)
+        ports = self.stack_manager_flood_ports(valve.stack_manager)
         self.assertEqual(output_ports, ports, 'InterVLAN flooding does not match expected')
         route_manager = valve._route_manager_by_ipv.get(4, None)
         vlan = valve.dp.vlans[100]
@@ -1571,7 +1601,7 @@ vlans:
         """Test intervlan flooding goes towards the root (through s3)"""
         output_ports = [3]
         valve = self.valves_manager.valves[4]
-        ports = self.switch_manager_flood_ports(valve.switch_manager)
+        ports = self.stack_manager_flood_ports(valve.stack_manager)
         self.assertEqual(output_ports, ports, 'InterVLAN flooding does not match expected')
         route_manager = valve._route_manager_by_ipv.get(4, None)
         vlan = valve.dp.vlans[100]
@@ -1689,14 +1719,14 @@ dps:
         valve = self.valves_manager.valves[0x1]
         port = valve.dp.ports[3]
         # Apply tunnel to ofmsgs on valve
-        self.apply_ofmsgs(valve.switch_manager.add_tunnel_acls())
+        self.apply_ofmsgs(valve.stack_manager.add_tunnel_acls())
         # Should encapsulate and output packet towards tunnel destination s3
         self.validate_tunnel(
             1, 0, 3, self.SRC_ID, True,
             'Did not encapsulate and forward')
         # Set the chosen port down to force a recalculation on the tunnel path
         self.set_port_down(port.number)
-        ofmsgs = valve.switch_manager.add_tunnel_acls()
+        ofmsgs = valve.stack_manager.add_tunnel_acls()
         self.assertTrue(ofmsgs, 'No tunnel ofmsgs returned after a topology change')
         self.apply_ofmsgs(ofmsgs)
         # Should encapsulate and output packet using the new path
@@ -1707,7 +1737,7 @@ dps:
     def test_update_same_tunnel(self):
         """Test tunnel rules when outputting to host on the same switch as the source"""
         valve = self.valves_manager.valves[0x1]
-        self.apply_ofmsgs(valve.switch_manager.add_tunnel_acls())
+        self.apply_ofmsgs(valve.stack_manager.add_tunnel_acls())
         self.validate_tunnel(2, 0, 1, 0, True, 'Did not forward to host on same DP')
 
     def test_update_dst_tunnel(self):
@@ -1715,12 +1745,12 @@ dps:
         valve = self.valves_manager.valves[0x1]
         port = valve.dp.ports[3]
         # Apply tunnel to ofmsgs on valve
-        self.apply_ofmsgs(valve.switch_manager.add_tunnel_acls())
+        self.apply_ofmsgs(valve.stack_manager.add_tunnel_acls())
         # Should accept encapsulated packet and output to the destination host
         self.validate_tunnel(3, self.DST_ID, 1, 0, True, 'Did not output to host')
         # Set the chosen port down to force a recalculation on the tunnel path
         self.set_port_down(port.number)
-        ofmsgs = valve.switch_manager.add_tunnel_acls()
+        ofmsgs = valve.stack_manager.add_tunnel_acls()
         self.assertTrue(ofmsgs, 'No tunnel ofmsgs returned after a topology change')
         self.apply_ofmsgs(ofmsgs)
         # Should ccept encapsulated packet and output using the new path
@@ -1729,7 +1759,7 @@ dps:
     def test_update_none_tunnel(self):
         """Test tunnel on a switch not using a tunnel ACL"""
         valve = self.valves_manager.valves[0x1]
-        self.apply_ofmsgs(valve.switch_manager.add_tunnel_acls())
+        self.apply_ofmsgs(valve.stack_manager.add_tunnel_acls())
         # Should drop any packets received from the tunnel
         self.validate_tunnel(
             5, self.NONE_ID, None, None, False,
@@ -1829,7 +1859,7 @@ dps:
         port1 = valve.dp.ports[3]
         port2 = valve.dp.ports[5]
         # Apply tunnel to ofmsgs on valve
-        self.apply_ofmsgs(valve.switch_manager.add_tunnel_acls())
+        self.apply_ofmsgs(valve.stack_manager.add_tunnel_acls())
         # Should accept packet from stack and output to the next switch
         self.validate_tunnel(
             3, self.TRANSIT_ID, 5, self.TRANSIT_ID, True,
@@ -1842,7 +1872,7 @@ dps:
             'Did not output to next switch')
         # Set the chosen port to the next switch down to force a path recalculation
         self.set_port_down(port2.number)
-        ofmsgs = valve.switch_manager.add_tunnel_acls()
+        ofmsgs = valve.stack_manager.add_tunnel_acls()
         self.assertTrue(ofmsgs, 'No tunnel ofmsgs returned after a topology change')
         self.apply_ofmsgs(ofmsgs)
         # Should accept encapsulated packet and output using the new path
@@ -1929,7 +1959,7 @@ dps:
         valve = self.valves_manager.valves[0x1]
         port = valve.dp.ports[3]
         # Apply tunnel to ofmsgs on valve
-        self.apply_ofmsgs(valve.switch_manager.add_tunnel_acls())
+        self.apply_ofmsgs(valve.stack_manager.add_tunnel_acls())
         # Should encapsulate and output packet towards tunnel destination s3
         self.validate_tunnel(
             1, 0, 3, self.TUNNEL_ID, True,
@@ -1939,7 +1969,7 @@ dps:
             'Did not encapsulate and forward')
         # Set the chosen port down to force a recalculation on the tunnel path
         self.set_port_down(port.number)
-        ofmsgs = valve.switch_manager.add_tunnel_acls()
+        ofmsgs = valve.stack_manager.add_tunnel_acls()
         self.assertTrue(ofmsgs, 'No tunnel ofmsgs returned after a topology change')
         self.apply_ofmsgs(ofmsgs)
         # Should encapsulate and output packet using the new path
@@ -2067,7 +2097,7 @@ dps:
         valve = self.valves_manager.valves[0x1]
         port = valve.dp.ports[3]
         # Apply tunnel to ofmsgs on valve
-        self.apply_ofmsgs(valve.switch_manager.add_tunnel_acls())
+        self.apply_ofmsgs(valve.stack_manager.add_tunnel_acls())
         # Should encapsulate and output packet towards tunnel destination s3
         self.validate_tunnel(
             1, 0, 3, self.SRC_ID, True,
@@ -2078,7 +2108,7 @@ dps:
             eth_type=0x86dd, ip_proto=56)
         # Set the chosen port down to force a recalculation on the tunnel path
         self.set_port_down(port.number)
-        ofmsgs = valve.switch_manager.add_tunnel_acls()
+        ofmsgs = valve.stack_manager.add_tunnel_acls()
         self.assertTrue(ofmsgs, 'No tunnel ofmsgs returned after a topology change')
         self.apply_ofmsgs(ofmsgs)
         # Should encapsulate and output packet using the new path
@@ -2089,7 +2119,7 @@ dps:
     def test_update_same_tunnel(self):
         """Test tunnel rules when outputting to host on the same switch as the source"""
         valve = self.valves_manager.valves[0x1]
-        self.apply_ofmsgs(valve.switch_manager.add_tunnel_acls())
+        self.apply_ofmsgs(valve.stack_manager.add_tunnel_acls())
         self.validate_tunnel(2, 0, 1, 0, True, 'Did not forward to host on same DP')
 
     def test_update_dst_tunnel(self):
@@ -2097,12 +2127,12 @@ dps:
         valve = self.valves_manager.valves[0x1]
         port = valve.dp.ports[3]
         # Apply tunnel to ofmsgs on valve
-        self.apply_ofmsgs(valve.switch_manager.add_tunnel_acls())
+        self.apply_ofmsgs(valve.stack_manager.add_tunnel_acls())
         # Should accept encapsulated packet and output to the destination host
         self.validate_tunnel(3, self.DST_ID, 1, 0, True, 'Did not output to host')
         # Set the chosen port down to force a recalculation on the tunnel path
         self.set_port_down(port.number)
-        ofmsgs = valve.switch_manager.add_tunnel_acls()
+        ofmsgs = valve.stack_manager.add_tunnel_acls()
         self.assertTrue(ofmsgs, 'No tunnel ofmsgs returned after a topology change')
         self.apply_ofmsgs(ofmsgs)
         # Should ccept encapsulated packet and output using the new path
@@ -2111,7 +2141,7 @@ dps:
     def test_update_none_tunnel(self):
         """Test tunnel on a switch not using a tunnel ACL"""
         valve = self.valves_manager.valves[0x1]
-        self.apply_ofmsgs(valve.switch_manager.add_tunnel_acls())
+        self.apply_ofmsgs(valve.stack_manager.add_tunnel_acls())
         # Should drop any packets received from the tunnel
         self.validate_tunnel(
             5, self.NONE_ID, None, None, False,
@@ -2211,7 +2241,7 @@ dps:
         port1 = valve.dp.ports[3]
         port2 = valve.dp.ports[5]
         # Apply tunnel to ofmsgs on valve
-        self.apply_ofmsgs(valve.switch_manager.add_tunnel_acls())
+        self.apply_ofmsgs(valve.stack_manager.add_tunnel_acls())
         # Should accept packet from stack and output to the next switch
         self.validate_tunnel(
             3, self.TRANSIT_ID, 5, self.TRANSIT_ID, True,
@@ -2224,7 +2254,7 @@ dps:
             'Did not output to next switch')
         # Set the chosen port to the next switch down to force a path recalculation
         self.set_port_down(port2.number)
-        ofmsgs = valve.switch_manager.add_tunnel_acls()
+        ofmsgs = valve.stack_manager.add_tunnel_acls()
         self.assertTrue(ofmsgs, 'No tunnel ofmsgs returned after a topology change')
         self.apply_ofmsgs(ofmsgs)
         # Should accept encapsulated packet and output using the new path
@@ -2311,7 +2341,7 @@ dps:
         valve = self.valves_manager.valves[0x1]
         port = valve.dp.ports[3]
         # Apply tunnel to ofmsgs on valve
-        self.apply_ofmsgs(valve.switch_manager.add_tunnel_acls())
+        self.apply_ofmsgs(valve.stack_manager.add_tunnel_acls())
         # Should encapsulate and output packet towards tunnel destination s3
         self.validate_tunnel(
             1, 0, 3, self.TUNNEL_ID, True,
@@ -2321,7 +2351,7 @@ dps:
             'Did not encapsulate and forward')
         # Set the chosen port down to force a recalculation on the tunnel path
         self.set_port_down(port.number)
-        ofmsgs = valve.switch_manager.add_tunnel_acls()
+        ofmsgs = valve.stack_manager.add_tunnel_acls()
         self.assertTrue(ofmsgs, 'No tunnel ofmsgs returned after a topology change')
         self.apply_ofmsgs(ofmsgs)
         # Should encapsulate and output packet using the new path
@@ -2396,8 +2426,8 @@ dps:
     def test_topo(self):
         """Test topology functions."""
         dp = self.valves_manager.valves[self.DP_ID].dp
-        self.assertTrue(dp.is_stack_root())
-        self.assertFalse(dp.is_stack_edge())
+        self.assertTrue(dp.stack.is_root())
+        self.assertFalse(dp.stack.is_edge())
 
     def test_add_remove_port(self):
         self.update_and_revert_config(self.CONFIG, self.CONFIG3, 'warm')
@@ -2466,8 +2496,8 @@ dps:
     def test_topo(self):
         """Test topology functions."""
         dp_obj = self.valves_manager.valves[self.DP_ID].dp
-        self.assertFalse(dp_obj.is_stack_root())
-        self.assertTrue(dp_obj.is_stack_edge())
+        self.assertFalse(dp_obj.stack.is_root())
+        self.assertTrue(dp_obj.stack.is_edge())
 
     def test_add_remove_port(self):
         self.update_and_revert_config(self.CONFIG, self.CONFIG3, 'warm')
@@ -2719,7 +2749,7 @@ dps:
             valve = self.valves_manager.valves[new_dp.dp_id]
             changes = valve.dp.get_config_changes(valve.logger, new_dp)
             changed_ports, all_ports_changed = changes[1], changes[6]
-            for port in valve.dp.stack_ports:
+            for port in valve.dp.stack_ports():
                 if not all_ports_changed:
                     self.assertIn(
                         port.number, changed_ports,
@@ -2735,10 +2765,388 @@ dps:
         for new_dp in new_dps:
             valve = self.valves_manager.valves[new_dp.dp_id]
             changed_ports = valve.dp.get_config_changes(valve.logger, new_dp)[1]
-            for port in valve.dp.stack_ports:
+            for port in valve.dp.stack_ports():
                 self.assertNotIn(
                     port.number, changed_ports,
                     'Stack port detected as changed on non-topology change')
+
+
+class ValveStackHealthTest(ValveTestBases.ValveTestNetwork):
+    """Test stack root health metrics"""
+
+    UPDATE_TIME = 10
+
+    CONFIG = """
+vlans:
+    vlan100:
+        vid: 100
+dps:
+    sw1:
+        hardware: 'GenericTFM'
+        dp_id: 1
+        stack: {priority: 1, down_time_multiple: 1}
+        interfaces:
+            1:
+                native_vlan: vlan100
+            2:
+                stack: {dp: sw2, port: 2}
+            3:
+                stack: {dp: sw3, port: 2}
+            4:
+                native_vlan: vlan100
+                lacp: 1
+            5:
+                native_vlan: vlan100
+                lacp: 1
+            6:
+                stack: {dp: sw2, port: 3}
+            7:
+                stack: {dp: sw3, port: 3}
+    sw2:
+        hardware: 'GenericTFM'
+        dp_id: 2
+        stack: {priority: 2, down_time_multiple: 2}
+        interfaces:
+            1:
+                native_vlan: vlan100
+            2:
+                stack: {dp: sw1, port: 2}
+            3:
+                stack: {dp: sw1, port: 6}
+            4:
+                native_vlan: vlan100
+                lacp: 1
+            5:
+                native_vlan: vlan100
+                lacp: 1
+            6:
+                native_vlan: vlan100
+                lacp: 2
+            7:
+                native_vlan: vlan100
+                lacp: 2
+    sw3:
+        hardware: 'GenericTFM'
+        dp_id: 3
+        interfaces:
+            1:
+                native_vlan: vlan100
+            2:
+                stack: {dp: sw1, port: 3}
+            3:
+                stack: {dp: sw1, port: 7}
+"""
+
+    def setUp(self):
+        """Start network for test"""
+        self.setup_valves(self.CONFIG)
+
+    def test_timeout(self):
+        """Test stack health on health timeouts"""
+        dps = [valve.dp for valve in self.valves_manager.valves.values()]
+        for dp in dps:
+            for port in dp.ports.values():
+                if port.lacp:
+                    port.actor_up()
+                    port.select_port()
+                if port.stack:
+                    port.stack_up()
+        last_live_times = {'sw1': 100, 'sw2': 100, 'sw3': 100}
+        self.assertTrue(dps[0].stack.update_health(
+            110, last_live_times, self.UPDATE_TIME,
+            dps[0].lacp_down_ports(), dp.stack.down_ports())[0])
+        self.assertFalse(dps[0].stack.update_health(
+            120, last_live_times, self.UPDATE_TIME,
+            dps[0].lacp_down_ports(), dp.stack.down_ports())[0])
+        self.assertTrue(dps[1].stack.update_health(
+            110, last_live_times, self.UPDATE_TIME,
+            dps[1].lacp_down_ports(), dp.stack.down_ports())[0])
+        self.assertFalse(dps[1].stack.update_health(
+            130, last_live_times, self.UPDATE_TIME,
+            dps[1].lacp_down_ports(), dp.stack.down_ports())[0])
+        self.assertTrue(dps[2].stack.update_health(
+            110, last_live_times, self.UPDATE_TIME,
+            dps[2].lacp_down_ports(), dp.stack.down_ports())[0])
+        self.assertFalse(dps[2].stack.update_health(
+            140, last_live_times, self.UPDATE_TIME,
+            dps[2].lacp_down_ports(), dp.stack.down_ports())[0])
+
+    def test_lacp_down(self):
+        """Test stack health on LACP ports being DOWN"""
+        dps = [valve.dp for valve in self.valves_manager.valves.values()]
+        for dp in dps:
+            for port in dp.ports.values():
+                if port.lacp:
+                    port.actor_up()
+                    port.select_port()
+                if port.stack:
+                    port.stack_up()
+        last_live_times = {'sw1': 100, 'sw2': 100, 'sw3': 100}
+        self.assertTrue(dps[0].stack.update_health(
+            110, last_live_times, self.UPDATE_TIME,
+            dps[0].lacp_down_ports(), dps[0].stack.down_ports())[0])
+        for port in dps[0].ports.values():
+            if port.lacp:
+                port.actor_notconfigured()
+        self.assertFalse(dps[0].stack.update_health(
+            110, last_live_times, self.UPDATE_TIME,
+            dps[0].lacp_down_ports(), dps[0].stack.down_ports())[0])
+        self.assertTrue(dps[1].stack.update_health(
+            110, last_live_times, self.UPDATE_TIME,
+            dps[1].lacp_down_ports(), dps[1].stack.down_ports())[0])
+        for port in dps[1].ports.values():
+            if port.lacp:
+                port.actor_nosync()
+        self.assertFalse(dps[1].stack.update_health(
+            110, last_live_times, self.UPDATE_TIME,
+            dps[1].lacp_down_ports(), dps[1].stack.down_ports())[0])
+        self.assertTrue(dps[2].stack.update_health(
+            110, last_live_times, self.UPDATE_TIME,
+            dps[2].lacp_down_ports(), dps[2].stack.down_ports())[0])
+
+    def test_stack_port_down(self):
+        """Test stack health on stack ports being DOWN"""
+        dps = [valve.dp for valve in self.valves_manager.valves.values()]
+        for dp in dps:
+            for port in dp.ports.values():
+                if port.lacp:
+                    port.actor_up()
+                    port.select_port()
+                if port.stack:
+                    port.stack_up()
+        last_live_times = {'sw1': 100, 'sw2': 100, 'sw3': 100}
+        self.assertTrue(dps[0].stack.update_health(
+            110, last_live_times, self.UPDATE_TIME,
+            dps[0].lacp_down_ports(), dps[0].stack.down_ports())[0])
+        for port in dps[0].ports.values():
+            if port.stack:
+                port.stack_bad()
+        self.assertFalse(dps[0].stack.update_health(
+            110, last_live_times, self.UPDATE_TIME,
+            dps[0].lacp_down_ports(), dps[0].stack.down_ports())[0])
+        self.assertTrue(dps[1].stack.update_health(
+            110, last_live_times, self.UPDATE_TIME,
+            dps[1].lacp_down_ports(), dps[1].stack.down_ports())[0])
+        for port in dps[1].ports.values():
+            if port.stack:
+                port.stack_gone()
+        self.assertFalse(dps[1].stack.update_health(
+            110, last_live_times, self.UPDATE_TIME,
+            dps[1].lacp_down_ports(), dps[1].stack.down_ports())[0])
+        self.assertTrue(dps[2].stack.update_health(
+            110, last_live_times, self.UPDATE_TIME,
+            dps[2].lacp_down_ports(), dps[2].stack.down_ports())[0])
+        for port in dps[2].ports.values():
+            if port.stack:
+                port.stack_admin_down()
+        self.assertFalse(dps[2].stack.update_health(
+            110, last_live_times, self.UPDATE_TIME,
+            dps[2].lacp_down_ports(), dps[2].stack.down_ports())[0])
+
+
+class ValveRootNominationTest(ValveStackHealthTest):
+    """Test ValveStackManager root nomination calculations"""
+
+    UPDATE_TIME = 10
+
+    CONFIG = """
+vlans:
+    vlan100:
+        vid: 100
+dps:
+    sw1:
+        hardware: 'GenericTFM'
+        dp_id: 1
+        stack: {priority: 1, down_time_multiple: 1}
+        interfaces:
+            1:
+                native_vlan: vlan100
+            2:
+                stack: {dp: sw2, port: 2}
+            3:
+                stack: {dp: sw3, port: 2}
+            4:
+                native_vlan: vlan100
+                lacp: 1
+            5:
+                native_vlan: vlan100
+                lacp: 1
+            6:
+                stack: {dp: sw2, port: 3}
+            7:
+                stack: {dp: sw3, port: 3}
+    sw2:
+        hardware: 'GenericTFM'
+        dp_id: 2
+        stack: {priority: 2, down_time_multiple: 2}
+        interfaces:
+            1:
+                native_vlan: vlan100
+            2:
+                stack: {dp: sw1, port: 2}
+            3:
+                stack: {dp: sw1, port: 6}
+            4:
+                native_vlan: vlan100
+                lacp: 1
+            5:
+                native_vlan: vlan100
+                lacp: 1
+            6:
+                native_vlan: vlan100
+                lacp: 2
+            7:
+                native_vlan: vlan100
+                lacp: 2
+    sw3:
+        hardware: 'GenericTFM'
+        dp_id: 3
+        interfaces:
+            1:
+                native_vlan: vlan100
+            2:
+                stack: {dp: sw1, port: 3}
+            3:
+                stack: {dp: sw1, port: 7}
+"""
+
+    def setUp(self):
+        """Start network for test"""
+        self.setup_valves(self.CONFIG)
+
+    def other_valves(self, root_valve):
+        return [valve for valve in self.valves_manager.valves.values() if valve != root_valve]
+
+    def test_root_nomination(self):
+        """Test root selection health"""
+        dps = [valve.dp for valve in self.valves_manager.valves.values()]
+        for dp in dps:
+            for port in dp.ports.values():
+                if port.lacp:
+                    port.actor_up()
+                    port.select_port()
+                if port.stack:
+                    port.stack_up()
+        valves = self.valves_manager.valves
+        last_live_times = {'sw1': 100, 'sw2': 100, 'sw3': 100}
+        # Start not root currently selected, all valves should select root sw1
+        for valve in valves.values():
+            self.assertEqual(valve.stack_manager.nominate_stack_root(
+                None, list(valves.values()), 100, last_live_times, self.UPDATE_TIME), 'sw1')
+        # timeout SW1, all valves should select sw2
+        for valve in valves.values():
+            self.assertEqual(valve.stack_manager.nominate_stack_root(
+                valves[1], self.other_valves(valves[1]), 111,
+                last_live_times, self.UPDATE_TIME), 'sw2')
+        # timeout sw2, default select sw1
+        for valve in valves.values():
+            self.assertEqual(valve.stack_manager.nominate_stack_root(
+                valves[2], self.other_valves(valves[2]),
+                121, last_live_times, self.UPDATE_TIME), 'sw1')
+
+    def test_consistent_roots(self):
+        """Test inconsistent root detection"""
+        valves = self.valves_manager.valves
+        for valve in valves.values():
+            valve.dp.stack.root_name = 'sw1'
+        for valve in valves.values():
+            self.assertTrue(valve.stack_manager.consistent_roots(
+                'sw1', valve, self.other_valves(valve)))
+        valves[1].dp.stack.root_name = 'sw2'
+        for valve in valves.values():
+            self.assertFalse(valve.stack_manager.consistent_roots(
+                'sw1', valve, self.other_valves(valve)))
+
+
+class ValveStackConfigTest(ValveTestBases.ValveTestNetwork):
+    """Test recompiling Stack into YAML config object"""
+
+    CONFIG = """
+vlans:
+    vlan100:
+        vid: 100
+dps:
+    sw1:
+        hardware: 'GenericTFM'
+        dp_id: 1
+        stack: {priority: 1, down_time_multiple: 1}
+        interfaces:
+            1:
+                native_vlan: vlan100
+            2:
+                stack: {dp: sw2, port: 2}
+            3:
+                stack: {dp: sw3, port: 2}
+            4:
+                native_vlan: vlan100
+                lacp: 1
+            5:
+                native_vlan: vlan100
+                lacp: 1
+            6:
+                stack: {dp: sw2, port: 3}
+            7:
+                stack: {dp: sw3, port: 3}
+    sw2:
+        hardware: 'GenericTFM'
+        dp_id: 2
+        stack: {priority: 2, down_time_multiple: 2}
+        interfaces:
+            1:
+                native_vlan: vlan100
+            2:
+                stack: {dp: sw1, port: 2}
+            3:
+                stack: {dp: sw1, port: 6}
+            4:
+                native_vlan: vlan100
+                lacp: 1
+            5:
+                native_vlan: vlan100
+                lacp: 1
+            6:
+                native_vlan: vlan100
+                lacp: 2
+            7:
+                native_vlan: vlan100
+                lacp: 2
+    sw3:
+        hardware: 'GenericTFM'
+        dp_id: 3
+        interfaces:
+            1:
+                native_vlan: vlan100
+            2:
+                stack: {dp: sw1, port: 3}
+            3:
+                stack: {dp: sw1, port: 7}
+"""
+
+    def setUp(self):
+        """Start network for test"""
+        self.setup_valves(self.CONFIG)
+
+    def test_stack(self):
+        """Test getting config for stack with correct config"""
+        dp = self.valves_manager.valves[1].dp
+        stack_conf = yaml.load(dp.stack.to_conf())
+        self.assertIsInstance(stack_conf, dict)
+        self.assertIn('priority', stack_conf)
+        self.assertIn('down_time_multiple', stack_conf)
+        self.assertIn('route_learning', stack_conf)
+        self.assertNotIn('dyn_healthy', stack_conf)
+        self.assertNotIn('canonical_port_order', stack_conf)
+        self.assertNotIn('graph', stack_conf)
+        self.assertNotIn('name', stack_conf)
+
+    def test_dp_stack(self):
+        """Test getting config for DP with correct subconfig stack"""
+        dp = self.valves_manager.valves[1].dp
+        dp_conf = yaml.load(dp.to_conf())
+        stack_conf = yaml.load(dp.stack.to_conf())
+        self.assertIn('stack', dp_conf)
+        self.assertIsInstance(dp_conf['stack'], dict)
+        self.assertEqual(dp_conf['stack'], stack_conf)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`Stack`: All stack related DP methods are moved to a stack class `Stack` in `stack.py`. `Stack` provides the additional configuration option `down_time_multiple` that configures how many `FAUCET_STACK_ROOT_STATE_UPDATE_TIME` intervals for a down stack node to still be considered healthy.

`ValveStackManager`: All stack based algorithms in the various valve managers that don't directly belong in that valve manager have been moved to `ValveStackManager` in `valve_stack.py`. Part of the root nomination process has been moved to this class, along with the away & towards root port selection & pruning calculations. Tunnel updating has been moved to here as well.

`FAUCET_STACK_ROOT_STATE_UPDATE_TIME` environment variable configures the number of seconds to wait before checking stack root health. If the current root is unhealthy, a new root will be nominated.