### PR TITLE
Add unit test redundant ofmsgs offset check

### DIFF
--- a/tests/unit/faucet/test_valve_config.py
+++ b/tests/unit/faucet/test_valve_config.py
@@ -142,7 +142,7 @@ dps:
     def test_delete_permanent_learn(self):
         """Test port permanent learn can deconfigured."""
         table = self.network.tables[self.DP_ID]
-        before_table_state = str(table)
+        before_table_state = table.table_state()
         self.rcv_packet(2, 0x200, {
             'eth_src': self.P2_V200_MAC,
             'eth_dst': self.P3_V200_MAC,

--- a/tests/unit/faucet/test_valve_stack.py
+++ b/tests/unit/faucet/test_valve_stack.py
@@ -2543,6 +2543,13 @@ dps:
             valve_of.valve_flowreorder(
                 ofmsgs + [global_flowmod, global_metermod, global_groupmod]), False)
 
+    def test_all_offset(self):
+        """Test groups with the redundant controller offset check for all possible offsets"""
+        valve = self.valves_manager.valves[0x1]
+        port = valve.dp.ports[1]
+        ofmsgs = valve.acl_manager.add_port(port)
+        self.apply_ofmsgs(ofmsgs, 0x1, all_offsets=True)
+
 
 class ValveWarmStartStackTest(ValveTestBases.ValveTestNetwork):
     """Test warm starting stack ports"""


### PR DESCRIPTION
I had to generate the offset ofmsgs from the original (before reorganizing and optimizing) ofmsgs due to the prepared ofmsgs flow structure.