### PR TITLE
Add multiple controllers to test redundancy for the integration tests

### DIFF
--- a/.github/workflows/tests-codecheck.yml
+++ b/.github/workflows/tests-codecheck.yml
@@ -20,8 +20,14 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - if: ${{ steps.file_changes.outputs.all }}
+        name: Setup dependencies
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y jq
+      - if: ${{ steps.file_changes.outputs.all }}
         name: Compare file changes
         run: |
+          sudo apt-get install jq
           FILES_ALL="$(echo '${{ steps.file_changes.outputs.all }}' | jq -r '.[]' | tr '\n' ' ')"
           FILES_ADDED="$(echo '${{ steps.file_changes.outputs.added }}' | jq -r '.[]' | tr '\n' ' ')"
           FILES_DELETED="$(echo '${{ steps.file_changes.outputs.deleted }}' | jq -r '.[]' | tr '\n' ' ')"

--- a/.github/workflows/tests-integration.yml
+++ b/.github/workflows/tests-integration.yml
@@ -23,6 +23,11 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - if: ${{ steps.file_changes.outputs.all }}
+        name: Setup dependencies
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y jq
+      - if: ${{ steps.file_changes.outputs.all }}
         name: Compare file changes
         run: |
           FILES_ALL="$(echo '${{ steps.file_changes.outputs.all }}' | jq -r '.[]' | tr '\n' ' ')"
@@ -84,6 +89,11 @@ jobs:
         uses: lots0logs/gh-action-get-changed-files@2.1.4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+      - if: ${{ steps.file_changes.outputs.all }}
+        name: Setup dependencies
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y jq
       - if: ${{ steps.file_changes.outputs.all }}
         name: Compare file changes
         run: |

--- a/.github/workflows/tests-unit.yml
+++ b/.github/workflows/tests-unit.yml
@@ -22,6 +22,11 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - if: ${{ steps.file_changes.outputs.all }}
+        name: Setup dependencies
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y jq
+      - if: ${{ steps.file_changes.outputs.all }}
         name: Compare file changes
         run: |
           FILES_ALL="$(echo '${{ steps.file_changes.outputs.all }}' | jq -r '.[]' | tr '\n' ' ')"

--- a/clib/mininet_test_base_topo.py
+++ b/clib/mininet_test_base_topo.py
@@ -19,6 +19,9 @@ class FaucetTopoTestBase(FaucetTestBase):
     Extension to the base test for the integration test suite to help set up arbitrary topologies
     """
 
+    NUM_FAUCET_CONTROLLERS = 2
+    NUM_GAUGE_CONTROLLERS = 1
+
     NETPREFIX = 24
     IPV = 4
     GROUP_TABLE = False
@@ -285,10 +288,10 @@ class FaucetTopoTestBase(FaucetTestBase):
             labels = {'dp_id': '0x%x' % int(dpid), 'dp_name': name}
             self.assertEqual(
                 0, self.scrape_prometheus_var(
-                    var='stack_cabling_errors_total', labels=labels, default=None))
+                    var='stack_cabling_errors_total', labels=labels, default=None, verify_consistent=True))
             self.assertGreater(
                 self.scrape_prometheus_var(
-                    var='stack_probes_received_total', labels=labels), 0)
+                    var='stack_probes_received_total', labels=labels, verify_consistent=True), 0)
 
     def verify_stack_hosts(self, verify_bridge_local_rule=True, retries=3):
         """Verify hosts with stack LLDP messages"""
@@ -317,7 +320,7 @@ class FaucetTopoTestBase(FaucetTestBase):
         labels.update({'dp_id': '0x%x' % int(dpid), 'dp_name': dp_name})
         return self.scrape_prometheus_var(
             'port_stack_state', labels=labels,
-            default=None, dpid=dpid)
+            default=None, dpid=dpid, verify_consistent=True)
 
     def wait_for_stack_port_status(self, dpid, dp_name, port_no, status, timeout=25):
         """Wait until prometheus detects a stack port has a certain status"""
@@ -648,7 +651,7 @@ details partner lacp pdu:
                                 # Obtain up LACP ports for that dpid
                                 port_labels = self.port_labels(port)
                                 lacp_state = self.scrape_prometheus_var(
-                                    'port_lacp_state', port_labels, default=0, dpid=dpid)
+                                    'port_lacp_state', port_labels, default=0, dpid=dpid, verify_consistent=True)
                                 lacp_up_ports += 1 if lacp_state == 3 else 0
         return lacp_up_ports
 


### PR DESCRIPTION
Modify `NUM_FAUCET_CONTROLLER` constant to set how many controllers you want to run in the integration test suite.

Modify `FAUCET_CONTROLLER_START_DELAY` to change how long to wait before starting the next controller.

As expected group mod & meter mod tests fail due to incorrect order of group/meter flowmods. This is mostly fixed by having the `FAUCET_CONTROLLER_START_DELAY` which prevents the flowmod collision during startup, however when the tests flap the ports they will still encounter the problem.

8021X failures:
Pretty much all of the 8021X tests fail with 2 Faucet controllers running.
- Faucet8021XCustomACLLoginTest
- Faucet8021XCustomACLLogoutTest
- Faucet8021XDynACLLoginTest
- Faucet8021XDynACLLogoutTest
- Faucet8021XFailureTest
- Faucet8021XPortFlapTest
- Faucet8021XPortStatusTest
- Faucet8021XSuccessTest
- Faucet8021XVLANTest

BGP Routing failures:
BGP routing tests are mostly fine, however sometimes (most of the time) they will fail. It seems like the BGP state is being picked up by one of the controllers only.
- FaucetUntaggedIPv4GlobalInterVLANRouteTest
- FaucetUntaggedBGPIPv4RouteTest
- FaucetUntaggedBGPIPv4DefaultRouteTest
- FaucetUntaggedBGPIPv6RouteTest
- FaucetUntaggedBGPDualstackDefaultRouteTest

FaucetLLDPIntervalTest fails due to expecting LLDP packets with an interval. With multiple controllers, multiple packets are sent at relatively the same time, disrupting the interval assumption.

If configured to run hardware tests we just change to running a single controller. I think more configuration is needed to support hardware and the 'fake' hardware tests with multiple controllers.