### PR TITLE
Check for empty values when evaluating ACL changes in config.

### DIFF
--- a/faucet/dp.py
+++ b/faucet/dp.py
@@ -1361,7 +1361,7 @@ configuration.
                     changed_acl_ports.add(port_no)
                     logger.info('port %s ACL changed (ACL %s content changed)' % (
                         port_no, port_acls_changed))
-                elif old_acl_ids != new_acl_ids:
+                elif (old_acl_ids or new_acl_ids) and old_acl_ids != new_acl_ids:
                     changed_acl_ports.add(port_no)
                     logger.info('port %s ACL changed (ACL %s to %s)' % (
                         port_no, old_acl_ids, new_acl_ids))

--- a/tests/integration/mininet_tests.py
+++ b/tests/integration/mininet_tests.py
@@ -3450,6 +3450,41 @@ class FaucetConfigReloadAclTest(FaucetConfigReloadTestBase):
         self.verify_tp_dst_blocked(5003, first_host, second_host)
 
 
+class FaucetConfigReloadEmptyAclTest(FaucetConfigReloadTestBase):
+
+    CONFIG = """
+        interfaces:
+            %(port_1)d:
+                native_vlan: 100
+            %(port_2)d:
+                native_vlan: 100
+            %(port_3)d:
+                native_vlan: 300
+            %(port_4)d:
+                native_vlan: 100
+"""
+    CONFIG_GLOBAL = """
+vlans:
+    100:
+        description: "untagged"
+    200:
+        description: "untagged"
+    300:
+        description: "untagged"
+        acls_in: [1]
+"""
+
+    STAT_RELOAD = '1'
+    def test_port_acls(self):
+        hup = not self.STAT_RELOAD
+        self.change_port_config(
+            self.port_map['port_3'], 'acls_in', [],
+            restart=True, cold_start=False, hup=hup)
+        self.change_port_config(
+            self.port_map['port_1'], 'acls_in', [],
+            restart=True, cold_start=False, hup=hup)
+
+
 class FaucetConfigStatReloadAclTest(FaucetConfigReloadAclTest):
 
     # Use the stat-based reload method.

--- a/tests/integration/mininet_tests.py
+++ b/tests/integration/mininet_tests.py
@@ -3475,6 +3475,7 @@ vlans:
 """
 
     STAT_RELOAD = '1'
+
     def test_port_acls(self):
         hup = not self.STAT_RELOAD
         self.change_port_config(


### PR DESCRIPTION
The fix tries to address a corner case which was discovered during operations with forchestrator/faucetizer where adding an empty acls_in results in an exception when calling dp.cold_start_port:

File "/usr/lib/python3/dist-packages/faucet/valve_util.py", line 34, in __koe
    func(*args, **kwargs)
  File "/usr/lib/python3/dist-packages/faucet/faucet.py", line 166, in reload_config
    self.valves_manager.request_reload_configs(
  File "/usr/lib/python3/dist-packages/faucet/valves_manager.py", line 289, in request_reload_configs
    result = self.load_configs(now, new_config_file, delete_dp=delete_dp)
  File "/usr/lib/python3/dist-packages/faucet/valves_manager.py", line 271, in load_configs
    return self._apply_configs(self.parse_configs(new_config_file), now, delete_dp)
  File "/usr/lib/python3/dist-packages/faucet/valves_manager.py", line 249, in _apply_configs
    ofmsgs = valve.reload_config(now, new_dp)
  File "/usr/lib/python3/dist-packages/faucet/valve.py", line 1494, in reload_config
    cold_start, ofmsgs = self._apply_config_changes(
  File "/usr/lib/python3/dist-packages/faucet/valve.py", line 1473, in _apply_config_changes
    ofmsgs.extend(self.acl_manager.cold_start_port(port))
  File "/usr/lib/python3/dist-packages/faucet/valve_acl.py", line 352, in cold_start_port
    in_port_match = self.port_acl_table.match(in_port=port.number)
AttributeError: 'NoneType' object has no attribute 'match'

 Another defensive fix could be to check for the existence of port_acl_table in dp.cold_start_port but that could mask other issues which lead to this particular corner case. 