### PR TITLE
Change root health & nomination calculation

### DIFF
--- a/clib/mininet_test_base.py
+++ b/clib/mininet_test_base.py
@@ -152,9 +152,10 @@ class FaucetTestBase(unittest.TestCase):
     cpn_intf = None
     cpn_ipv6 = False
     config_ports = {}
-    rand_dpids = set()
     event_sock = None
     event_log = None
+
+    rand_dpids = set()
 
     def __init__(self, name, config, root_tmpdir, ports_sock, max_test_load,
                  port_order=None, start_port=None):

--- a/clib/mininet_test_base_topo.py
+++ b/clib/mininet_test_base_topo.py
@@ -22,6 +22,8 @@ class FaucetTopoTestBase(FaucetTestBase):
     NUM_FAUCET_CONTROLLERS = 2
     NUM_GAUGE_CONTROLLERS = 1
 
+    DESCENDING_DPIDS = False
+
     NETPREFIX = 24
     IPV = 4
     GROUP_TABLE = False
@@ -142,6 +144,8 @@ class FaucetTopoTestBase(FaucetTestBase):
             self.OVS_TYPE,
             self.ports_sock,
             self._test_name(),
+            self.NUM_DPS,
+            self.DESCENDING_DPIDS,
             host_links=host_links,
             host_vlans=host_vlans,
             switch_links=switch_links,

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -284,6 +284,16 @@ within the configuration block 'stack':
       - 3
       - The down_time_multiple value determines the number of root update time
         intervals for a stack node to be considered healthy when not running.
+    * - min_stack_health
+      - float
+      - 1.0
+      - Minimum percentage value of required UP stack ports for this stack node to
+        be considered healthy. The default value of 1.0 is considered 100%.
+    * - min_lacp_health
+      - float
+      - 1.0
+      - Minimum percentage value of required UP stack ports for this stack node to
+        be considered healthy. The default value of 1.0 is considered 100%.
 
 LLDP (DP)
 #########

--- a/faucet/dp.py
+++ b/faucet/dp.py
@@ -326,15 +326,15 @@ configuration.
     def __str__(self):
         return str(self.name)
 
-    def clone_dyn_state(self, prev_dp):
+    def clone_dyn_state(self, prev_dp, dps=None):
         """Clone dynamic state for this dp"""
         self.dyn_running = prev_dp.dyn_running
         self.dyn_up_port_nos = set(prev_dp.dyn_up_port_nos)
         self.dyn_last_coldstart_time = prev_dp.dyn_last_coldstart_time
-        if self.stack:
-            self.stack.clone_dyn_state(prev_dp.stack)
         for number in self.ports:
             self.ports[number].clone_dyn_state(prev_dp.ports.get(number))
+        if self.stack:
+            self.stack.clone_dyn_state(prev_dp.stack, dps)
 
     def cold_start(self, now):
         """Update to reflect a cold start"""

--- a/faucet/dp.py
+++ b/faucet/dp.py
@@ -324,7 +324,7 @@ configuration.
         super().__init__(_id, dp_id, conf)
 
     def __str__(self):
-        return self.name
+        return str(self.name)
 
     def clone_dyn_state(self, prev_dp):
         """Clone dynamic state for this dp"""
@@ -378,7 +378,9 @@ configuration.
         if self.dot1x:
             self._check_conf_types(self.dot1x, self.dot1x_defaults_types)
         self._check_conf_types(self.table_sizes, self.default_table_sizes_types)
-        self.stack = Stack('stack', self.dp_id, self.name, self.canonical_port_order, self.stack)
+        self.stack = Stack('stack', self.dp_id, self.name,
+                           self.canonical_port_order, self.lacp_down_ports, self.lacp_ports,
+                           self.stack)
 
     def _lldp_defaults(self):
         self._check_conf_types(self.lldp_beacon, self.lldp_beacon_defaults_types)

--- a/faucet/valve_lldp.py
+++ b/faucet/valve_lldp.py
@@ -125,10 +125,10 @@ class ValveLLDPManager(ValveManagerBase):
                 self.notify({'STACK_STATE': {
                     'port': port.number,
                     'state': after_state}})
-                stack_changes += 1
                 self.logger.info('Stack %s state %s (previous state %s): %s' % (
                     port, port.stack_state_name(after_state),
                     port.stack_state_name(before_state), reason))
+                stack_changes += 1
                 port_up = False
                 if port.is_stack_up():
                     port_up = True

--- a/faucet/valve_stack.py
+++ b/faucet/valve_stack.py
@@ -222,22 +222,15 @@ This includes port nominations and flood directionality."""
         Returns:
             bool: True if current stack node is healthy
         """
-        prev_health = self.stack.dyn_healthy
+        prev_health = self.stack.dyn_healthy_info
         new_health, reason = self.stack.update_health(
-            now, last_live_times, update_time, self.dp.lacp_down_ports(),
-            self.stack.down_ports())
+            now, last_live_times, update_time)
+        new_health = self.stack.dyn_healthy_info
         if prev_health != new_health:
-            health = 'HEALTHY' if new_health else 'UNHEALTHY'
+            health = 'HEALTHY' if self.stack.dyn_healthy else 'UNHEALTHY'
             self.logger.info('Stack node %s %s (%s)' % (self.stack.name, health, reason))
+        new_health = self.stack.dyn_healthy
         return new_health
-
-    def consistent_roots(self, expected_root_name, valve, other_valves):
-        """Returns true if all the stack nodes have the root configured correctly"""
-        stacked_valves = {valve}.union(self.stacked_valves(other_valves))
-        for stack_valve in stacked_valves:
-            if stack_valve.dp.stack.root_name != expected_root_name:
-                return False
-        return True
 
     def nominate_stack_root(self, root_valve, other_valves, now, last_live_times, update_time):
         """
@@ -287,6 +280,14 @@ This includes port nominations and flood directionality."""
             _, new_root_name = stacks[0].nominate_stack_root(stacks)
 
         return new_root_name
+
+    def consistent_roots(self, expected_root_name, valve, other_valves):
+        """Returns true if all the stack nodes have the root configured correctly"""
+        stacked_valves = {valve}.union(self.stacked_valves(other_valves))
+        for stack_valve in stacked_valves:
+            if stack_valve.dp.stack.root_name != expected_root_name:
+                return False
+        return True
 
     def stack_ports(self):
         """Yield the stack ports of this stack node"""

--- a/faucet/valve_stack.py
+++ b/faucet/valve_stack.py
@@ -225,11 +225,9 @@ This includes port nominations and flood directionality."""
         prev_health = self.stack.dyn_healthy_info
         new_health, reason = self.stack.update_health(
             now, last_live_times, update_time)
-        new_health = self.stack.dyn_healthy_info
-        if prev_health != new_health:
-            health = 'HEALTHY' if self.stack.dyn_healthy else 'UNHEALTHY'
+        if prev_health != self.stack.dyn_healthy_info:
+            health = 'HEALTHY' if new_health else 'UNHEALTHY'
             self.logger.info('Stack node %s %s (%s)' % (self.stack.name, health, reason))
-        new_health = self.stack.dyn_healthy
         return new_health
 
     def nominate_stack_root(self, root_valve, other_valves, now, last_live_times, update_time):
@@ -276,8 +274,14 @@ This includes port nominations and flood directionality."""
                 _, new_root_name = stacks[0].nominate_stack_root(stacks)
         else:
             # No healthy stack roots, so forced to choose a bad root
-            stacks = [valve.dp.stack for valve in unhealthy_valves]
-            _, new_root_name = stacks[0].nominate_stack_root(stacks)
+            new_root_name = None
+            if root_valve:
+                # Current root is unhealthy along with all other roots, so keep root the same
+                new_root_name = root_valve.dp.name
+            if root_valve not in unhealthy_valves:
+                # Pick the best unhealthy root
+                stacks = [valve.dp.stack for valve in unhealthy_valves]
+                _, new_root_name = stacks[0].nominate_stack_root(stacks)
 
         return new_root_name
 

--- a/faucet/valves_manager.py
+++ b/faucet/valves_manager.py
@@ -266,7 +266,7 @@ class ValvesManager:
             if dp_id in self.valves:
                 self.logger.info('Reconfiguring existing datapath %s', dpid_log(dp_id))
                 valve = self.valves[dp_id]
-                ofmsgs = valve.reload_config(now, new_dp)
+                ofmsgs = valve.reload_config(now, new_dp, list(self.valves.values()))
                 self.send_flows_to_dp_by_id(valve, ofmsgs)
                 sent[dp_id] = valve.dp.dyn_running
             else:

--- a/tests/generative/unit/test_topology.py
+++ b/tests/generative/unit/test_topology.py
@@ -74,6 +74,7 @@ class ValveGenerativeBase(ValveTestBases.ValveTestNetwork):
         link_vlans = {link: None for link in switch_links}
         topo = FaucetFakeOFTopoGenerator(
             'ovstype', 'portsock', 'testname',
+            self.NUM_DPS, False,
             host_links, host_vlans, switch_links, link_vlans,
             start_port=self.START_PORT, port_order=self.PORT_ORDER,
             get_serialno=self.get_serialno)

--- a/tests/unit/clib/test_topo.py
+++ b/tests/unit/clib/test_topo.py
@@ -39,6 +39,7 @@ class FaucetTopoTest(TestCase):
         expected_ports = [self.START_PORT + port for port in port_order]
         topo = FaucetFakeOFTopoGenerator(
             '', '', '',
+            2, False,
             host_links, host_vlans, switch_links, link_vlans,
             start_port=self.START_PORT, port_order=port_order,
             get_serialno=self.get_serialno)
@@ -60,6 +61,7 @@ class FaucetTopoTest(TestCase):
         expected_ports = [start_port + port for port in port_order]
         topo = FaucetFakeOFTopoGenerator(
             '', '', '',
+            2, False,
             host_links, host_vlans, switch_links, link_vlans,
             start_port=start_port, port_order=port_order,
             get_serialno=self.get_serialno)
@@ -80,6 +82,7 @@ class FaucetTopoTest(TestCase):
         hw_ports = {1: 'p1', 2: 'p2', 3: 'p3', 4: 'p4', 5: 'p5', 6: 'p6'}
         topo = FaucetFakeOFTopoGenerator(
             '', '', '',
+            2, False,
             host_links, host_vlans, switch_links, link_vlans,
             hw_dpid=hw_dpid, hw_ports=hw_ports,
             start_port=self.START_PORT, port_order=self.PORT_ORDER,
@@ -95,6 +98,7 @@ class FaucetTopoTest(TestCase):
         link_vlans = {}
         topo = FaucetFakeOFTopoGenerator(
             '', '', '',
+            2, False,
             host_links, host_vlans, switch_links, link_vlans,
             start_port=self.START_PORT, port_order=self.PORT_ORDER,
             get_serialno=self.get_serialno)
@@ -113,6 +117,7 @@ class FaucetTopoTest(TestCase):
         link_vlans = {(0, 1): [0, 1]}
         topo = FaucetFakeOFTopoGenerator(
             '', '', '',
+            2, False,
             host_links, host_vlans, switch_links, link_vlans,
             start_port=self.START_PORT, port_order=self.PORT_ORDER,
             get_serialno=self.get_serialno)
@@ -142,6 +147,7 @@ class FaucetTopoTest(TestCase):
         link_vlans = {}
         topo = FaucetFakeOFTopoGenerator(
             '', '', '',
+            2, False,
             host_links, host_vlans, switch_links, link_vlans,
             host_options=host_options,
             start_port=self.START_PORT, port_order=self.PORT_ORDER,
@@ -160,6 +166,7 @@ class FaucetTopoTest(TestCase):
         link_vlans = {edge: None for edge in switch_links}
         topo = FaucetFakeOFTopoGenerator(
             '', '', '',
+            2, False,
             host_links, host_vlans, switch_links, link_vlans,
             start_port=self.START_PORT, port_order=self.PORT_ORDER,
             get_serialno=self.get_serialno)
@@ -176,6 +183,7 @@ class FaucetTopoTest(TestCase):
         link_vlans = {edge: None for edge in switch_links}
         topo = FaucetFakeOFTopoGenerator(
             '', '', '',
+            2, False,
             host_links, host_vlans, switch_links, link_vlans,
             start_port=self.START_PORT, port_order=self.PORT_ORDER,
             get_serialno=self.get_serialno)

--- a/tests/unit/faucet/test_valve_stack.py
+++ b/tests/unit/faucet/test_valve_stack.py
@@ -932,6 +932,7 @@ class ValveStackRedundancyTestCase(ValveTestBases.ValveTestNetwork):
     def test_redundancy(self):
         """Test redundant stack connections"""
         now = 1
+        import sys
         self.trigger_stack_ports()
         # All switches are down to start with.
         for dpid in self.valves_manager.valves:
@@ -960,12 +961,14 @@ class ValveStackRedundancyTestCase(ValveTestBases.ValveTestNetwork):
         self.assertEqual(1, self.get_prom('faucet_stack_root_dpid', bare=True))
         self.assertTrue(self.get_prom('is_dp_stack_root', dp_id=1))
         self.assertFalse(self.get_prom('is_dp_stack_root', dp_id=2))
-        # s2 has come up, but has all stack ports down and but s1 is still down.
+        # s2 has come up, but has all stack ports down and s1 is still down.
         self.valves_manager.meta_dp_state.dp_last_live_time['s2'] = now
         now += (self.STACK_ROOT_STATE_UPDATE_TIME * 2)
         # No change because s2 still isn't healthy.
+        sys.stderr.write('\nFAIL HERE??\n')
         self.assertFalse(
             self.valves_manager.maintain_stack_root(now, self.STACK_ROOT_STATE_UPDATE_TIME))
+        sys.stderr.write('PASSED FAIL\n')
         # We expect s2 to be the new root because now it has stack links up.
         self.set_stack_all_ports_status('s2', STACK_STATE_UP)
         now += (self.STACK_ROOT_STATE_UPDATE_TIME * 2)
@@ -2867,23 +2870,17 @@ dps:
                     port.stack_up()
         last_live_times = {'sw1': 100, 'sw2': 100, 'sw3': 100}
         self.assertTrue(dps[0].stack.update_health(
-            110, last_live_times, self.UPDATE_TIME,
-            dps[0].lacp_down_ports(), dp.stack.down_ports())[0])
+            110, last_live_times, self.UPDATE_TIME)[0])
         self.assertFalse(dps[0].stack.update_health(
-            120, last_live_times, self.UPDATE_TIME,
-            dps[0].lacp_down_ports(), dp.stack.down_ports())[0])
+            120, last_live_times, self.UPDATE_TIME)[0])
         self.assertTrue(dps[1].stack.update_health(
-            110, last_live_times, self.UPDATE_TIME,
-            dps[1].lacp_down_ports(), dp.stack.down_ports())[0])
+            110, last_live_times, self.UPDATE_TIME)[0])
         self.assertFalse(dps[1].stack.update_health(
-            130, last_live_times, self.UPDATE_TIME,
-            dps[1].lacp_down_ports(), dp.stack.down_ports())[0])
+            130, last_live_times, self.UPDATE_TIME)[0])
         self.assertTrue(dps[2].stack.update_health(
-            110, last_live_times, self.UPDATE_TIME,
-            dps[2].lacp_down_ports(), dp.stack.down_ports())[0])
+            110, last_live_times, self.UPDATE_TIME)[0])
         self.assertFalse(dps[2].stack.update_health(
-            140, last_live_times, self.UPDATE_TIME,
-            dps[2].lacp_down_ports(), dp.stack.down_ports())[0])
+            140, last_live_times, self.UPDATE_TIME)[0])
 
     def test_lacp_down(self):
         """Test stack health on LACP ports being DOWN"""
@@ -2897,26 +2894,21 @@ dps:
                     port.stack_up()
         last_live_times = {'sw1': 100, 'sw2': 100, 'sw3': 100}
         self.assertTrue(dps[0].stack.update_health(
-            110, last_live_times, self.UPDATE_TIME,
-            dps[0].lacp_down_ports(), dps[0].stack.down_ports())[0])
+            110, last_live_times, self.UPDATE_TIME)[0])
         for port in dps[0].ports.values():
             if port.lacp:
                 port.actor_notconfigured()
         self.assertFalse(dps[0].stack.update_health(
-            110, last_live_times, self.UPDATE_TIME,
-            dps[0].lacp_down_ports(), dps[0].stack.down_ports())[0])
+            110, last_live_times, self.UPDATE_TIME)[0])
         self.assertTrue(dps[1].stack.update_health(
-            110, last_live_times, self.UPDATE_TIME,
-            dps[1].lacp_down_ports(), dps[1].stack.down_ports())[0])
+            110, last_live_times, self.UPDATE_TIME)[0])
         for port in dps[1].ports.values():
             if port.lacp:
                 port.actor_nosync()
         self.assertFalse(dps[1].stack.update_health(
-            110, last_live_times, self.UPDATE_TIME,
-            dps[1].lacp_down_ports(), dps[1].stack.down_ports())[0])
+            110, last_live_times, self.UPDATE_TIME)[0])
         self.assertTrue(dps[2].stack.update_health(
-            110, last_live_times, self.UPDATE_TIME,
-            dps[2].lacp_down_ports(), dps[2].stack.down_ports())[0])
+            110, last_live_times, self.UPDATE_TIME)[0])
 
     def test_stack_port_down(self):
         """Test stack health on stack ports being DOWN"""
@@ -2930,32 +2922,390 @@ dps:
                     port.stack_up()
         last_live_times = {'sw1': 100, 'sw2': 100, 'sw3': 100}
         self.assertTrue(dps[0].stack.update_health(
-            110, last_live_times, self.UPDATE_TIME,
-            dps[0].lacp_down_ports(), dps[0].stack.down_ports())[0])
+            110, last_live_times, self.UPDATE_TIME)[0])
         for port in dps[0].ports.values():
             if port.stack:
                 port.stack_bad()
         self.assertFalse(dps[0].stack.update_health(
-            110, last_live_times, self.UPDATE_TIME,
-            dps[0].lacp_down_ports(), dps[0].stack.down_ports())[0])
+            110, last_live_times, self.UPDATE_TIME)[0])
         self.assertTrue(dps[1].stack.update_health(
-            110, last_live_times, self.UPDATE_TIME,
-            dps[1].lacp_down_ports(), dps[1].stack.down_ports())[0])
+            110, last_live_times, self.UPDATE_TIME)[0])
         for port in dps[1].ports.values():
             if port.stack:
                 port.stack_gone()
         self.assertFalse(dps[1].stack.update_health(
-            110, last_live_times, self.UPDATE_TIME,
-            dps[1].lacp_down_ports(), dps[1].stack.down_ports())[0])
+            110, last_live_times, self.UPDATE_TIME)[0])
         self.assertTrue(dps[2].stack.update_health(
-            110, last_live_times, self.UPDATE_TIME,
-            dps[2].lacp_down_ports(), dps[2].stack.down_ports())[0])
+            110, last_live_times, self.UPDATE_TIME)[0])
         for port in dps[2].ports.values():
             if port.stack:
                 port.stack_admin_down()
         self.assertFalse(dps[2].stack.update_health(
-            110, last_live_times, self.UPDATE_TIME,
-            dps[2].lacp_down_ports(), dps[2].stack.down_ports())[0])
+            110, last_live_times, self.UPDATE_TIME)[0])
+
+
+class ValveVariableRootHealthTest(ValveTestBases.ValveTestNetwork):
+    """Test stack root health metrics"""
+
+    UPDATE_TIME = 10
+
+    CONFIG = """
+vlans:
+    vlan100:
+        vid: 100
+dps:
+    sw1:
+        hardware: 'GenericTFM'
+        dp_id: 1
+        stack: {priority: 1, down_time_multiple: 1, min_stack_health: 0.5, min_lacp_health: 0.1}
+        interfaces:
+            1:
+                native_vlan: vlan100
+            2:
+                stack: {dp: sw2, port: 2}
+            3:
+                stack: {dp: sw3, port: 2}
+            4:
+                native_vlan: vlan100
+                lacp: 1
+            5:
+                native_vlan: vlan100
+                lacp: 1
+            6:
+                stack: {dp: sw2, port: 3}
+            7:
+                stack: {dp: sw3, port: 3}
+    sw2:
+        hardware: 'GenericTFM'
+        dp_id: 2
+        stack: {priority: 2, down_time_multiple: 2, min_stack_health: 0.1, min_lacp_health: 0.5}
+        interfaces:
+            1:
+                native_vlan: vlan100
+            2:
+                stack: {dp: sw1, port: 2}
+            3:
+                stack: {dp: sw1, port: 6}
+            4:
+                native_vlan: vlan100
+                lacp: 1
+            5:
+                native_vlan: vlan100
+                lacp: 1
+            6:
+                native_vlan: vlan100
+                lacp: 2
+            7:
+                native_vlan: vlan100
+                lacp: 2
+    sw3:
+        hardware: 'GenericTFM'
+        dp_id: 3
+        interfaces:
+            1:
+                native_vlan: vlan100
+            2:
+                stack: {dp: sw1, port: 3}
+            3:
+                stack: {dp: sw1, port: 7}
+"""
+
+    def setUp(self):
+        """Start network for test"""
+        self.setup_valves(self.CONFIG)
+
+    def other_valves(self, root_valve):
+        return [valve for valve in self.valves_manager.valves.values() if valve != root_valve]
+
+    def test_sw3_lacp(self):
+        """Test LACP health metrics with SW3"""
+        dps = [valve.dp for valve in self.valves_manager.valves.values()]
+        for dp in dps:
+            for port in dp.ports.values():
+                if port.lacp:
+                    port.actor_up()
+                    port.select_port()
+                if port.stack:
+                    port.stack_up()
+        last_live_times = {'sw1': 100, 'sw2': 100, 'sw3': 100}
+        # SW3 has no LACP ports, so LACP health percentage should be 0.0,
+        #   but overall should be considered healthy
+        dps[2].stack.update_health(100, last_live_times, self.UPDATE_TIME)
+        self.assertEqual(dps[2].stack.dyn_healthy_info[2], 0.0)
+        self.assertTrue(dps[2].stack.dyn_healthy)
+
+    def test_sw1_lacp_down(self):
+        """Test LACP health metrics with SW1"""
+        dps = [valve.dp for valve in self.valves_manager.valves.values()]
+        for dp in dps:
+            for port in dp.ports.values():
+                if port.lacp:
+                    port.actor_up()
+                    port.select_port()
+                if port.stack:
+                    port.stack_up()
+        last_live_times = {'sw1': 100, 'sw2': 100, 'sw3': 100}
+        # Take down some LACP ports, health percentage configured so
+        #   SW1 will still be healthy
+        for port in dps[0].ports.values():
+            if port.lacp:
+                port.actor_nosync()
+                port.deselect_port()
+                break
+        dps[0].stack.update_health(100, last_live_times, self.UPDATE_TIME)
+        self.assertEqual(dps[0].stack.dyn_healthy_info[2], 0.5)
+        self.assertTrue(dps[0].stack.dyn_healthy)
+        # Take down the remaining LACP ports, now unhealthy
+        for port in dps[0].ports.values():
+            if port.lacp:
+                port.actor_nosync()
+                port.deselect_port()
+        dps[0].stack.update_health(100, last_live_times, self.UPDATE_TIME)
+        self.assertEqual(dps[0].stack.dyn_healthy_info[2], 0.0)
+        self.assertFalse(dps[0].stack.dyn_healthy)
+
+    def test_sw2_lacp_down(self):
+        """Test LACP health metrics with SW2"""
+        dps = [valve.dp for valve in self.valves_manager.valves.values()]
+        for dp in dps:
+            for port in dp.ports.values():
+                if port.lacp:
+                    port.actor_up()
+                    port.select_port()
+                if port.stack:
+                    port.stack_up()
+        last_live_times = {'sw1': 100, 'sw2': 100, 'sw3': 100}
+        # Take down some LACP ports, health percentage configured
+        #   so SW2 will still be healthy
+        for port_num in [4, 5]:
+            port = dps[1].ports[port_num]
+            if port.lacp:
+                port.actor_nosync()
+                port.deselect_port()
+        dps[1].stack.update_health(100, last_live_times, self.UPDATE_TIME)
+        self.assertEqual(dps[1].stack.dyn_healthy_info[2], 0.5)
+        self.assertTrue(dps[1].stack.dyn_healthy)
+        # Take down the remaining LACP ports
+        for port_num in [6]:
+            port = dps[1].ports[port_num]
+            if port.lacp:
+                port.actor_nosync()
+                port.deselect_port()
+        dps[1].stack.update_health(100, last_live_times, self.UPDATE_TIME)
+        self.assertEqual(dps[1].stack.dyn_healthy_info[2], 0.25)
+        self.assertFalse(dps[1].stack.dyn_healthy)
+
+    def test_sw1_stack_down(self):
+        """Test stack health metrics with SW1"""
+        dps = [valve.dp for valve in self.valves_manager.valves.values()]
+        for dp in dps:
+            for port in dp.ports.values():
+                if port.lacp:
+                    port.actor_up()
+                    port.select_port()
+                if port.stack:
+                    port.stack_up()
+        last_live_times = {'sw1': 100, 'sw2': 100, 'sw3': 100}
+        # All switches running, stack and LACP UP
+        for port_num in [2, 3]:
+            port = dps[0].ports[port_num]
+            if port.stack:
+                port.stack_bad()
+        dps[0].stack.update_health(100, last_live_times, self.UPDATE_TIME)
+        self.assertEqual(dps[0].stack.dyn_healthy_info[1], 0.5)
+        self.assertTrue(dps[0].stack.dyn_healthy)
+        for port_num in [6]:
+            port = dps[0].ports[port_num]
+            if port.stack:
+                port.stack_bad()
+        dps[0].stack.update_health(100, last_live_times, self.UPDATE_TIME)
+        self.assertEqual(dps[0].stack.dyn_healthy_info[1], 0.25)
+        self.assertFalse(dps[0].stack.dyn_healthy)
+
+    def test_sw2_stack_down(self):
+        """Test stack health metrics with SW2"""
+        dps = [valve.dp for valve in self.valves_manager.valves.values()]
+        for dp in dps:
+            for port in dp.ports.values():
+                if port.lacp:
+                    port.actor_up()
+                    port.select_port()
+                if port.stack:
+                    port.stack_up()
+        last_live_times = {'sw1': 100, 'sw2': 100, 'sw3': 100}
+        # All switches running, stack and LACP UP
+        for port_num in [2]:
+            port = dps[1].ports[port_num]
+            if port.stack:
+                port.stack_bad()
+        dps[1].stack.update_health(100, last_live_times, self.UPDATE_TIME)
+        self.assertEqual(dps[1].stack.dyn_healthy_info[1], 0.5)
+        self.assertTrue(dps[1].stack.dyn_healthy)
+        for port_num in [3]:
+            port = dps[1].ports[port_num]
+            if port.stack:
+                port.stack_bad()
+        dps[1].stack.update_health(100, last_live_times, self.UPDATE_TIME)
+        self.assertEqual(dps[1].stack.dyn_healthy_info[1], 0.0)
+        self.assertFalse(dps[1].stack.dyn_healthy)
+
+
+class ValveRootVariableNominationTest(ValveStackHealthTest):
+    """Test ValveStackManager root nomination calculations"""
+
+    UPDATE_TIME = 10
+
+    CONFIG = """
+vlans:
+    vlan100:
+        vid: 100
+dps:
+    sw1:
+        hardware: 'GenericTFM'
+        dp_id: 1
+        stack: {priority: 1, down_time_multiple: 1, min_stack_health: 0.5, min_lacp_health: 0.1}
+        interfaces:
+            1:
+                native_vlan: vlan100
+            2:
+                stack: {dp: sw2, port: 2}
+            3:
+                stack: {dp: sw3, port: 2}
+            4:
+                native_vlan: vlan100
+                lacp: 1
+            5:
+                native_vlan: vlan100
+                lacp: 1
+            6:
+                stack: {dp: sw2, port: 3}
+            7:
+                stack: {dp: sw3, port: 3}
+    sw2:
+        hardware: 'GenericTFM'
+        dp_id: 2
+        stack: {priority: 2, down_time_multiple: 2, min_stack_health: 0.1, min_lacp_health: 0.5}
+        interfaces:
+            1:
+                native_vlan: vlan100
+            2:
+                stack: {dp: sw1, port: 2}
+            3:
+                stack: {dp: sw1, port: 6}
+            4:
+                native_vlan: vlan100
+                lacp: 1
+            5:
+                native_vlan: vlan100
+                lacp: 1
+            6:
+                native_vlan: vlan100
+                lacp: 2
+            7:
+                native_vlan: vlan100
+                lacp: 2
+    sw3:
+        hardware: 'GenericTFM'
+        dp_id: 3
+        interfaces:
+            1:
+                native_vlan: vlan100
+            2:
+                stack: {dp: sw1, port: 3}
+            3:
+                stack: {dp: sw1, port: 7}
+"""
+
+    def setUp(self):
+        """Start network for test"""
+        self.setup_valves(self.CONFIG)
+
+    def other_valves(self, root_valve):
+        return [valve for valve in self.valves_manager.valves.values() if valve != root_valve]
+
+    def test_lacp_root_nomination(self):
+        """Test root selection health"""
+        dps = [valve.dp for valve in self.valves_manager.valves.values()]
+        for dp in dps:
+            for port in dp.ports.values():
+                if port.lacp:
+                    port.actor_up()
+                    port.select_port()
+                if port.stack:
+                    port.stack_up()
+        valves = self.valves_manager.valves
+        last_live_times = {'sw1': 100, 'sw2': 100, 'sw3': 100}
+        # Start not root currently selected, all valves should select root sw1
+        for valve in valves.values():
+            self.assertEqual(valve.stack_manager.nominate_stack_root(
+                None, list(valves.values()), 100, last_live_times, self.UPDATE_TIME), 'sw1')
+        # Create some LACP ports DOWN, but maintain above the health threshold, Equal percentage
+        #   of LACP ports taken down so LACP stays the same
+        for port_num in [4]:
+            port = dps[0].ports[port_num]
+            port.actor_nosync()
+        for port_num in [4, 5]:
+            port = dps[1].ports[port_num]
+            port.actor_nosync()
+        for valve in valves.values():
+            self.assertEqual(valve.stack_manager.nominate_stack_root(
+                None, list(valves.values()), 100, last_live_times, self.UPDATE_TIME), 'sw1')
+        # Change it so SW2 has greater percentage of LACP ports UP, so should be elected
+        for port_num in [4]:
+            port = dps[1].ports[port_num]
+            port.actor_up()
+        for valve in valves.values():
+            self.assertEqual(valve.stack_manager.nominate_stack_root(
+                None, list(valves.values()), 100, last_live_times, self.UPDATE_TIME), 'sw2')
+        # Stats of Sw1 and Sw2 the same, should choose lower priority: SW1
+        for port_num in [4]:
+            port = dps[1].ports[port_num]
+            port.actor_nosync()
+        for valve in valves.values():
+            self.assertEqual(valve.stack_manager.nominate_stack_root(
+                None, list(valves.values()), 100, last_live_times, self.UPDATE_TIME), 'sw1')
+        # SW2 considered DOWN, so should only nominate SW1
+        for port_num in [4, 5]:
+            port = dps[1].ports[port_num]
+            port.actor_nosync()
+        for valve in valves.values():
+            self.assertEqual(valve.stack_manager.nominate_stack_root(
+                None, list(valves.values()), 100, last_live_times, self.UPDATE_TIME), 'sw1')
+
+    def test_stack_root_nomination(self):
+        """Test root selection health"""
+        dps = [valve.dp for valve in self.valves_manager.valves.values()]
+        for dp in dps:
+            for port in dp.ports.values():
+                if port.lacp:
+                    port.actor_up()
+                    port.select_port()
+                if port.stack:
+                    port.stack_up()
+        valves = self.valves_manager.valves
+        last_live_times = {'sw1': 100, 'sw2': 100, 'sw3': 100}
+        # Start not root currently selected, all valves should select root sw1
+        for valve in valves.values():
+            self.assertEqual(valve.stack_manager.nominate_stack_root(
+                None, list(valves.values()), 100, last_live_times, self.UPDATE_TIME), 'sw1')
+        # Create some stack ports DOWN, but maintain above the health threshold, Equal percentage
+        #   of stack ports taken down so stack stays the same
+        for port_num in [2]:
+            port = dps[1].ports[port_num]
+            port.stack_bad()
+        for port_num in [2, 3]:
+            port = dps[0].ports[port_num]
+            port.stack_bad()
+        for valve in valves.values():
+            self.assertEqual(valve.stack_manager.nominate_stack_root(
+                None, list(valves.values()), 100, last_live_times, self.UPDATE_TIME), 'sw1')
+        # Change it so SW2 has greater percentage of stack ports UP, so should be elected
+        for port_num in [2]:
+            port = dps[1].ports[port_num]
+            port.stack_up()
+        for valve in valves.values():
+            self.assertEqual(valve.stack_manager.nominate_stack_root(
+                None, list(valves.values()), 100, last_live_times, self.UPDATE_TIME), 'sw2')
 
 
 class ValveRootNominationTest(ValveStackHealthTest):


### PR DESCRIPTION
`min_stack_health` & `min_lacp_health` are just additional configuration options for deciding if a stack node is healthy.

We now keep track of the individual health percentages so deciding the best root candidate is easier. We choose a root by sorting a list of tuples taking favour of healthy nodes, followed by the highest health percentages, lastly followed by the priority.