### PR TITLE
Flush varz and trigger expire event when vlan host caches get cleared

### DIFF
--- a/tests/integration/mininet_tests.py
+++ b/tests/integration/mininet_tests.py
@@ -3450,7 +3450,7 @@ class FaucetConfigReloadAclTest(FaucetConfigReloadTestBase):
         self.verify_tp_dst_blocked(5003, first_host, second_host)
 
 
-class FaucetConfigReloadMACExpireTest(FaucetConfigReloadTestBase):
+class FaucetConfigReloadMACFlushTest(FaucetConfigReloadTestBase):
 
     def test_port_change_vlan(self):
         self.ping_all_when_learned()

--- a/tests/integration/mininet_tests.py
+++ b/tests/integration/mininet_tests.py
@@ -3426,6 +3426,8 @@ class FaucetConfigReloadAclTest(FaucetConfigReloadTestBase):
                 acl_in: deny
 """
 
+    STAT_RELOAD = '1'
+
     def _verify_hosts_learned(self, hosts):
         self.pingAll()
         for host in hosts:
@@ -3448,6 +3450,28 @@ class FaucetConfigReloadAclTest(FaucetConfigReloadTestBase):
         self.verify_tp_dst_blocked(5001, first_host, second_host)
         self.verify_tp_dst_notblocked(5002, first_host, second_host)
         self.verify_tp_dst_blocked(5003, first_host, second_host)
+
+
+class FaucetConfigReloadMACExpireTest(FaucetConfigReloadTestBase):
+
+    def test_port_change_vlan(self):
+        self.ping_all_when_learned()
+        self.assertEqual(4, len(self.scrape_prometheus(var='learned_l2_port')))
+        self.change_port_config(
+            self.port_map['port_1'], 'native_vlan', 200,
+            restart=False, cold_start=False)
+        self.wait_until_matching_flow(
+            {'vlan_vid': 200}, table_id=self._ETH_SRC_TABLE,
+            actions=['OUTPUT:CONTROLLER', 'GOTO_TABLE:%u' % self._ETH_DST_TABLE])
+        self.change_port_config(
+            self.port_map['port_2'], 'native_vlan', 200,
+            restart=True, cold_start=False)
+        for port_name in ('port_1', 'port_2'):
+            self.wait_until_matching_flow(
+                {'in_port': int(self.port_map[port_name])},
+                table_id=self._VLAN_TABLE,
+                actions=['SET_FIELD: {vlan_vid:4296}'])
+        self.assertEqual(0, len(self.scrape_prometheus(var='learned_l2_port')))
 
 
 class FaucetConfigReloadEmptyAclTest(FaucetConfigReloadTestBase):

--- a/tests/integration/mininet_tests.py
+++ b/tests/integration/mininet_tests.py
@@ -3426,8 +3426,6 @@ class FaucetConfigReloadAclTest(FaucetConfigReloadTestBase):
                 acl_in: deny
 """
 
-    STAT_RELOAD = '1'
-
     def _verify_hosts_learned(self, hosts):
         self.pingAll()
         for host in hosts:


### PR DESCRIPTION
Forch relies on varz and events to maintain a cache of learned MAC entries. The PR makes sure that the respective varz are flushed and events triggered when the VLAN caches are flushed on config change.