### PR TITLE
Don't use time.time in unit tests

### DIFF
--- a/clib/valve_test_lib.py
+++ b/clib/valve_test_lib.py
@@ -884,11 +884,11 @@ class ValveTestBases:
 
         def disconnect_dp(self):
             valve = self.valves_manager.valves[self.DP_ID]
-            valve.datapath_disconnect(time.time())
+            valve.datapath_disconnect(self.mock_time())
 
         def cold_start_stack(self):
             """Cold-start entire stack"""
-            self.valves_manager.reload_stack_root_config(self, time.time())
+            self.valves_manager.reload_stack_root_config(self, self.mock_time())
 
         def cold_start(self, dp_id=None):
             """
@@ -901,7 +901,7 @@ class ValveTestBases:
             if dp_id is None:
                 dp_id = self.DP_ID
             valve = self.valves_manager.valves[dp_id]
-            valve.datapath_disconnect(time.time())
+            valve.datapath_disconnect(self.mock_time())
             return self.connect_dp(dp_id)
 
         def get_prom(self, var, labels=None, bare=False, dp_id=None):
@@ -1444,7 +1444,7 @@ class ValveTestBases:
             """Test disconnection of DP from controller."""
             valve = self.valves_manager.valves[self.DP_ID]
             self.assertEqual(1, int(self.get_prom('dp_status')))
-            self.prom_inc(partial(valve.datapath_disconnect, time.time()), 'of_dp_disconnections_total')
+            self.prom_inc(partial(valve.datapath_disconnect, self.mock_time()), 'of_dp_disconnections_total')
             self.assertEqual(0, int(self.get_prom('dp_status')))
 
         def test_unexpected_port(self):
@@ -2306,7 +2306,7 @@ meters:
             valve = self.valves_manager.valves[self.DP_ID]
             for port_status in (0, 1):
                 self.apply_ofmsgs(valve.port_status_handler(
-                    1, ofp.OFPPR_MODIFY, port_status, [], time.time())[valve])
+                    1, ofp.OFPPR_MODIFY, port_status, [], self.mock_time())[valve])
 
         def test_unknown_port_status(self):
             """Test unknown port status message."""
@@ -2315,7 +2315,7 @@ meters:
             unknown_messages = list(set(range(0, len(known_messages) + 1)) - known_messages)
             self.assertTrue(unknown_messages)
             self.assertFalse(valve.port_status_handler(
-                1, unknown_messages[0], 1, [], time.time()).get(valve, []))
+                1, unknown_messages[0], 1, [], self.mock_time()).get(valve, []))
 
         def test_move_port(self):
             """Test host moves a port."""

--- a/clib/valve_test_lib.py
+++ b/clib/valve_test_lib.py
@@ -886,10 +886,6 @@ class ValveTestBases:
             valve = self.valves_manager.valves[self.DP_ID]
             valve.datapath_disconnect(self.mock_time())
 
-        def cold_start_stack(self):
-            """Cold-start entire stack"""
-            self.valves_manager.reload_stack_root_config(self, self.mock_time())
-
         def cold_start(self, dp_id=None):
             """
             Cold start a DP

--- a/clib/valve_test_lib.py
+++ b/clib/valve_test_lib.py
@@ -886,6 +886,10 @@ class ValveTestBases:
             valve = self.valves_manager.valves[self.DP_ID]
             valve.datapath_disconnect(time.time())
 
+        def cold_start_stack(self):
+            """Cold-start entire stack"""
+            self.valves_manager.reload_stack_root_config(self, time.time())
+
         def cold_start(self, dp_id=None):
             """
             Cold start a DP

--- a/clib/valve_test_lib.py
+++ b/clib/valve_test_lib.py
@@ -29,7 +29,6 @@ import pstats
 import shutil
 import socket
 import tempfile
-import time
 import unittest
 import yaml
 

--- a/tests/unit/faucet/test_valve_stack.py
+++ b/tests/unit/faucet/test_valve_stack.py
@@ -407,6 +407,7 @@ dps:
         valve = self.valves_manager.valves[0x1]
         other_valves = self.get_other_valves(valve)
         port = valve.dp.ports[3]
+        print('TAP port is %s' % port)
         # Make sure LACP state has been updated
         self.assertTrue(valve.lacp_update(port, True, 1, 1, other_valves), 'No OFMSGS returned')
         self.assertTrue(port.is_actor_up(), 'Actor not UP')
@@ -415,6 +416,8 @@ dps:
         self.assertTrue(port.is_actor_none(), 'Actor not NONE')
         # Restart switch & LACP port
         self.cold_start()
+        print('TAP port is %s/%s' % (port, self.valves_manager.valves[0x1].dp.ports[3]))
+        # TAP try cold_start here
         self.assertTrue(valve.port_add(3), 'No OFMSGS returned')
         # Successfully restart LACP from downed
         self.assertTrue(valve.lacp_update(port, True, 1, 1, other_valves), 'No OFMSGS returned')

--- a/tests/unit/faucet/test_valve_stack.py
+++ b/tests/unit/faucet/test_valve_stack.py
@@ -407,7 +407,6 @@ dps:
         valve = self.valves_manager.valves[0x1]
         other_valves = self.get_other_valves(valve)
         port = valve.dp.ports[3]
-        print('TAP port is %s' % id(port))
         # Make sure LACP state has been updated
         self.assertTrue(valve.lacp_update(port, True, 1, 1, other_valves), 'No OFMSGS returned')
         self.assertTrue(port.is_actor_up(), 'Actor not UP')
@@ -415,8 +414,7 @@ dps:
         valve.port_delete(3, other_valves=other_valves)
         self.assertTrue(port.is_actor_none(), 'Actor not NONE')
         # Restart switch & LACP port
-        self.cold_start_stack()
-        print('TAP port is %s/%s' % (id(port), id(self.valves_manager.valves[0x1].dp.ports[3])))
+        self.cold_start()
         self.assertTrue(valve.port_add(3), 'No OFMSGS returned')
         # Successfully restart LACP from downed
         self.assertTrue(valve.lacp_update(port, True, 1, 1, other_valves), 'No OFMSGS returned')

--- a/tests/unit/faucet/test_valve_stack.py
+++ b/tests/unit/faucet/test_valve_stack.py
@@ -407,7 +407,7 @@ dps:
         valve = self.valves_manager.valves[0x1]
         other_valves = self.get_other_valves(valve)
         port = valve.dp.ports[3]
-        print('TAP port is %s' % port)
+        print('TAP port is %s' % id(port))
         # Make sure LACP state has been updated
         self.assertTrue(valve.lacp_update(port, True, 1, 1, other_valves), 'No OFMSGS returned')
         self.assertTrue(port.is_actor_up(), 'Actor not UP')
@@ -416,7 +416,7 @@ dps:
         self.assertTrue(port.is_actor_none(), 'Actor not NONE')
         # Restart switch & LACP port
         self.cold_start()
-        print('TAP port is %s/%s' % (port, self.valves_manager.valves[0x1].dp.ports[3]))
+        print('TAP port is %s/%s' % (id(port), id(self.valves_manager.valves[0x1].dp.ports[3])))
         # TAP try cold_start here
         self.assertTrue(valve.port_add(3), 'No OFMSGS returned')
         # Successfully restart LACP from downed

--- a/tests/unit/faucet/test_valve_stack.py
+++ b/tests/unit/faucet/test_valve_stack.py
@@ -415,9 +415,8 @@ dps:
         valve.port_delete(3, other_valves=other_valves)
         self.assertTrue(port.is_actor_none(), 'Actor not NONE')
         # Restart switch & LACP port
-        self.cold_start()
+        self.cold_start_stack()
         print('TAP port is %s/%s' % (id(port), id(self.valves_manager.valves[0x1].dp.ports[3])))
-        # TAP try cold_start here
         self.assertTrue(valve.port_add(3), 'No OFMSGS returned')
         # Successfully restart LACP from downed
         self.assertTrue(valve.lacp_update(port, True, 1, 1, other_valves), 'No OFMSGS returned')


### PR DESCRIPTION
No specific problem observed, but it's the theory of the thing.
