### PR TITLE
Apt packages shouldn't be installed in docker/runtests.sh.

### DIFF
--- a/.github/workflows/tests-integration.yml
+++ b/.github/workflows/tests-integration.yml
@@ -11,7 +11,7 @@ jobs:
     name: Sanity tests
     runs-on: ubuntu-latest
     container:
-      image: faucet/test-base:8.0.3
+      image: faucet/test-base:8.0.4
       options: --privileged --cap-add=ALL -v /lib/modules:/lib/modules -v /var/local/lib/docker:/var/lib/docker --sysctl net.ipv6.conf.all.disable_ipv6=0 --ulimit core=-1
     steps:
       - name: Checkout repo
@@ -77,7 +77,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: sanity-tests
     container:
-      image: faucet/test-base:8.0.3
+      image: faucet/test-base:8.0.4
       options: --privileged --cap-add=ALL -v /lib/modules:/lib/modules -v /var/local/lib/docker:/var/lib/docker --sysctl net.ipv6.conf.all.disable_ipv6=0 --ulimit core=-1
     strategy:
       matrix:

--- a/Dockerfile.fuzz-config
+++ b/Dockerfile.fuzz-config
@@ -1,6 +1,6 @@
 ## Image name: faucet/config-fuzzer
 
-FROM faucet/test-base:8.0.3
+FROM faucet/test-base:8.0.4
 
 ENV PIP3="pip3 --no-cache-dir install --upgrade"
 ENV PATH="/venv/bin:$PATH"

--- a/Dockerfile.fuzz-packet
+++ b/Dockerfile.fuzz-packet
@@ -1,6 +1,6 @@
 ## Image name: faucet/packet-fuzzer
 
-FROM faucet/test-base:8.0.3
+FROM faucet/test-base:8.0.4
 
 ENV PIP3="pip3 -q --no-cache-dir install --upgrade"
 ENV PATH="/venv/bin:$PATH"

--- a/docker/runtests.sh
+++ b/docker/runtests.sh
@@ -181,8 +181,6 @@ export http_proxy=
 
 if [ "$INTEGRATIONTESTS" == 1 ] ; then
   echo "========== Running faucet integration tests =========="
-  sudo apt-get update -y
-  sudo apt-get install dnsmasq -y
   cd /faucet-src/tests/integration
   ./mininet_main.py -c
 elif [ "$GEN_INT" == 1 ] ; then


### PR DESCRIPTION
We shouldn't install apt packages in docker/runtests.sh as it slows the tests down and requires the test container have network connectivity to an apt mirror.

Revert change that was part of #3697 and install dnsmasq in the test-base image instead.