### PR TITLE
Simplify and make warm starting less impactful, by removing use of table wildcard deletes.

### DIFF
--- a/clib/mininet_test_base.py
+++ b/clib/mininet_test_base.py
@@ -1691,7 +1691,7 @@ dbs:
 
     def change_port_config(self, port, config_name, config_value,
                            conf=None, restart=True, cold_start=False,
-                           hup=True):
+                           hup=True, change_expected=True):
         if conf is None:
             conf = self._get_faucet_conf()
         if config_name is None:
@@ -1703,7 +1703,7 @@ dbs:
                 conf['dps'][self.DP_NAME]['interfaces'][port][config_name] = config_value
         self.reload_conf(
             conf, self.faucet_config_path,
-            restart, cold_start, hup=hup)
+            restart, cold_start, hup=hup, change_expected=change_expected)
 
     def change_vlan_config(self, vlan, config_name, config_value,
                            conf=None, restart=True, cold_start=False,

--- a/faucet/dp.py
+++ b/faucet/dp.py
@@ -1378,16 +1378,6 @@ configuration.
                     changed_acl_ports.add(port_no)
                     logger.info('port %s ACL changed (ACL %s to %s)' % (
                         port_no, old_acl_ids, new_acl_ids))
-            # If any of the changed VLANs have tagged ports we will need to restore their flows,
-            # even if those tagged ports didn't change, as the delete VLAN operation uses
-            # a wildcard delete.
-            for port_no in same_ports:
-                old_port = self.ports[port_no]
-                new_port = new_dp.ports[port_no]
-                for tagged_vlan in new_port.tagged_vlans:
-                    if tagged_vlan.vid in changed_vlans:
-                        logger.info('port %s has a changed tagged VLAN' % port_no)
-                        changed_ports.add(port_no)
 
             if changed_acl_ports:
                 same_ports -= changed_acl_ports

--- a/faucet/valve_pipeline.py
+++ b/faucet/valve_pipeline.py
@@ -144,27 +144,6 @@ class ValvePipeline(ValveManagerBase):
         ofmsgs.extend(self.filter_packets(
             {'eth_type': valve_of.ECTP_ETH_TYPE}, priority_offset=10))
 
-        ofmsgs.extend(self.add_drop_spoofed_faucet_mac_rules())
-
-        return ofmsgs
-
-    def add_drop_spoofed_faucet_mac_rules(self):
-        """Install rules to drop spoofed faucet mac"""
-        # antispoof for FAUCET's MAC address
-        # TODO: antispoof for controller IPs on this VLAN, too.
-        ofmsgs = []
-        if self.dp.drop_spoofed_faucet_mac:
-            if self.dp.stack_ports:
-                vlan_macs = {vlan.faucet_mac for vlan in self.dp.vlans.values()}
-                for port in self.dp.ports.values():
-                    if not port.stack:
-                        for mac in vlan_macs:
-                            ofmsgs.extend(self.filter_packets(
-                                {'eth_src': mac, 'in_port': port.number}))
-            else:
-                for vlan in list(self.dp.vlans.values()):
-                    ofmsgs.extend(self.filter_packets(
-                        {'eth_src': vlan.faucet_mac}))
         return ofmsgs
 
     def _add_egress_table_rule(self, port, vlan, pop_vlan=True):

--- a/faucet/valve_switch.py
+++ b/faucet/valve_switch.py
@@ -64,6 +64,7 @@ def valve_switch_factory(logger, dp, pipeline, acl_manager, stack_manager):  # p
         'dp_high_priority': dp.high_priority,
         'dp_highest_priority': dp.highest_priority,
         'faucet_dp_mac': dp.faucet_dp_mac,
+        'drop_spoofed_faucet_mac': dp.drop_spoofed_faucet_mac,
     }
 
     if dp.stack:

--- a/faucet/valve_switch_stack.py
+++ b/faucet/valve_switch_stack.py
@@ -264,6 +264,18 @@ class ValveSwitchStackManagerBase(ValveSwitchManager):
         """
         raise NotImplementedError
 
+    def add_drop_spoofed_faucet_mac_rules(self, vlan):
+        """Install rules to drop spoofed faucet mac"""
+        # antispoof for FAUCET's MAC address
+        # TODO: antispoof for controller IPs on this VLAN, too.
+        ofmsgs = []
+        if self.drop_spoofed_faucet_mac:
+            for port in self.ports.values():
+                if not port.stack:
+                    ofmsgs.extend(self.pipeline.filter_packets(
+                        {'eth_src': vlan.faucet_mac, 'in_port': port.number}))
+        return ofmsgs
+
     def add_port(self, port):
         ofmsgs = super().add_port(port)
         # If this is a stacking port, accept all VLANs (came from another FAUCET)

--- a/tests/integration/mininet_multidp_tests.py
+++ b/tests/integration/mininet_multidp_tests.py
@@ -388,7 +388,7 @@ class FaucetStringOfDPLACPUntaggedTest(FaucetMultiDPTestBase):
         interfaces_conf[fail_port]['lacp'] = 0
         interfaces_conf[fail_port]['lacp_active'] = False
         self.reload_conf(conf, self.faucet_config_path, restart=True,
-                         cold_start=False, change_expected=True)
+                         cold_start=False, change_expected=True, dpid=self.dpids[1])
 
         self.wait_for_lacp_port_init(src_port, self.dpids[0], self.topo.switches_by_id[0])
         self.wait_for_lacp_port_up(dst_port, self.dpids[0], self.topo.switches_by_id[0])
@@ -418,7 +418,7 @@ class FaucetStringOfDPLACPUntaggedTest(FaucetMultiDPTestBase):
         interfaces_conf[fail_port]['lacp'] = 0
         interfaces_conf[fail_port]['lacp_active'] = False
         self.reload_conf(conf, self.faucet_config_path, restart=True,
-                         cold_start=False, change_expected=True)
+                         cold_start=False, change_expected=True, dpid=self.dpids[1])
 
         self.wait_for_lacp_port_init(src_port, self.dpids[0], self.topo.switches_by_id[0])
         self.wait_for_lacp_port_up(dst_port, self.dpids[0], self.topo.switches_by_id[0])

--- a/tests/integration/mininet_tests.py
+++ b/tests/integration/mininet_tests.py
@@ -3321,7 +3321,7 @@ class FaucetConfigReloadTest(FaucetConfigReloadTestBase):
         self.ping_all_when_learned()
         self.reload_conf(
             orig_conf, self.faucet_config_path,
-            restart=True, cold_start=False, change_expected=True)
+            restart=True, cold_start=False, change_expected=False)
         self.assertEqual(0, self.scrape_prometheus_var('faucet_config_load_error', dpid=False))
         event = self._wait_until_matching_event(lambda event: event['CONFIG_CHANGE']['success'])
         self.assertEqual(good_config_hash_info, event['CONFIG_CHANGE']['config_hash_info'])
@@ -3521,10 +3521,10 @@ vlans:
         hup = not self.STAT_RELOAD
         self.change_port_config(
             self.port_map['port_3'], 'acls_in', [],
-            restart=True, cold_start=False, hup=hup)
+            restart=True, cold_start=False, hup=hup, change_expected=False)
         self.change_port_config(
             self.port_map['port_1'], 'acls_in', [],
-            restart=True, cold_start=False, hup=hup)
+            restart=True, cold_start=False, hup=hup, change_expected=False)
 
 
 class FaucetConfigStatReloadAclTest(FaucetConfigReloadAclTest):

--- a/tests/unit/faucet/test_valve_config.py
+++ b/tests/unit/faucet/test_valve_config.py
@@ -234,12 +234,8 @@ dps:
         self.setup_valves(self.CONFIG)[self.DP_ID]
 
     def test_port_mirror(self):
-        """Test addition of port mirroring does not cause a del VLAN."""
-        reload_ofmsgs = self.update_config(self.MORE_CONFIG, reload_type='warm')[self.DP_ID]
-        for ofmsg in reload_ofmsgs:
-            if valve_of.is_flowdel(ofmsg):
-                if ofmsg.table_id == valve_of.ofp.OFPTT_ALL and ofmsg.match:
-                    self.assertNotIn('vlan_vid', ofmsg.match, ofmsg)
+        """Test addition of port mirroring is a warm start."""
+        self.update_config(self.MORE_CONFIG, reload_type='warm')[self.DP_ID]
 
 
 class ValveAddPortTestCase(ValveTestBases.ValveTestNetwork):

--- a/tests/unit/faucet/test_valve_stack.py
+++ b/tests/unit/faucet/test_valve_stack.py
@@ -1716,7 +1716,7 @@ dps:
             'Did not encapsulate and forward')
         new_config_yaml = yaml.safe_load(self.CONFIG)
         new_config_yaml['dps']['s1']['interfaces'][1]['description'] = 'changed'
-        self.update_config(yaml.dump(new_config_yaml), reload_type='warm')
+        self.update_config(yaml.dump(new_config_yaml), reload_type=None)
         self.activate_all_ports()
         # warm start with no topo change with tunnel.
         self.validate_tunnel(


### PR DESCRIPTION
* Remove use of table wildcard delete, which is impactful on forwarding and unnecessary.
* Enforce non-use of table wildcard deletes in the future.
* Move maintenance of VLAN antispoofing rules to switch managers, which have the necessary internal knowledge.