### PR TITLE
ACL warm start refactoring and performance improvements, and add missing del_vlan call to valve_route.

### DIFF
--- a/faucet/acl.py
+++ b/faucet/acl.py
@@ -182,10 +182,6 @@ The output action contains a dictionary with the following elements:
     def build(self, meters, vid, port_num):
         """Check that ACL can be built from config."""
 
-        class NullRyuDatapath:
-            """Placeholder Ryu Datapath."""
-            ofproto = valve_of.ofp
-
         self.matches = {}
         self.set_fields = set()
         self.meter = False
@@ -201,10 +197,8 @@ The output action contains a dictionary with the following elements:
                 raise InvalidConfigError(err)
             test_config_condition(not ofmsgs, 'OF messages is empty')
             for ofmsg in ofmsgs:
-                ofmsg.datapath = NullRyuDatapath()
-                ofmsg.set_xid(0)
                 try:
-                    ofmsg.serialize()
+                    valve_of.verify_flowmod(ofmsg)
                 except (KeyError, ValueError) as err:
                     raise InvalidConfigError(err)
                 except Exception as err:

--- a/faucet/dp.py
+++ b/faucet/dp.py
@@ -277,6 +277,7 @@ configuration.
         self.max_hosts_per_resolve_cycle = None
         self.max_resolve_backoff_time = None
         self.meters = None
+        self.all_meters = None
         self.metrics_rate_limit_sec = None
         self.name = None
         self.ofchannel_log = None
@@ -315,6 +316,7 @@ configuration.
         self.lacp_active_ports = []
         self.tables = {}
         self.meters = {}
+        self.all_meters = {}
         self.lldp_beacon = {}
         self.table_sizes = {}
         self.dyn_up_port_nos = set()
@@ -1077,6 +1079,7 @@ configuration.
             if self.tunnel_acls:
                 for tunnel_acl in self.tunnel_acls:
                     tunnel_acl.verify_tunnel_rules()
+            self.all_meters = copy.copy(self.meters)
             for unused_meter in set(self.meters.keys()) - acl_meters:
                 del self.meters[unused_meter]
 

--- a/faucet/dp.py
+++ b/faucet/dp.py
@@ -822,6 +822,7 @@ configuration.
 
         dp_by_name = {}
         vlan_by_name = {}
+        acl_meters = set()
 
         def first_unused_vlan_id(vid):
             """Returns the first unused VID from the starting vid"""
@@ -1007,6 +1008,7 @@ configuration.
             for meter_name in acl.get_meters():
                 test_config_condition(meter_name not in self.meters, (
                     'meter %s is not configured' % meter_name))
+                acl_meters.add(meter_name)
             for port_no in acl.get_mirror_destinations():
                 port = self.ports[port_no]
                 port.output_only = True
@@ -1075,6 +1077,8 @@ configuration.
             if self.tunnel_acls:
                 for tunnel_acl in self.tunnel_acls:
                     tunnel_acl.verify_tunnel_rules()
+            for unused_meter in set(self.meters.keys()) - acl_meters:
+                del self.meters[unused_meter]
 
         def resolve_routers():
             """Resolve VLAN references in routers."""

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -327,7 +327,7 @@ class Valve:
     def _delete_all_valve_flows(self):
         """Delete all flows from all FAUCET tables."""
         ofmsgs = [valve_table.wildcard_table.flowdel()]
-        if self.dp.meters or self.dp.packetin_pps or self.dp.slowpath_pps:
+        if self.dp.all_meters or self.dp.packetin_pps or self.dp.slowpath_pps:
             ofmsgs.append(valve_of.meterdel())
         if self.dp.group_table:
             ofmsgs.append(self.dp.groups.delete_all())
@@ -1316,7 +1316,6 @@ class Valve:
         if restart_type is None:
             self.dp_init(new_dp)
             return restart_type, ofmsgs
-
 
         if deleted_ports:
             ofmsgs.extend(self.ports_delete(deleted_ports))

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -1335,20 +1335,14 @@ class Valve:
                     added_meters.add(meter_key)
             changed_meters -= added_meters
         if deleted_meters:
-            deleted_meter_ids = [self.dp.meters[meter_key].meter_id for meter_key in deleted_meters]
-            ofmsgs.extend([valve_of.meterdel(deleted_meter_id) for deleted_meter_id in deleted_meter_ids])
+            ofmsgs.extend(self.acl_manager.del_meters(deleted_meters))
 
         self.dp_init(new_dp, valves)
 
         if changed_meters:
-            for changed_meter in changed_meters:
-                ofmsgs.append(valve_of.meteradd(
-                    new_dp.meters.get(changed_meter).entry, command=1))
+            ofmsgs.extend(self.acl_manager.change_meters(changed_meters))
         if added_meters:
-            for added_meter in added_meters:
-                ofmsgs.append(valve_of.meteradd(
-                    self.dp.meters.get(added_meter).entry, command=0))
-
+            ofmsgs.extend(self.acl_manager.add_meters(added_meters))
         if added_ports:
             ofmsgs.extend(self.ports_add(added_ports))
         if changed_ports:

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -1334,15 +1334,17 @@ class Valve:
                     deleted_meters.add(meter_key)
                     added_meters.add(meter_key)
             changed_meters -= added_meters
-        if deleted_meters:
-            ofmsgs.extend(self.acl_manager.del_meters(deleted_meters))
+        if self.acl_manager:
+            if deleted_meters:
+                ofmsgs.extend(self.acl_manager.del_meters(deleted_meters))
 
         self.dp_init(new_dp, valves)
 
-        if changed_meters:
-            ofmsgs.extend(self.acl_manager.change_meters(changed_meters))
-        if added_meters:
-            ofmsgs.extend(self.acl_manager.add_meters(added_meters))
+        if self.acl_manager:
+            if changed_meters:
+                ofmsgs.extend(self.acl_manager.change_meters(changed_meters))
+            if added_meters:
+                ofmsgs.extend(self.acl_manager.add_meters(added_meters))
         if added_ports:
             ofmsgs.extend(self.ports_add(added_ports))
         if changed_ports:

--- a/faucet/valve_acl.py
+++ b/faucet/valve_acl.py
@@ -500,15 +500,15 @@ class ValveAclManager(ValveManagerBase):
                 valve_of.output_port(nfv_sw_port_num)]),),
         )
 
-    def del_mab_flow(self, port_num, nfv_sw_port_num, mac):
+    def del_mab_flow(self, port_num, _nfv_sw_port_num, _mac):
         """
         Remove MAB ACL for sending IP Activity to Chewie NFV
             Returns flowmods to send all IP traffic to Chewie
 
         Args:
             port_num (int): Number of port in
-            nfv_sw_port_num(int): Number of port out
-            mac(str): MAC address of the valve/port combo
+            _nfv_sw_port_num(int): Number of port out
+            _mac(str): MAC address of the valve/port combo
 
         """
         return [self.port_acl_table.flowdel(
@@ -571,6 +571,8 @@ class ValveAclManager(ValveManagerBase):
     def del_meters(self, deleted_meters):
         ofmsgs = []
         if deleted_meters:
-            deleted_meter_ids = [self.dp.meters[meter_key].meter_id for meter_key in deleted_meters]
-            ofmsgs.extend([valve_of.meterdel(deleted_meter_id) for deleted_meter_id in deleted_meter_ids])
+            deleted_meter_ids = [
+                self.meters[meter_key].meter_id for meter_key in deleted_meters]
+            ofmsgs.extend([
+                valve_of.meterdel(deleted_meter_id) for deleted_meter_id in deleted_meter_ids])
         return ofmsgs

--- a/faucet/valve_acl.py
+++ b/faucet/valve_acl.py
@@ -549,3 +549,28 @@ class ValveAclManager(ValveManagerBase):
                 self.acl_priority, priority, self.meters,
                 acl.exact_match, in_port, None, acl.dyn_tunnel_rules, source_id, flowdel=True))
         return ofmsgs
+
+    def change_meters(self, changed_meters):
+        """Change existing meters with same name/ID."""
+        ofmsgs = []
+        if changed_meters:
+            for changed_meter in changed_meters:
+                ofmsgs.append(valve_of.meteradd(
+                    self.meters.get(changed_meter).entry, command=1))
+        return ofmsgs
+
+    def add_meters(self, added_meters):
+        """Add new meters."""
+        ofmsgs = []
+        if added_meters:
+            for added_meter in added_meters:
+                ofmsgs.append(valve_of.meteradd(
+                    self.meters.get(added_meter).entry, command=0))
+        return ofmsgs
+
+    def del_meters(self, deleted_meters):
+        ofmsgs = []
+        if deleted_meters:
+            deleted_meter_ids = [self.dp.meters[meter_key].meter_id for meter_key in deleted_meters]
+            ofmsgs.extend([valve_of.meterdel(deleted_meter_id) for deleted_meter_id in deleted_meter_ids])
+        return ofmsgs

--- a/faucet/valve_of.py
+++ b/faucet/valve_of.py
@@ -774,6 +774,20 @@ def flowmod(cookie, command, table_id, priority, out_port, out_group,
         flags=flags)
 
 
+class NullRyuDatapath:
+    """Placeholder Ryu Datapath."""
+    ofproto = ofp
+
+
+@functools.lru_cache()
+def verify_flowmod(flowmod):
+    """Verify flowmod can be serialized."""
+    flowmod.datapath = NullRyuDatapath()
+    # Must be non-zero.
+    flowmod.set_xid(1)
+    flowmod.serialize()
+
+
 def group_act(group_id):
     """Return an action to run a group."""
     return parser.OFPActionGroup(group_id)

--- a/faucet/valve_route.py
+++ b/faucet/valve_route.py
@@ -425,12 +425,11 @@ class ValveRouteManager(ValveManagerBase):
 
     def del_vlan(self, vlan):
         """Delete a VLAN."""
-        return [
-            self.vip_table.flowdel(
-                match=self.vip_table.match(vlan=vlan)),
-            self.fib_table.flowdel(
-                match=self.fib_table.match(vlan=vlan)),
-        ]
+        ofmsgs = []
+        if vlan.faucet_vips_by_ipv:
+            ofmsgs.append(self.fib_table.flowdel(
+                match=self.fib_table.match(vlan=vlan)))
+        return ofmsgs
 
     def _add_resolved_route(self, vlan, ip_gw, ip_dst, eth_dst, is_updated):
         """Return flowmods for enabling routing of a resolved nexthop"""

--- a/faucet/valve_route.py
+++ b/faucet/valve_route.py
@@ -410,6 +410,7 @@ class ValveRouteManager(ValveManagerBase):
         raise NotImplementedError # pragma: no cover
 
     def add_vlan(self, vlan, cold_start):
+        """Add a VLAN."""
         ofmsgs = []
         # add controller IPs if configured.
         for faucet_vip in vlan.faucet_vips_by_ipv(self.IPV):
@@ -421,6 +422,15 @@ class ValveRouteManager(ValveManagerBase):
             ofmsgs.extend(self._add_faucet_fib_to_vip(
                 vlan, priority, faucet_vip, faucet_vip_host))
         return ofmsgs
+
+    def del_vlan(self, vlan):
+        """Delete a VLAN."""
+        return [
+            self.vip_table.flowdel(
+                match=self.vip_table.match(vlan=vlan)),
+            self.fib_table.flowdel(
+                match=self.fib_table.match(vlan=vlan)),
+        ]
 
     def _add_resolved_route(self, vlan, ip_gw, ip_dst, eth_dst, is_updated):
         """Return flowmods for enabling routing of a resolved nexthop"""

--- a/tests/integration/mininet_tests.py
+++ b/tests/integration/mininet_tests.py
@@ -1745,14 +1745,19 @@ class FaucetUntaggedMeterAddTest(FaucetUntaggedMeterParseTest):
                 }
             }
         }]
-        conf['dps'][self.DP_NAME]['interfaces'][self.port_map['port_2']].update({
-            'acls_in': ['lossyacl2'],
-        })
-
+        port_conf = conf['dps'][self.DP_NAME]['interfaces'][self.port_map['port_2']]
+        port_conf['acls_in'] = ['lossyacl2']
         self.reload_conf(
             conf, self.faucet_config_path,
             restart=True, cold_start=True, change_expected=True, hup=True)
         self.wait_until_matching_lines_from_file(
+            r'.+\'meter_id\'\: 2+',
+            self.get_matching_meters_on_dpid(self.dpid))
+        port_conf['acls_in'] = []
+        self.reload_conf(
+            conf, self.faucet_config_path,
+            restart=True, cold_start=True, change_expected=True)
+        self.wait_until_no_matching_lines_from_file(
             r'.+\'meter_id\'\: 2+',
             self.get_matching_meters_on_dpid(self.dpid))
 
@@ -1762,54 +1767,19 @@ class FaucetUntaggedMeterModTest(FaucetUntaggedMeterParseTest):
     def test_untagged(self):
         super(FaucetUntaggedMeterModTest, self).test_untagged()
         conf = self._get_faucet_conf()
-        del conf['acls']
-        conf.update({
-            'meters': {
-                'lossymeter': {
-                    'meter_id': 1,
-                    'entry': {
-                        'flags': ['PKTPS'],
-                        'bands': [{'rate': '1000', 'type': 'DROP'}]
-                    },
-                },
-            },
-            'acls': {
-                'lossyacl': [
-                    {
-                        'rule': {
-                            'actions': {
-                                'allow': 1,
-                                'meter': 'lossymeter'
-                            }
-                        }
-                    }
-                ]
-            }
-        })
-        conf['dps'][self.DP_NAME]['interfaces'][self.port_map['port_1']].update({
-            'acls_in': ['lossyacl'],
-        })
+        conf['dps'][self.DP_NAME]['interfaces'][self.port_map['port_1']]['acls_in'] = ['lossyacl']
         self.reload_conf(
             conf, self.faucet_config_path,
             restart=True, cold_start=True, change_expected=True, hup=True)
         self.wait_until_matching_lines_from_file(
-            r'.+PKTPS+',
+            r'.+KBPS+',
             self.get_matching_meters_on_dpid(self.dpid))
-
-
-class FaucetUntaggedMeterDeleteTest(FaucetUntaggedMeterAddTest):
-
-    def test_untagged(self):
-        super(FaucetUntaggedMeterDeleteTest, self).test_untagged()
-        conf = self._get_faucet_conf()
-        conf['dps'][self.DP_NAME]['interfaces'][self.port_map['port_2']].update({
-            'acls_in': [],
-        })
+        conf['meters']['lossymeter']['entry']['flags'] = ['PKTPS']
         self.reload_conf(
             conf, self.faucet_config_path,
-            restart=True, cold_start=True, change_expected=True)
-        self.wait_until_no_matching_lines_from_file(
-            r'.+\'meter_id\'\: 2+',
+            restart=True, cold_start=False, change_expected=True, hup=True)
+        self.wait_until_matching_lines_from_file(
+            r'.+PKTPS+',
             self.get_matching_meters_on_dpid(self.dpid))
 
 

--- a/tests/unit/faucet/test_valve.py
+++ b/tests/unit/faucet/test_valve.py
@@ -182,6 +182,57 @@ dps:
         self.assertTrue(table.is_output(match, port=3))
 
 
+class ValveUnusedMeterTestCase(ValveTestBases.ValveTestNetwork):
+    """Test unused meters are not configured."""
+
+    CONFIG = """
+meters:
+    unusedmeter:
+        meter_id: 1
+        entry:
+            flags: "KBPS"
+            bands:
+                [
+                    {
+                        type: "DROP",
+                        rate: 1
+                    }
+                ]
+    usedmeter:
+        meter_id: 2
+        entry:
+            flags: "KBPS"
+            bands:
+                [
+                    {
+                        type: "DROP",
+                        rate: 2
+                    }
+                ]
+acls:
+    meteracl:
+        - rule:
+            actions:
+                meter: usedmeter
+                allow: 1
+dps:
+    s1:
+%s
+        interfaces:
+            p1:
+                number: 1
+                native_vlan: 0x100
+                acls_in: [meteracl]
+""" % DP1_CONFIG
+
+    def setUp(self):
+        self.setup_valves(self.CONFIG)
+
+    def test_usedmeter(self):
+        valve = self.valves_manager.valves[self.DP_ID]
+        self.assertEqual(['usedmeter'], list(valve.dp.meters.keys()))
+
+
 class ValveOFErrorTestCase(ValveTestBases.ValveTestNetwork):
     """Test decoding of OFErrors."""
 


### PR DESCRIPTION
Incremental fixes while auditing table manager change methods.

* valve_route did not delete deconfigured VLAN
* Move meter add/change/del functions should move to ACL manager, and don't configure unused meters.
* ACL manager will call serialize() on same flows when parsing ACL, even if ACL doesn't change. Serialization check can be cached so that parse serialize() cost only needs to be paid once. Particularly impactful for very large, mostly static ACLs. Also test XID needs to be > 0 to avoid Ryu debug message when meters are used.

