### PR TITLE
Pickout least unhealthy of roots if all roots are unhealthy

### DIFF
--- a/faucet/valve_stack.py
+++ b/faucet/valve_stack.py
@@ -275,13 +275,8 @@ This includes port nominations and flood directionality."""
         else:
             # No healthy stack roots, so forced to choose a bad root
             new_root_name = None
-            if root_valve:
-                # Current root is unhealthy along with all other roots, so keep root the same
-                new_root_name = root_valve.dp.name
-            if root_valve not in unhealthy_valves:
-                # Pick the best unhealthy root
-                stacks = [valve.dp.stack for valve in unhealthy_valves]
-                _, new_root_name = stacks[0].nominate_stack_root(stacks)
+            stacks = [valve.dp.stack for valve in unhealthy_valves]
+            _, new_root_name = stacks[0].nominate_stack_root(stacks)
 
         return new_root_name
 

--- a/tests/unit/faucet/test_valve_stack.py
+++ b/tests/unit/faucet/test_valve_stack.py
@@ -3407,11 +3407,11 @@ dps:
             self.assertEqual(valve.stack_manager.nominate_stack_root(
                 valves[1], self.other_valves(valves[1]), 111,
                 last_live_times, self.UPDATE_TIME), 'sw2')
-        # timeout sw2, should stay sw2 because there are no healthy switches
+        # timeout sw2, should pick sw1 because there are no healthy switches and owing to naming scheme, sw1 is picked
         for valve in valves.values():
             self.assertEqual(valve.stack_manager.nominate_stack_root(
                 valves[2], self.other_valves(valves[2]),
-                121, last_live_times, self.UPDATE_TIME), 'sw2')
+                121, last_live_times, self.UPDATE_TIME), 'sw1')
 
     def test_consistent_roots(self):
         """Test inconsistent root detection"""


### PR DESCRIPTION
Currently, we persist with the current root if all roots are unhealthy. This change picks out the least unhealthy of all roots if all roots are unhealthy.