### PR TITLE
Reverse tunnel

### DIFF
--- a/clib/fakeoftable.py
+++ b/clib/fakeoftable.py
@@ -178,7 +178,7 @@ class FakeOFNetwork:
             pkt = dict(pkt)
             if dp_id == dst_dpid:
                 # A packet has reached the destination, so test for the output
-                found = self.tables[dp_id].is_output(pkt, port, vid, trace=trace)
+                found = self.tables[dp_id].is_full_output(pkt, port, vid, trace=trace)
                 if not found and trace:
                     # A packet on the destination DP is not output in the expected state so
                     #   continue searching (flood reflection)
@@ -500,6 +500,9 @@ class FakeOFTable:
             elif action.type == ofp.OFPAT_POP_VLAN:
                 # Remove VLAN header from the packet
                 packet_dict.pop('vlan_vid')
+                if 'vlan_pcp' in packet_dict:
+                    # Also make sure to pop off any VLAN header information too
+                    packet_dict.pop('vlan_pcp')
                 if 'encap_vid' in packet_dict:
                     # Move the encapsulated VID to the front
                     packet_dict['vlan_vid'] = packet_dict['encap_vid']

--- a/clib/mininet_test_base.py
+++ b/clib/mininet_test_base.py
@@ -56,6 +56,9 @@ class FaucetTestBase(unittest.TestCase):
     # Number of Gauge controllers to create
     NUM_GAUGE_CONTROLLERS = 1
 
+    # List of switches (by switch index) to ignore (treating them as outside the Faucet network)
+    IGNORED_SWITCHES = []
+
     CONTROLLER_CLASS = mininet_test_topo.FAUCET
 
     DP_NAME = 'faucet-1'
@@ -2574,7 +2577,7 @@ dbs:
                 return
             time.sleep(1)
         if flow:
-            self.fail('flow %s matching %s table ID %s had zero packet count' % (flow, match, table_id))
+            self.fail('DPID %s flow %s matching %s table ID %s had zero packet count' % (dpid, flow, match, table_id))
         else:
             self.fail('no flow matching %s table ID %s' % (match, table_id))
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1034,7 +1034,7 @@ Failover is an experimental option, but can be configured as follows:
       - None
       - The list of ports the packet can be output through.
 
-A tunnel ACL will encapsulate a packet before sending it through the stack topology
+A tunnel ACL will encapsulate a packet before sending it through the stack topology.
 
 .. note:: Currently tunnel ACLs only support VLAN encapsulation.
 
@@ -1062,6 +1062,22 @@ A tunnel ACL will encapsulate a packet before sending it through the stack topol
       - int/str
       - None
       - The name or port number of the interface on the remote DP to output the packet
+    * - exit_instructions
+      - list
+      - None
+      - An additional list of output actions to apply to the packet after decapsulating from the tunnel and before outputting to the destination. This is in the form of the ordered ACL output actions.
+    * - maintain_encapsulation
+      - bool
+      - False
+      - Forces the tunnel encapsulation to be kept on the packet upon exiting the tunnel
+    * - bi_directional
+      - bool
+      - False
+      - If true, configures a reverse path (from the destination to the source) indicated by a different VLAN_PCP using the same tunnel ID
+    * - reverse
+      - bool
+      - False
+      - If true, configures the tunnel to be solely a 'reverse' tunnel. Indicated by a different VLAN_PCP, potentially using a used tunnel ID. This provides a more general reverse tunnel output that can go to a different destination.
 
 .. _gauge-configuration:
 

--- a/faucet/conf.py
+++ b/faucet/conf.py
@@ -27,7 +27,13 @@ class InvalidConfigError(Exception):
 
 
 def test_config_condition(cond, msg):
-    """Evaluate condition and raise InvalidConfigError if condition True."""
+    """
+    Evaluate condition and raise InvalidConfigError if condition True.
+
+    Args:
+        cond (bool): Condition on which to raise an error if it is true
+        msg (str): Message for the error if the condition is true
+    """
     if cond:
         raise InvalidConfigError(msg)
 

--- a/faucet/dp.py
+++ b/faucet/dp.py
@@ -768,17 +768,28 @@ configuration.
 
     def finalize_tunnel_acls(self, dps):
         """Resolve each tunnels sources"""
+        # Find all tunnel ACLs that are in `self.tunnel_acls` that are have a configured source
         if self.tunnel_acls:
+            # TODO: A Tunnel ACL can contain multiple different tunnel IDs
             tunnel_ids = {tunnel_acl._id: tunnel_acl for tunnel_acl in self.tunnel_acls}
             referenced_acls = set()
             for dp in dps:
-                for port in dp.ports.values():
-                    if port.acls_in:
-                        for acl in port.acls_in:
-                            tunnel_acl = tunnel_ids.get(acl._id)
-                            if tunnel_acl:
-                                tunnel_acl.add_tunnel_source(dp.name, port.number)
-                                referenced_acls.add(tunnel_acl._id)
+                if dp.dp_acls:
+                    for acl in dp.dp_acls:
+                        tunnel_acl = tunnel_ids.get(acl._id)
+                        if tunnel_acl:
+                            # ACL is configured on a DP
+                            tunnel_acl.add_tunnel_source(dp.name, None)
+                            referenced_acls.add(tunnel_acl._id)
+                else:
+                    for port in dp.ports.values():
+                        if port.acls_in:
+                            for acl in port.acls_in:
+                                tunnel_acl = tunnel_ids.get(acl._id)
+                                if tunnel_acl:
+                                    tunnel_acl.add_tunnel_source(dp.name, port.number)
+                                    referenced_acls.add(tunnel_acl._id)
+            # Any tunnel ACL that has not been resolved should be ignored
             for tunnel_id, tunnel_acl in tunnel_ids.items():
                 if tunnel_id not in referenced_acls:
                     self.tunnel_acls.remove(tunnel_acl)
@@ -935,38 +946,18 @@ configuration.
                     return port.number
                 return port
 
-            def resolve_tunnel_objects(dst_dp_name, dst_port_name, tunnel_id_name):
+            def get_tunnel_vlan(tunnel_id_name, resolved_dst):
                 """
-                Resolves the names of the tunnel src and dst (DP & port) pairs into the correct \
-                    objects
-                Args:
-                    dst_dp (str): DP of the tunnel's destination port
-                    dst_port (int): Destination port of the tunnel
-                    tunnel_id_name (int/str/None): Tunnel identification number or VLAN reference
-                Returns:
-                    dst_dp name, dst_port name and tunnel id
-                """
-                if vid is not None:
-                    # VLAN ACL
-                    test_config_condition(True, 'Tunnels do not support VLAN-ACLs')
-                elif dp is not None:
-                    # DP ACL
-                    test_config_condition(True, 'Tunnels do not support DP-ACLs')
-                test_config_condition(dst_dp_name not in dp_by_name, (
-                    'Could not find referenced destination DP (%s) for tunnel ACL %s' % (
-                        dst_dp_name, acl_in)))
-                dst_dp = dp_by_name[dst_dp_name]
-                dst_port = dst_dp.resolve_port(dst_port_name)
-                test_config_condition(dst_port is None, (
-                    'Could not find referenced destination port (%s) for tunnel ACL %s' % (
-                        dst_port_name, acl_in)))
-                test_config_condition(dst_port.stack is None, (
-                    'destination port %s for tunnel ACL %s cannot be a stack port' % (
-                        dst_port_name, acl_in)))
-                dst_port = dst_port.number
-                dst_dp = dst_dp.name
-                resolved_dst = (dst_dp, dst_port)
+                Obtain the VLAN that is configured for a tunnel.
+                If the tunnel VLAN exists, ensure it has the correct properties and is not used.
+                If the VLAN does not exist, then create one.
 
+                Args:
+                    tunnel_id_name (str/int/None): Reference to the VLAN object that the tunnel will use
+                    resolved_dst (tuple): DP, port destination tuple
+                Returns:
+                    VLAN: VLAN object used by the tunnel
+                """
                 if not tunnel_id_name:
                     if resolved_dst in tunnel_dsts_to_vlan:
                         tunnel_vlan = tunnel_dsts_to_vlan[resolved_dst]
@@ -1006,7 +997,39 @@ configuration.
                             existing_tunnel_vlan == tunnel_vlan.vid,
                             'Cannot have multiple tunnel IDs (%u, %u) to same destination %s' % (
                                 existing_tunnel_vlan.vid, tunnel_vlan.vid, resolved_dst))
+                return tunnel_vlan
 
+            def resolve_tunnel_objects(dst_dp_name, dst_port_name, tunnel_id_name):
+                """
+                Resolves the names of the tunnel src and dst (DP & port) pairs into the correct \
+                    objects
+                Args:
+                    dst_dp (str): DP of the tunnel's destination port
+                    dst_port (int/None): Destination port of the tunnel
+                    tunnel_id_name (int/str/None): Tunnel identification number or VLAN reference
+                Returns:
+                    dst_dp name, dst_port name and tunnel id
+                """
+                # VLAN tunnel ACL
+                test_config_condition(vid is not None, 'Tunnels do not support VLAN-ACLs')
+                # Port & DP tunnel ACL
+                test_config_condition(dst_dp_name not in dp_by_name, (
+                    'Could not find referenced destination DP (%s) for tunnel ACL %s' % (
+                        dst_dp_name, acl_in)))
+                dst_dp = dp_by_name[dst_dp_name]
+                dst_port = None
+                if dst_port_name:
+                    dst_port = dst_dp.resolve_port(dst_port_name)
+                    test_config_condition(dst_port is None, (
+                        'Could not find referenced destination port (%s) for tunnel ACL %s' % (
+                            dst_port_name, acl_in)))
+                    test_config_condition(dst_port.stack is None, (
+                        'destination port %s for tunnel ACL %s cannot be a stack port' % (
+                            dst_port_name, acl_in)))
+                    dst_port = dst_port.number
+                dst_dp = dst_dp.name
+                resolved_dst = (dst_dp, dst_port)
+                tunnel_vlan = get_tunnel_vlan(tunnel_id_name, resolved_dst)
                 # Sources will be resolved later on
                 self.tunnel_acls.append(self.acls[acl_in])
                 tunnel_dsts_to_vlan[resolved_dst] = tunnel_vlan
@@ -1031,7 +1054,6 @@ configuration.
 
         def resolve_acls():
             """Resolve config references in ACLs."""
-            # TODO: move this config validation to ACL object.
             for vlan in self.vlans.values():
                 if vlan.acls_in:
                     acls = []
@@ -1075,7 +1097,7 @@ configuration.
 
             if self.dp_acls:
                 acls = []
-                for acl in self.acls:
+                for acl in self.dp_acls:
                     resolve_acl(acl, dp=self)
                     acls.append(self.acls[acl])
                 self.dp_acls = acls

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -233,7 +233,8 @@ class Valve:
         self.stack_manager = None
         if self.dp.stack:
             self.stack_manager = ValveStackManager(
-                self.logger, self.dp, self.dp.stack, self.dp.tunnel_acls, self.acl_manager)
+                self.logger, self.dp, self.dp.stack, self.dp.tunnel_acls, self.acl_manager,
+                self.dp.tables['eth_dst'])
 
         self._lldp_manager = ValveLLDPManager(
             self.dp.tables['vlan'], self.dp.highest_priority, self.logger,
@@ -382,6 +383,8 @@ class Valve:
         """Configure a VLAN."""
         self.logger.info('Configuring %s' % vlan)
         ofmsgs = []
+        if vlan.reserved_internal_vlan:
+            return ofmsgs
         for manager in self._managers:
             ofmsgs.extend(manager.add_vlan(vlan, cold_start))
         return ofmsgs
@@ -1089,12 +1092,12 @@ class Valve:
 
         if updated_port:
             for vlan in updated_port.vlans():
-                if _update_vlan(vlan, now, rate_limited):
+                if not vlan.reserved_internal_vlan and _update_vlan(vlan, now, rate_limited):
                     _update_port(vlan, updated_port)
                     vlan.dyn_last_updated_metrics_sec = now
         else:
             for vlan in self.dp.vlans.values():
-                if _update_vlan(vlan, now, rate_limited):
+                if not vlan.reserved_internal_vlan and _update_vlan(vlan, now, rate_limited):
                     for port in vlan.get_ports():
                         _update_port(vlan, port)
                     vlan.dyn_last_updated_metrics_sec = now

--- a/faucet/valve_of.py
+++ b/faucet/valve_of.py
@@ -44,6 +44,13 @@ ECTP_ETH_TYPE = 0x9000
 
 # https://en.wikipedia.org/wiki/IEEE_P802.1p
 # Avoid use of PCP 1 which is BK priority (lowest)
+
+TUNNEL_INDICATOR_FIELD = 'vlan_pcp'
+# Used to indicate traffic in a one-to-one bi-directional tunnel is heading in the reverse/return direction
+PCP_TUNNEL_REVERSE_DIRECTION_FLAG = 4
+# Used to indicate traffic belongs in a tunnel (for all cases not including the 1-1 reverse bi-directional tunnel)
+PCP_TUNNEL_FLAG = 3
+
 PCP_EXT_PORT_FLAG = 2
 PCP_NONEXT_PORT_FLAG = 0
 EXTERNAL_FORWARDING_FIELD = 'vlan_pcp'
@@ -404,6 +411,18 @@ def goto_table(table):
     return parser.OFPInstructionGotoTable(table.table_id)
 
 
+@functools.lru_cache()
+def goto_table_id(table_id):
+    """Return instruction to goto table by table ID.
+
+    Args:
+        table (int): table by ID to goto.
+    Returns:
+        ryu.ofproto.ofproto_v1_3_parser.OFPInstruction: goto instruction.
+    """
+    return parser.OFPInstructionGotoTable(table_id)
+
+
 def metadata_goto_table(metadata, mask, table):
     """Return instructions to write metadata and goto table.
 
@@ -683,6 +702,7 @@ MATCH_FIELDS = {
 
 
 def match_from_dict(match_dict):
+    """Parse a match dict into a OFPMatch object"""
     kwargs = {}
     for of_match, field in match_dict.items():
         of_match = OLD_MATCH_FIELDS.get(of_match, of_match)


### PR DESCRIPTION
- Adds additional configuration options to the tunnel mechanism.
- Adds more DHCP tests to the integration test suite using the bidirectional tunnel to a coprocessor port with a dnsmasq server.

Allows for a tunnel ACL to be configured as a DP ACL as either a source (via `dp_acls`) or destination (by not specifying the tunnel option `port`). This will mean, once the packet has reached the destination DP, it will pop off the tunnel ID and then goto the `eth_dst` table.

`exit_instructions`: An additional list of output actions to apply to the packet after decapsulating from the tunnel and before outputting to the destination.
E.g. The following applies the VID 101 onto the packet after popping off the tunnel ID. This only applies to the forward direction of the tunnel if bidirectionality is configured.
```
acls:
    tunnel_acl:
        - rule:
            dl_type: 0x0800
            ip_proto: 1
            actions:
                output:
                    - tunnel: {
                        dp: s2,
                        port: 1,
                        exit_instructions: [{'vlan_vid': 101}]
                    }
```

`maintain_encapsulation`: Forces the tunnel encapsulation to be kept on the packet upon exiting the tunnel.
E.g. Normally, when outputting to s2:1 the tunnel will pop off the top VLAN header (the tunnel encapsulation). With `maintain_encapsulation` turned on, we do not do this step and just output to s2:1.
```
acls:
    tunnel_acl:
        - rule:
            in_port: 1
            dl_type: 0x0800
            ip_proto: 1
            actions:
                output:
                    - tunnel: {
                        dp: s2,
                        port: 1,
                        maintain_encapsulation: True
                    }
```

`bi_directional`: Configures a reverse path (from the destination to the source) indicated by a different VLAN_PCP using the same tunnel ID.
E.g. The reverse path of a bidirectional tunnel assumes that packets from s2:1 that are already encapsulated with the `tunnel_id` will be bound for the source of `tunnel_acl`. The flowrule will modify the VLAN_PCP of the tunnel_id VLAN header to be 4 which will indicate the packet is headed in the reverse direction. All packets from s2:1 that do not have the `tunnel_id` will be handled normally.
```
acls:
    tunnel_acl:
        - rule:
            in_port: 1
            dl_type: 0x0800
            ip_proto: 1
            actions:
                output:
                    - tunnel: {
                        dp: s2,
                        port: 1,
                        bi_directional: True,
                    }
```

`reverse`: Configures the tunnel to be solely a 'reverse' tunnel. Indicated by a different VLAN_PCP, potentially using a used tunnel ID. This provides a more general bi_directional tunnel output that can go to a different destination.
E.g.
```
acls:
    forward_acl:
        - rule:
            dl_type: 0x0800
            ip_proto: 1
            actions:
                output:
                    - tunnel: {
                        dp: s2,
                        port: 1,
                    }
    reverse_acl:
        - rule:
            dl_type: 0x0800
            ip_proto: 1
            actions:
                output:
                    - tunnel: {
                        dp: s1,
                        port: 1,
                        reverse: True,
                    }
```


There are two ACLs, one for sw1 and one for sw2 that are applied as DP ACLs.
VLAN-3 and VLAN-4 are used as the tunnel indicators for the switches sw1 and sw2 respectively.
These ACLs will take DHCP traffic and encapsulate in a tunnel and output it towards the coprocessor port on sw1 that will contain a DHCP server.
The DHCP server responses should maintain the tunnel encapsulation, so when the response is input into the Faucet network through the coprocessor port, the tunnel encapsulation indicates that we want to return to the correct switch. A VLAN_PCP change occurs and from that point onwards, packets with a tunnel VLAN and a VLAN PCP of 4 will be send towards the source of that specific tunnel.
Once the packet has arrived at the source of the tunnel, since the ACLs are applied as DP ACLs, the tunnel VLAN is popped from the packet and then it is sent to the eth_dst table of that switch to then be forwarded to the host where we have learnt a matching MAC address for.
`faucet.yaml`:
```
acls:
  sw1_dhcp:
  - rule:
      actions:
        allow: 0
        output:
        - vlan_vid: 100
        - tunnel:
            bi_directional: true
            dp: s01
            maintain_encapsulation: true
            port: 3
            tunnel_id: 300
      dl_type: 2048
      in_port: 4
      nw_proto: 17
      udp_dst: 67
      udp_src: 68
  - rule:
      actions:
        allow: 0
        output:
        - vlan_vid: 200
        - tunnel:
            bi_directional: true
            dp: s01
            maintain_encapsulation: true
            port: 3
            tunnel_id: 300
      dl_type: 2048
      in_port: 5
      nw_proto: 17
      udp_dst: 67
      udp_src: 68
  - rule:
      actions:
        allow: 0
      dl_type: 2048
      nw_proto: 17
      udp_dst: 67
      udp_src: 68
  - rule:
      actions:
        allow: 0
      dl_type: 2048
      nw_proto: 17
      udp_dst: 68
      udp_src: 67
  - rule:
      actions:
        allow: 1
  sw2_dhcp:
  - rule:
      actions:
        allow: 0
        output:
        - vlan_vid: 100
        - tunnel:
            bi_directional: true
            dp: s01
            maintain_encapsulation: true
            port: 3
            tunnel_id: 400
      dl_type: 2048
      in_port: 5
      nw_proto: 17
      udp_dst: 67
      udp_src: 68
  - rule:
      actions:
        allow: 0
        output:
        - vlan_vid: 200
        - tunnel:
            bi_directional: true
            dp: s01
            maintain_encapsulation: true
            port: 3
            tunnel_id: 400
      dl_type: 2048
      in_port: 6
      nw_proto: 17
      udp_dst: 67
      udp_src: 68
  - rule:
      actions:
        allow: 0
      dl_type: 2048
      nw_proto: 17
      udp_dst: 67
      udp_src: 68
  - rule:
      actions:
        allow: 0
      dl_type: 2048
      nw_proto: 17
      udp_dst: 68
      udp_src: 67
  - rule:
      actions:
        allow: 1
dps:
  s01:
    dp_acls: [sw1_dhcp]
    dp_id: 2172366108
    hardware: Open vSwitch
    interfaces:
      1:
        name: b1
        stack: {dp: s02, port: 1}
      2:
        name: b2
        stack: {dp: s02, port: 2}
      3:
        coprocessor: {strategy: vlan_vid}
        name: dhcp
      4:
        name: host1
        native_vlan: vlan-1
      5:
        name: host2
        native_vlan: vlan-2
    stack:
      priority: 1
  s02:
    dp_acls: [sw2_dhcp]
    dp_id: 2172366109
    hardware: Open vSwitch
    interfaces:
      1:
        name: b1
        stack: {dp: s01, port: 1}
      2:
        name: b2
        stack: {dp: s01, port: 2}
      5:
        name: host3
        native_vlan: vlan-1
      6:
        name: host4
        native_vlan: vlan-2
vlans:
  vlan-1:
    faucet_mac: 00:00:00:00:00:11
    faucet_vips: [10.1.0.254/24]
    vid: 100
  vlan-2:
    faucet_mac: 00:00:00:00:00:22
    faucet_vips: [10.2.0.254/24]
    vid: 200
  vlan-3:
    reserved_internal_vlan: true
    vid: 300
  vlan-4:
    reserved_internal_vlan: true
    vid: 400
```
