### PR TITLE
Upgrade test-base image.

### DIFF
--- a/.github/workflows/tests-integration.yml
+++ b/.github/workflows/tests-integration.yml
@@ -11,7 +11,7 @@ jobs:
     name: Sanity tests
     runs-on: ubuntu-latest
     container:
-      image: faucet/test-base:8.0.6
+      image: faucet/test-base:9.0.0
       options: --privileged --cap-add=ALL -v /lib/modules:/lib/modules -v /var/local/lib/docker:/var/lib/docker --sysctl net.ipv6.conf.all.disable_ipv6=0 --ulimit core=-1
     steps:
       - name: Checkout repo
@@ -77,7 +77,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: sanity-tests
     container:
-      image: faucet/test-base:8.0.4
+      image: faucet/test-base:9.0.0
       options: --privileged --cap-add=ALL -v /lib/modules:/lib/modules -v /var/local/lib/docker:/var/lib/docker --sysctl net.ipv6.conf.all.disable_ipv6=0 --ulimit core=-1
     strategy:
       matrix:

--- a/Dockerfile.fuzz-config
+++ b/Dockerfile.fuzz-config
@@ -1,6 +1,6 @@
 ## Image name: faucet/config-fuzzer
 
-FROM faucet/test-base:8.0.6
+FROM faucet/test-base:9.0.0
 
 ENV PIP3="pip3 --no-cache-dir install --upgrade"
 ENV PATH="/venv/bin:$PATH"

--- a/Dockerfile.fuzz-packet
+++ b/Dockerfile.fuzz-packet
@@ -1,6 +1,6 @@
 ## Image name: faucet/packet-fuzzer
 
-FROM faucet/test-base:8.0.6
+FROM faucet/test-base:9.0.0
 
 ENV PIP3="pip3 -q --no-cache-dir install --upgrade"
 ENV PATH="/venv/bin:$PATH"

--- a/Dockerfile.tests
+++ b/Dockerfile.tests
@@ -1,6 +1,6 @@
 ## Image name: faucet/tests
 
-FROM faucet/test-base:8.0.6
+FROM faucet/test-base:9.0.0
 
 COPY ./ /faucet-src/
 WORKDIR /faucet-src/

--- a/clib/clib_mininet_test_main.py
+++ b/clib/clib_mininet_test_main.py
@@ -67,7 +67,7 @@ EXTERNAL_DEPENDENCIES = (
     ('nc', ['-h'], 'OpenBSD netcat', '', 0),
     ('vconfig', [], 'the VLAN you are talking about', '', 0),
     ('fuser', ['-V'], r'fuser \(PSmisc\)',
-     r'fuser \(PSmisc\) (\d+\.\d+)\n', "22.0"),
+     r'fuser \(PSmisc\) (\d+\.\d+|UNKNOWN)\n', "22.0"),
     ('lsof', ['-v'], r'lsof version',
      r'revision: (\d+\.\d+)\n', "4.86"),
     ('mn', ['--version'], r'\d+\.\d+.\d+',
@@ -204,6 +204,9 @@ def check_dependencies():
                 print('cannot parse version %s for %s' % (
                     version_match, required_binary))
                 return False
+            if binary == 'fuser' and binary_version == 'UNKNOWN':
+                # Workaround for psmisc 23.3
+                return True
             if version.parse(binary_version) < version.parse(binary_minversion):
                 print('%s version %s is less than required version %s' % (
                     required_binary, binary_version, binary_minversion))

--- a/docker/runtests.sh
+++ b/docker/runtests.sh
@@ -130,12 +130,6 @@ cd /faucet-src/tests
 
 ./sysctls_for_tests.sh || true
 
-# TODO: need to force UTF-8 as POSIX causes python3/pytype errors.
-locale-gen en_US.UTF-8
-export LANG=en_US.UTF-8
-export LANGUAGE=en_US.en
-export LC_ALL=en_US.UTF-8
-
 export PYTHONPATH=/faucet-src:/faucet-src/faucet:/faucet-src/clib
 
 if [ "$HELP" == 1 ] ; then


### PR DESCRIPTION
  * Changes test-base image to Debian from Ubuntu as Ubuntu have stopped supporting i386.
  * Includes workaround for unknown psmisc version issue in debian buster (which is fixed in newer debian/ubuntu releases).
  * Upgrade:
    * openvswitch to v2.15.0.
    * mininet to v2.3.0.
    * Debian to buster.

needs new https://github.com/faucetsdn/docker-test-base release cut before this can be merged