### PR TITLE
Add varz to track changes to stack state, lacp status and stack root

### DIFF
--- a/faucet/faucet_metrics.py
+++ b/faucet/faucet_metrics.py
@@ -204,6 +204,17 @@ class FaucetMetrics(PromClient):
             'lacp_port_id',
             'lacp port ID for for port',
             self.PORT_REQUIRED_LABELS)
+        self.port_stack_state_change_count = self._counter(
+            'port_stack_state_change_count',
+            'number of changes in port stack state',
+            self.PORT_REQUIRED_LABELS)
+        self.port_lacp_state_change_count = self._counter(
+            'port_lacp_state_change_count',
+            'number of changes in port lacp state',
+            self.PORT_REQUIRED_LABELS)
+        self.stack_root_change_count = self._counter(
+            'stack_root_change_count',
+            'number of changes in stack root', [])
 
     def _counter(self, var, var_help, labels):
         return Counter(var, var_help, labels, registry=self._reg) # pylint: disable=unexpected-keyword-arg

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -172,6 +172,9 @@ class Valve:
     def _set_port_var(self, var, val, port):
         self._set_var(var, val, labels=self.dp.port_labels(port.number))
 
+    def _inc_port_var(self, var, port, val=1):
+        self._inc_var(var, labels=self.dp.port_labels(port.number), val=val)
+
     def _remove_var(self, var, labels=None):
         if labels is None:
             labels = self.dp.base_prom_labels()
@@ -758,6 +761,7 @@ class Valve:
         lacp_state = port.actor_state()
         lacp_role = port.lacp_port_state()
         self._set_port_var('port_lacp_state', lacp_state, port)
+        self._inc_port_var('port_lacp_state_change_count', port)
         self._set_port_var('lacp_port_id', port.lacp_port_id, port)
         self._set_port_var('port_lacp_role', lacp_role, port)
         self.notify(

--- a/faucet/valve_lldp.py
+++ b/faucet/valve_lldp.py
@@ -133,6 +133,8 @@ class ValveLLDPManager(ValveManagerBase):
             after_state, reason = port.stack_port_update(now)
             if before_state != after_state:
                 self._set_port_var('port_stack_state', after_state, port)
+                self._inc_var(
+                    'port_stack_state_change_count', labels=valve.dp.port_labels(port.number))
                 self.notify({'STACK_STATE': {
                     'port': port.number,
                     'state': after_state}})

--- a/faucet/valves_manager.py
+++ b/faucet/valves_manager.py
@@ -177,6 +177,7 @@ class ValvesManager:
                     self.metrics.is_dp_stack_root.labels(**labels).set(0)
                 self.meta_dp_state.stack_root_name = new_root_name
                 self.metrics.faucet_stack_root_dpid.set(new_root_valve.dp.dp_id)
+                self.metrics.stack_root_change_count.inc(1)
                 self.reload_stack_root_config(now)
                 if prev_root_name:
                     stack_change = True

--- a/tests/unit/faucet/test_valve.py
+++ b/tests/unit/faucet/test_valve.py
@@ -492,6 +492,8 @@ vlans:
             5, int(self.get_prom('port_lacp_state', labels=labels)))
         self.assertFalse(
             valve.dp.ports[1].non_stack_forwarding())
+        self.assertEqual(
+            4, int(self.get_prom('port_lacp_state_change_count_total', labels=labels)))
 
     def test_lacp_timeout(self):
         """Test LACP comes up and then times out."""


### PR DESCRIPTION
Adds varz to enable monitoring frequent changes to stack state, lacp status and stack root.