### PR TITLE
Fix codecov upload at end of unit test run.

### DIFF
--- a/.github/workflows/tests-unit.yml
+++ b/.github/workflows/tests-unit.yml
@@ -4,6 +4,7 @@ on: [push, pull_request]
 
 env:
   FILES_CHANGED: "all"
+  CODECOV_PY_VER: 3.6
 
 jobs:
   unit-tests:
@@ -62,7 +63,7 @@ jobs:
       - name: Running unit tests
         run: |
           ./tests/run_unit_tests.sh
-      - if: ${{ matrix.python-version == env.CODECHECK_PY_VER }}
+      - if: ${{ matrix.python-version == env.CODECOV_PY_VER }}
         name: Upload codecov
         uses: codecov/codecov-action@v1
       - if: ${{ matrix.python-version != 3.5 && (env.FILES_CHANGED == 'all' || env.RQ_FILES_CHANGED || env.PY_FILES_CHANGED) }}


### PR DESCRIPTION
I broke codecov uploads when I refactored our github action runs into separate workflows (89008526fcec1aaeec98e5ba679bc333813d83a7).

Fix codecov uploads so they work again.