### PR TITLE
Don't exclude .git directory from docker containers.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
-.git
 .vagrant
 
 **/__pycache__


### PR DESCRIPTION
 * Our release process requires the .git directory to exist for docker
   image builds to succeed.