### PR TITLE
Only run release CIs if tag format is correct.

### DIFF
--- a/.github/workflows/release-debian.yml
+++ b/.github/workflows/release-debian.yml
@@ -1,9 +1,9 @@
 name: Build debian packages and images for release
 
 on:
-  release:
-    types:
-      - published
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
 
 env:
   DEBIAN_FRONTEND: noninteractive

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -1,9 +1,9 @@
 name: Build docker images for release
 
 on:
-  release:
-    types:
-      - published
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   faucet-docker-image:

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -1,9 +1,9 @@
 name: Build python packages for release
 
 on:
-  release:
-    types:
-      - published
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
 
 env:
   RELEASE_PY_VER: 3.8


### PR DESCRIPTION
Prevent our release CIs from running if our tag format isn't used.