### PR TITLE
DownRev Scapy to 2.4.4 (#3869)

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -9,4 +9,4 @@ netifaces
 packaging
 requests
 requirements-parser
-scapy==2.4.5
+scapy==2.4.4

--- a/tests/integration/mininet_tests.py
+++ b/tests/integration/mininet_tests.py
@@ -1900,6 +1900,17 @@ class FaucetUntaggedTcpIPv6IperfTest(FaucetUntaggedTest):
 class FaucetSanityTest(FaucetUntaggedTest):
     """Sanity test - make sure test environment is correct before running all tess."""
 
+    def test_scapy_fuzz(self):
+        # Scapy 2.4.5 has issues with 'fuzz' generation
+        #  so black-list that version with a test
+        exception = False
+        try:
+            scapy.all.send(scapy.all.fuzz(scapy.all.Ether()))
+        except Exception as e:
+            error('%s:' % self._test_name(), e)
+            exception = True
+        self.assertFalse(exception, 'Scapy threw an exception in send(fuzz())')
+
     def test_ryu_config(self):
         varstr = ', '.join(self.scrape_prometheus(var='ryu_config'))
         self.assertTrue('echo_request_interval"} 10.0' in varstr)


### PR DESCRIPTION
In order to avoid this exception with 'send(fuzz(...))' usage:
---
  File "/venv/lib/python3.7/site-packages/scapy/arch/linux.py", line 605, in send
    self.outs.bind(sdto)
TypeError: argument 1 must be str, not NetworkInterface
---

Which is seen in the following integration tests:
* FaucetUntaggedIPv4ControlPlaneFuzzTest
* FaucetUntaggedIPv6ControlPlaneFuzzTest