### PR TITLE
CodeCheck - Part4

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -3,3 +3,8 @@
 
 [FORMAT]
 max-line-length=120
+
+[BASIC]
+# Default: method-naming-style=snake_case (SnakeCaseStyle)
+# Override: add 'unittest' methods (setUp & tearDown)
+method-rgx=(([^\W\dA-Z][^\WA-Z]{2,}|_[^\WA-Z]*|__[^\WA-Z\d_][^\WA-Z]+__)|(setUp)|(tearDown))$

--- a/.pylintrc
+++ b/.pylintrc
@@ -8,3 +8,9 @@ max-line-length=120
 # Default: method-naming-style=snake_case (SnakeCaseStyle)
 # Override: add 'unittest' methods (setUp & tearDown)
 method-rgx=(([^\W\dA-Z][^\WA-Z]{2,}|_[^\WA-Z]*|__[^\WA-Z\d_][^\WA-Z]+__)|(setUp)|(tearDown))$
+
+# Default: argument-naming-style=snake_case (SnakeCaseStyle)
+# Default: variable-naming-style=snake_case (SnakeCaseStyle)
+# Override: add Faucet name (dp)
+argument-rgx=(([^\W\dA-Z][^\WA-Z]{2,}|_[^\WA-Z]*|__[^\WA-Z\d_][^\WA-Z]+__)|(dp))$
+variable-rgx=(([^\W\dA-Z][^\WA-Z]{2,}|_[^\WA-Z]*|__[^\WA-Z\d_][^\WA-Z]+__)|(dp))$

--- a/faucet/config_parser.py
+++ b/faucet/config_parser.py
@@ -96,7 +96,7 @@ def _dp_parse_port(dp_id, port_key, port_conf, vlans):
     return port
 
 
-def _dp_add_ports(dp, dp_conf, dp_id, vlans):  # pylint: disable=invalid-name
+def _dp_add_ports(dp, dp_conf, dp_id, vlans):
     ports_conf = dp_conf.get('interfaces', {})
     port_ranges_conf = dp_conf.get('interface_ranges', {})
     # as users can config port VLAN by using VLAN name, we store vid in
@@ -154,19 +154,19 @@ def _dp_add_ports(dp, dp_conf, dp_id, vlans):  # pylint: disable=invalid-name
         dp.add_port(port)
 
 
-def _parse_acls(dp, acls_conf):  # pylint: disable=invalid-name
+def _parse_acls(dp, acls_conf):
     for acl_key, acl_conf in acls_conf.items():
         acl = ACL(acl_key, dp.dp_id, acl_conf)
         dp.add_acl(acl_key, acl)
 
 
-def _parse_routers(dp, routers_conf):  # pylint: disable=invalid-name
+def _parse_routers(dp, routers_conf):
     for router_key, router_conf in routers_conf.items():
         router = Router(router_key, dp.dp_id, router_conf)
         dp.add_router(router_key, router)
 
 
-def _parse_meters(dp, meters_conf):  # pylint: disable=invalid-name
+def _parse_meters(dp, meters_conf):
     for meter_key, meter_conf in meters_conf.items():
         meter = Meter(meter_key, dp.dp_id, meter_conf)
         dp.meters[meter_key] = meter

--- a/faucet/dp.py
+++ b/faucet/dp.py
@@ -771,7 +771,7 @@ configuration.
         """Resolve inter-DP config for stacking"""
         if self.stack:
             self.stack.resolve_topology(dps, meta_dp_state)
-            for dp in dps:  # pylint: disable=invalid-name
+            for dp in dps:
                 # Must set externals flag for entire stack.
                 if dp.stack and dp.has_externals:
                     self.has_externals = True
@@ -785,7 +785,7 @@ configuration.
             # TODO: A Tunnel ACL can contain multiple different tunnel IDs
             tunnel_ids = {tunnel_acl._id: tunnel_acl for tunnel_acl in self.tunnel_acls}
             referenced_acls = set()
-            for dp in dps:  # pylint: disable=invalid-name
+            for dp in dps:
                 if dp.dp_acls:
                     for acl in dp.dp_acls:
                         tunnel_acl = tunnel_ids.get(acl._id)
@@ -909,7 +909,7 @@ configuration.
                     test_config_condition(stack_dp not in dp_by_name, (
                         'stack DP %s not defined' % stack_dp))
                     port_stack_dp[port] = dp_by_name[stack_dp]
-                for port, dp in port_stack_dp.items():  # pylint: disable=invalid-name
+                for port, dp in port_stack_dp.items():
                     port.stack['dp'] = dp
                     stack_port = dp.resolve_port(port.stack['port'])
                     test_config_condition(stack_port is None, (
@@ -936,7 +936,7 @@ configuration.
                     if not mirror_port.coprocessor:
                         mirror_port.output_only = True
 
-        def resolve_acl(acl_in, vid=None, port_num=None):  # pylint: disable=invalid-name
+        def resolve_acl(acl_in, vid=None, port_num=None):
             """
             Resolve an individual ACL
             Args:

--- a/faucet/stack.py
+++ b/faucet/stack.py
@@ -256,7 +256,7 @@ is technically a fixed allocation for this DP Stack instance."""
         if not self.ports:
             return
 
-        for dp in stack_priority_dps:  # pylint: disable=invalid-name
+        for dp in stack_priority_dps:
             test_config_condition(not isinstance(dp.stack.priority, int), (
                 'stack priority must be type %s not %s' % (
                     int, type(dp.stack.priority))))
@@ -272,14 +272,14 @@ is technically a fixed allocation for this DP Stack instance."""
             if meta_dp_state.stack_root_name in self.roots_names:
                 self.root_name = meta_dp_state.stack_root_name
 
-        for dp in stack_port_dps:  # pylint: disable=invalid-name
+        for dp in stack_port_dps:
             for vlan in dp.vlans.values():
                 if vlan.faucet_vips:
                     self.route_learning = True
 
         edge_count = Counter()
         graph = networkx.MultiGraph()
-        for dp in stack_port_dps:  # pylint: disable=invalid-name
+        for dp in stack_port_dps:
             graph.add_node(dp.name)
             for port in dp.stack_ports():
                 edge_name = Stack.modify_topology(graph, dp, port)
@@ -288,7 +288,7 @@ is technically a fixed allocation for this DP Stack instance."""
             test_config_condition(count != 2, '%s defined only in one direction' % edge_name)
         if graph.size() and self.name in graph:
             self.graph = graph
-            for dp in graph.nodes():  # pylint: disable=invalid-name
+            for dp in graph.nodes():
                 path_to_root_len = len(self.shortest_path(self.root_name, src_dp=dp))
                 test_config_condition(
                     path_to_root_len == 0, '%s not connected to stack' % dp)
@@ -296,10 +296,10 @@ is technically a fixed allocation for this DP Stack instance."""
                 self.root_flood_reflection = True
 
     @staticmethod
-    def modify_topology(graph, dp, port, add=True):  # pylint: disable=invalid-name
+    def modify_topology(graph, dp, port, add=True):
         """Add/remove an edge to the stack graph which originates from this dp and port."""
 
-        def canonical_edge(dp, port):  # pylint: disable=invalid-name
+        def canonical_edge(dp, port):
             peer_dp = port.stack['dp']
             peer_port = port.stack['port']
             sort_edge_a = (
@@ -339,7 +339,7 @@ is technically a fixed allocation for this DP Stack instance."""
 
         return edge_name
 
-    def modify_link(self, dp, port, add=True):  # pylint: disable=invalid-name
+    def modify_link(self, dp, port, add=True):
         """Update the stack topology according to the event"""
         return Stack.modify_topology(self.graph, dp, port, add)
 

--- a/faucet/tfm_pipeline.py
+++ b/faucet/tfm_pipeline.py
@@ -47,7 +47,6 @@ def init_table(table_id, name, max_entries, metadata_match, metadata_write):
     return valve_of.parser.OFPTableFeaturesStats(**table_attr)
 
 
-# pylint: disable=invalid-name
 # pylint: disable=too-many-arguments
 # pylint: disable=too-many-locals
 def load_tables(dp, valve_cl, max_table_id, min_max_flows, use_oxm_ids, fill_req):

--- a/faucet/valve_switch.py
+++ b/faucet/valve_switch.py
@@ -23,7 +23,7 @@ from faucet.valve_switch_stack import (
     ValveSwitchStackManagerNoReflection, ValveSwitchStackManagerReflection)
 
 
-def valve_switch_factory(logger, dp, pipeline, stack_manager):  # pylint: disable=invalid-name
+def valve_switch_factory(logger, dp, pipeline, stack_manager):
     """Return switch flood/learning manager based on datapath configuration.
 
         Args:

--- a/faucet/watcher_conf.py
+++ b/faucet/watcher_conf.py
@@ -187,9 +187,9 @@ For Prometheus:
             self.path is not None and not os.access(self.path, os.W_OK),
             '%s is not writable' % self.file)
 
-    def add_dp(self, dp):  # pylint: disable=invalid-name
+    def add_dp(self, dp):
         """Add a datapath to this watcher."""
-        self.dp = dp  # pylint: disable=invalid-name
+        self.dp = dp
 
     def check_config(self):
         super().check_config()

--- a/tests/integration/mininet_multidp_tests.py
+++ b/tests/integration/mininet_multidp_tests.py
@@ -315,7 +315,7 @@ class FaucetStringOfDPLACPUntaggedTest(FaucetMultiDPTestBase):
     match_bcast = {'dl_vlan': 100, 'dl_dst': 'ff:ff:ff:ff:ff:ff'}
     action_str = 'OUTPUT:%u'
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup network & create config file"""
         super().set_up(
             stack=False,
@@ -513,7 +513,7 @@ class FaucetSingleStackStringOfDPExtLoopProtUntaggedTest(FaucetMultiDPTestBase):
     NUM_DPS = 2
     NUM_HOSTS = 3
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup network & configuration file"""
         super().set_up(
             stack=True,
@@ -781,7 +781,7 @@ class FaucetSingleStackAclControlTest(FaucetMultiDPTestBase):
             (2, 1): [3]
         }
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup network & create configuration file"""
         super().set_up(
             stack=True,
@@ -918,7 +918,7 @@ class FaucetSingleStackOrderedAclControlTest(FaucetMultiDPTestBase):
             (2, 1): [3]
         }
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup network & create configuration file"""
         super().set_up(
             stack=True,
@@ -1037,7 +1037,7 @@ class FaucetStringOfDPACLOverrideTest(FaucetMultiDPTestBase):
             self.missing_config = os.path.join(self.tmpdir, 'missing_config.yaml')
         return [self.acls_config, self.missing_config]
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup network & create configuration file"""
         self.acls_config = None
         self.missing_config = None
@@ -1169,7 +1169,7 @@ class FaucetSingleTunnelTest(FaucetMultiDPTestBase):
     def output_only(self):
         return {2}   # Host 2 (first port, second switch).
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Start the network"""
         super().set_up(
             stack=True,
@@ -1200,7 +1200,7 @@ class FaucetTunnelLoopTest(FaucetSingleTunnelTest):
     NUM_DPS = 3
     SWITCH_TO_SWITCH_LINKS = 1
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Start a loop topology network"""
         super().set_up(
             stack=True,
@@ -1245,7 +1245,7 @@ class FaucetTunnelAllowTest(FaucetTopoTestBase):
             ]
         }
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Start the network"""
         super().setUp()
         network_graph = networkx.path_graph(self.NUM_DPS)
@@ -1372,7 +1372,7 @@ class FaucetSingleTunnelOrderedTest(FaucetMultiDPTestBase):
             0: [1]  # Host 0 'acls_in': [1]
         }
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Start the network"""
         super().set_up(
             stack=True,
@@ -1406,7 +1406,7 @@ class FaucetTunnelLoopOrderedTest(FaucetSingleTunnelOrderedTest):
     NUM_DPS = 3
     SWITCH_TO_SWITCH_LINKS = 1
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Start a loop topology network"""
         super().set_up(
             stack=True,
@@ -1452,7 +1452,7 @@ class FaucetTunnelAllowOrderedTest(FaucetTopoTestBase):
 
         }
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Start the network"""
         super().setUp()
         network_graph = networkx.path_graph(self.NUM_DPS)
@@ -2919,7 +2919,7 @@ class FaucetTunneltoCoprocessorTest(FaucetTopoTestBase):
             ]
         }
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Start the network"""
         super().setUp()
         network_graph = networkx.path_graph(self.NUM_DPS)
@@ -3036,7 +3036,7 @@ class FaucetDPACLTunnelTest(FaucetTopoTestBase):
             ]
         }
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Start the network"""
         super().setUp()
         network_graph = networkx.path_graph(self.NUM_DPS)
@@ -3131,7 +3131,7 @@ class FaucetACLTunnelDPDestinationTest(FaucetTopoTestBase):
             ]
         }
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Start the network"""
         super().setUp()
         network_graph = networkx.path_graph(self.NUM_DPS)
@@ -3301,7 +3301,7 @@ class FaucetRemoteDHCPCoprocessorTunnelTest(FaucetTopoTestBase):
         """Create a string of the host IP address"""
         return '0.0.0.0'
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Start the network"""
         super().setUp()
         network_graph = networkx.path_graph(self.NUM_DPS - 1)
@@ -3617,7 +3617,7 @@ class FaucetRemoteDHCPCoprocessor2VLANTunnelTest(FaucetTopoTestBase):
         """Create a string of the host IP address"""
         return '0.0.0.0'
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Start the network"""
         super().setUp()
         network_graph = networkx.path_graph(self.NUM_DPS - 1)

--- a/tests/integration/mininet_tests.py
+++ b/tests/integration/mininet_tests.py
@@ -130,7 +130,7 @@ vlans:
     # pylint: disable=invalid-name
     CONFIG = CONFIG_BOILER_UNTAGGED
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         super().setUp()
         self.topo = self.topo_class(
             self.OVS_TYPE, self.ports_sock, self._test_name(), [self.dpid],
@@ -2110,12 +2110,12 @@ class FaucetUntaggedInfluxTest(FaucetUntaggedTest):
             self.server.influx_log = self.influx_log
             self.server.timeout = self.DB_TIMEOUT
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         self.handler = InfluxPostHandler
         super().setUp()
         self.setup_influx()
 
-    def tearDown(self, ignore_oferrors=False):  # pylint: disable=invalid-name
+    def tearDown(self, ignore_oferrors=False):
         if self.server:
             self.server.shutdown()
             self.server.socket.close()
@@ -2285,7 +2285,7 @@ class FaucetUntaggedInfluxUnreachableTest(FaucetUntaggedInfluxTest):
 
 class FaucetSingleUntaggedInfluxTooSlowTest(FaucetUntaggedInfluxTest):
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         self.handler = SlowInfluxPostHandler
         super().setUp()
         self.setup_influx()
@@ -2658,7 +2658,7 @@ vlans:
                 native_vlan: 100
 """
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         super().setUp()
         self.topo = self.topo_class(
             self.OVS_TYPE, self.ports_sock, self._test_name(), [self.dpid],
@@ -3076,7 +3076,7 @@ acls:
         tcp_src: 65535
 """
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         super().setUp()
         self.acl_config_file = os.path.join(self.tmpdir, 'acl.txt')
         self.CONFIG = '\n'.join(
@@ -3261,7 +3261,7 @@ acls:
 """
     ACL_COOKIE = None
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         super().setUp()
         self.ACL_COOKIE = random.randint(1, 2**16 - 1)
         self.ACL = self.ACL.replace('COOKIE', str(self.ACL_COOKIE))
@@ -4076,7 +4076,7 @@ vlans:
                 loop_protect: True
 """
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         super().setUp()
         self.topo = self.topo_class(
             self.OVS_TYPE, self.ports_sock, self._test_name(), [self.dpid],
@@ -4171,7 +4171,7 @@ vlans:
                 native_vlan: 100
 """
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         super().setUp()
         self.topo = self.topo_class(
             self.OVS_TYPE, self.ports_sock, self._test_name(), [self.dpid],
@@ -4625,7 +4625,7 @@ vlans:
                 native_vlan: 101
 """
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         super().setUp()
         self.topo = self.topo_class(
             self.OVS_TYPE, self.ports_sock, self._test_name(), [self.dpid],
@@ -5597,7 +5597,7 @@ vlans:
 
     CONFIG = CONFIG_TAGGED_BOILER
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         super().setUp()
         self.topo = self.topo_class(
             self.OVS_TYPE, self.ports_sock, self._test_name(), [self.dpid],

--- a/tests/unit/faucet/test_valve.py
+++ b/tests/unit/faucet/test_valve.py
@@ -57,7 +57,7 @@ dps:
                 native_vlan: 0x100
 """ % DP1_CONFIG
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup basic port and vlan config"""
         self.setup_valves(self.CONFIG)
 
@@ -117,7 +117,7 @@ acls:
                 allow: 1
 """ % DP1_CONFIG
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup basic coprocessor config"""
         self.setup_valves(self.CONFIG)
 
@@ -171,7 +171,7 @@ dps:
                 restricted_bcast_arpnd: true
 """ % DP1_CONFIG
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup basic port and vlan config with restricted broadcast enabled"""
         self.setup_valves(self.CONFIG)
 
@@ -232,7 +232,7 @@ dps:
                 acls_in: [meteracl]
 """ % DP1_CONFIG
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup meter and ACL config"""
         self.setup_valves(self.CONFIG)
 
@@ -244,7 +244,7 @@ dps:
 class ValveOFErrorTestCase(ValveTestBases.ValveTestNetwork):
     """Test decoding of OFErrors."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         self.setup_valves(CONFIG)
 
     def test_oferror_parser(self):
@@ -296,7 +296,7 @@ vlans:
         vid: 0x200
 """ % GROUP_DP1_CONFIG
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup basic port and vlan config"""
         self.setup_valves(self.CONFIG)
 
@@ -364,7 +364,7 @@ vlans:
         vid: 0x200
 """ % IDLE_DP1_CONFIG
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup basic port and vlan config with mirroring"""
         self.setup_valves(self.CONFIG)
 
@@ -443,7 +443,7 @@ vlans:
         vid: 0x300
 """ % DP1_CONFIG
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup lacp config and activate ports"""
         self.setup_valves(self.CONFIG)
         self.activate_all_ports()
@@ -568,7 +568,7 @@ vlans:
         vid: 0x100
 """ % DP1_CONFIG
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup basic port and vlan config with overriden TFM sizing"""
         self.setup_valves(self.CONFIG)
 
@@ -622,7 +622,7 @@ vlans:
         vid: 0x300
 """ % DP1_CONFIG
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup basic port and vlan config"""
         self.setup_valves(self.CONFIG)
 
@@ -671,7 +671,7 @@ vlans:
         vid: 0x300
 """ % DP1_CONFIG
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup basic lacp config and activate ports"""
         self.setup_valves(self.CONFIG)
         self.activate_all_ports()
@@ -701,7 +701,7 @@ vlans:
 class ValveL2LearnTestCase(ValveTestBases.ValveTestNetwork):
     """Test L2 Learning"""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         self.setup_valves(CONFIG)
 
     def test_expiry(self):
@@ -750,7 +750,7 @@ dps:
                 acls_in: [acl1]
 """
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup basic port and vlan config with ACLs"""
         self.setup_valves(self.CONFIG)
 
@@ -790,7 +790,7 @@ dps:
                 acls_in: [acl1]
 """
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup basic port and vlan config with ACLs"""
         self.setup_valves(self.CONFIG)
 
@@ -881,7 +881,7 @@ routers:
             vlan: v100
 """ % DP1_CONFIG
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup complex config with routing, bgp, mirroring and ACLs"""
         self.setup_valves(self.CONFIG)
 
@@ -912,7 +912,7 @@ vlans:
         vid: 0x200
 """ % DP1_CONFIG
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup simple configuration with no ports up"""
         ofmsgs = self.setup_valves(self.CONFIG, ports_up=[])[self.DP_ID]
         self.valve = self.valves_manager.valves[self.DP_ID]

--- a/tests/unit/faucet/test_valve_config.py
+++ b/tests/unit/faucet/test_valve_config.py
@@ -47,7 +47,7 @@ dps:
                 native_vlan: 0x100
 """ % DP1_CONFIG
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup config with non-existent optional include file"""
         self.setup_valves(self.CONFIG)
 
@@ -86,7 +86,7 @@ dps:
 dps: {}
 """
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup invalid config"""
         self.setup_valves(self.CONFIG)
 
@@ -139,7 +139,7 @@ dps:
                 permanent_learn: False
 """ % DP1_CONFIG
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup basic port and vlan config"""
         self.setup_valves(self.CONFIG)
 
@@ -190,7 +190,7 @@ dps:
                 tagged_vlans: [0x100]
 """ % DP1_CONFIG
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup basic port and vlan config"""
         self.setup_valves(self.CONFIG)
 
@@ -235,7 +235,7 @@ dps:
                 mirror: [1]
 """ % DP1_CONFIG
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup basic port and vlan config"""
         _ = self.setup_valves(self.CONFIG)[self.DP_ID]
 
@@ -282,7 +282,7 @@ dps:
             ofmsg for ofmsg in ValveTestBases.flowmods_from_flows(ofmsgs)
             if ofmsg.match.get('in_port') == in_port]
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup basic port and vlan config"""
         initial_ofmsgs = self.setup_valves(self.CONFIG)[self.DP_ID]
         self.assertFalse(self._inport_flows(3, initial_ofmsgs))
@@ -429,7 +429,7 @@ dps:
                 native_vlan: 0x300
 """ % DP1_CONFIG
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup basic port and vlan config"""
         self.setup_valves(self.CONFIG)
 
@@ -485,7 +485,7 @@ dps:
                 native_vlan: 0x200
 """ % DP1_CONFIG
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup basic port and vlan config"""
         self.setup_valves(self.CONFIG)
 
@@ -525,7 +525,7 @@ dps:
                 native_vlan: 0x100
 """ % DP1_CONFIG
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup basic port and vlan config with priority offset"""
         self.setup_valves(self.CONFIG)
 
@@ -563,7 +563,7 @@ dps:
                 tagged_vlans: [0x100, 0x300]
 """ % DP1_CONFIG
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup basic port and vlan config"""
         self.setup_valves(self.CONFIG)
 
@@ -656,7 +656,7 @@ dps:
                 native_vlan: 0x200
 """ % DP1_CONFIG
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup basic ACL config"""
         self.setup_valves(self.CONFIG)
 
@@ -720,7 +720,7 @@ dps:
                 native_vlan: 0x200
 """ % DP1_CONFIG
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup basic port and vlan config"""
         self.setup_valves(self.CONFIG)
 
@@ -756,7 +756,7 @@ dps:
 class ValveACLTestCase(ValveTestBases.ValveTestNetwork):
     """Test ACL drop/allow and reloading."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         self.setup_valves(CONFIG)
 
     def test_vlan_acl_deny(self):
@@ -836,7 +836,7 @@ acls:
 class ValveEgressACLTestCase(ValveTestBases.ValveTestNetwork):
     """Test ACL drop/allow and reloading."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         self.setup_valves(CONFIG)
 
     def test_vlan_acl_deny(self):
@@ -987,7 +987,7 @@ dps:
 
     baseline_total_tt = None
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup basic port and vlan config"""
         self.setup_valves(CONFIG)
 
@@ -1048,7 +1048,7 @@ vlans:
         vid: 333
 """ % DP1_CONFIG
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup basic port and vlan config"""
         self.setup_valves(self.CONFIG)
 
@@ -1073,7 +1073,7 @@ dps:
                 native_vlan: 0x100
 """ % DP1_CONFIG
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup basic port and vlan config"""
         self.setup_valves(self.CONFIG)
 
@@ -1162,7 +1162,7 @@ dps:
 
     CONFIG_AUTO_REVERT = True
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup basic port and vlan config with hardware type set"""
         self.setup_valves(self.CONFIG)
 
@@ -1202,7 +1202,7 @@ dps:
 
     CONFIG_AUTO_REVERT = True
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup invalid config"""
         self.setup_valves(self.BAD_CONFIG, error_expected=1)
 
@@ -1239,7 +1239,7 @@ dps:
                 native_vlan: 0x100
 """
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup basic port and vlan config with hardware type set"""
         self.setup_valves(self.CONFIG)
 
@@ -1274,7 +1274,7 @@ dps:
 class ValveReloadConfigTestCase(ValveTestBases.ValveTestBig):  # pylint: disable=too-few-public-methods
     """Repeats the tests after a config reload."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         super().setUp()
         self.flap_port(1)
         self.update_config(CONFIG, reload_type='warm', reload_expected=False)

--- a/tests/unit/faucet/test_valve_egress.py
+++ b/tests/unit/faucet/test_valve_egress.py
@@ -36,7 +36,7 @@ class ValveTestEgressPipeline(ValveTestBases.ValveTestBig):  # pylint: disable=t
 class ValveEgressACLTestCase(ValveTestBases.ValveTestNetwork):
     """Test ACL drop/allow and reloading."""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         self.setup_valves(CONFIG)
 
     def test_vlan_acl_deny(self):

--- a/tests/unit/faucet/test_valve_stack.py
+++ b/tests/unit/faucet/test_valve_stack.py
@@ -109,7 +109,7 @@ dps:
                 native_vlan: 100
     """
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         self.setup_valves(self.CONFIG1)
         self.activate_stack()
 
@@ -186,7 +186,7 @@ dps:
                 lacp: 1
 """ % BASE_DP1_CONFIG
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup basic loop config"""
         self.setup_valves(self.CONFIG)
 
@@ -414,7 +414,7 @@ dps:
                 lacp: 1
 """ % BASE_DP1_CONFIG
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup basic loop config"""
         self.setup_valves(self.CONFIG)
 
@@ -487,7 +487,7 @@ dps:
                 lacp: 1
 """ % BASE_DP1_CONFIG
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup basic loop config"""
         self.setup_valves(self.CONFIG)
 
@@ -562,7 +562,7 @@ dps:
                 loop_protect_external: True
 """ % BASE_DP1_CONFIG
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         self.setup_valves(self.CONFIG)
         self.set_stack_port_up(1)
 
@@ -594,7 +594,7 @@ class ValveStackChainTest(ValveTestBases.ValveTestNetwork):
     DP = 's2'
     DP_ID = 2
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup basic loop config"""
         self.setup_valves(self.CONFIG)
 
@@ -669,7 +669,7 @@ class ValveStackLoopTest(ValveTestBases.ValveTestNetwork):
 
     CONFIG = STACK_LOOP_CONFIG
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup basic loop config"""
         self.setup_valves(self.CONFIG)
 
@@ -856,7 +856,7 @@ dps:
                 native_vlan: 100
 """ % BASE_DP1_CONFIG
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         self.setup_valves(self.CONFIG)
         self.set_stack_port_up(1)
 
@@ -923,7 +923,7 @@ dps:
                 native_vlan: 0x100
 """ % BASE_DP1_CONFIG
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         self.setup_valves(self.CONFIG)
 
     def test_nonstack_dp_port(self):
@@ -939,7 +939,7 @@ class ValveStackRedundancyTestCase(ValveTestBases.ValveTestNetwork):
     STACK_ROOT_STATE_UPDATE_TIME = 10
     STACK_ROOT_DOWN_TIME = STACK_ROOT_STATE_UPDATE_TIME * 3
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         self.setup_valves(self.CONFIG)
 
     def dp_by_name(self, dp_name):
@@ -1032,7 +1032,7 @@ class ValveRootStackTestCase(ValveTestBases.ValveTestNetwork):
     DP = 's3'
     DP_ID = 0x3
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         self.setup_valves(CONFIG)
         self.set_stack_port_up(5)
 
@@ -1088,7 +1088,7 @@ class ValveEdgeStackTestCase(ValveTestBases.ValveTestNetwork):
     DP = 's4'
     DP_ID = 0x4
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         self.setup_valves(CONFIG)
         self.set_stack_port_up(5)
 
@@ -1138,7 +1138,7 @@ class ValveStackProbeTestCase(ValveTestBases.ValveTestNetwork):
 
     CONFIG = STACK_CONFIG
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         self.setup_valves(self.CONFIG)
 
     def test_stack_probe(self):
@@ -1211,7 +1211,7 @@ class ValveStackGraphUpdateTestCase(ValveTestBases.ValveTestNetwork):
 
     CONFIG = STACK_CONFIG
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         self.setup_valves(self.CONFIG)
 
     def test_update_stack_graph(self):
@@ -1328,7 +1328,7 @@ class ValveTestIPV4StackedRouting(ValveTestBases.ValveTestStackedRouting):  # py
     VLAN200_FAUCET_VIPS = '10.0.2.254'
     VLAN200_FAUCET_VIP_SPACE = '10.0.2.254/24'
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         self.setup_stack_routing()
 
 
@@ -1372,7 +1372,7 @@ class ValveTestIPV4StackedRoutingDPOneVLAN(ValveTestBases.ValveTestStackedRoutin
                     stack: {dp: s1, port: 3}
     """
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         self.setup_stack_routing()
 
 
@@ -1451,7 +1451,7 @@ class ValveTestIPV4StackedRoutingPathNoVLANS(ValveTestBases.ValveTestStackedRout
                     stack: {dp: s3, port: 4}
     """
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         self.setup_stack_routing()
 
 
@@ -1463,7 +1463,7 @@ class ValveTestIPV6StackedRouting(ValveTestBases.ValveTestStackedRouting):
     VLAN100_FAUCET_VIP_SPACE = 'fc80::1:254/64'
     VLAN200_FAUCET_VIP_SPACE = 'fc80::1:254/64'
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         self.setup_stack_routing()
 
     @staticmethod
@@ -1570,7 +1570,7 @@ vlans:
                self.VLAN200_FAUCET_MAC, self.VLAN200_FAUCET_VIP_SPACE,
                self.base_config())
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Create a stacking config file."""
         self.create_config()
         self.setup_valves(self.CONFIG)
@@ -3116,7 +3116,7 @@ dps:
                     port: 2
     """
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         self.setup_valves(self.CONFIG)
 
     def test_topo(self):
@@ -3186,7 +3186,7 @@ dps:
                     port: 2
     """
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         self.setup_valves(self.CONFIG)
 
     def test_topo(self):
@@ -3229,7 +3229,7 @@ dps:
                 native_vlan: vlan100
 """
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         self.setup_valves(self.CONFIG)
 
     def check_groupmods_exist(self, ofmsgs, groupdel_exists=True):
@@ -3437,7 +3437,7 @@ dps:
                 native_vlan: vlan200
 """
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup network and start stack ports"""
         self.setup_valves(self.CONFIG)
 
@@ -3556,7 +3556,7 @@ dps:
                 stack: {dp: sw1, port: 7}
 """
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Start network for test"""
         self.setup_valves(self.CONFIG)
 
@@ -3712,7 +3712,7 @@ dps:
                 stack: {dp: sw1, port: 7}
 """
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Start network for test"""
         self.setup_valves(self.CONFIG)
 
@@ -3918,7 +3918,7 @@ dps:
                 stack: {dp: sw1, port: 7}
 """
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Start network for test"""
         self.setup_valves(self.CONFIG)
 
@@ -4076,7 +4076,7 @@ dps:
                 stack: {dp: sw1, port: 7}
 """
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Start network for test"""
         self.setup_valves(self.CONFIG)
 
@@ -4197,7 +4197,7 @@ dps:
                 stack: {dp: sw1, port: 7}
 """
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Start network for test"""
         self.setup_valves(self.CONFIG)
 
@@ -4258,7 +4258,7 @@ dps:
                 native_vlan: 100
 """ % BASE_DP1_CONFIG
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """Setup basic loop config"""
         self.setup_valves(self.CONFIG)
 

--- a/tests/unit/faucet/test_valve_stack.py
+++ b/tests/unit/faucet/test_valve_stack.py
@@ -951,7 +951,7 @@ class ValveStackRedundancyTestCase(ValveTestBases.ValveTestNetwork):
 
     def set_stack_all_ports_status(self, dp_name, status):
         """Set all stack ports to status on dp"""
-        dp = self.dp_by_name(dp_name)  # pylint: disable=invalid-name
+        dp = self.dp_by_name(dp_name)
         for port in dp.stack_ports():
             port.dyn_stack_current_state = status
 
@@ -961,7 +961,7 @@ class ValveStackRedundancyTestCase(ValveTestBases.ValveTestNetwork):
         self.trigger_stack_ports()
         # All switches are down to start with.
         for dpid in self.valves_manager.valves:
-            dp = self.valves_manager.valves[dpid].dp  # pylint: disable=invalid-name
+            dp = self.valves_manager.valves[dpid].dp
             dp.dyn_running = False
             self.set_stack_all_ports_status(dp.name, STACK_STATE_INIT)
         for valve in self.valves_manager.valves.values():
@@ -1068,16 +1068,16 @@ class ValveRootStackTestCase(ValveTestBases.ValveTestNetwork):
                         native_vlan: 100
         """
         self.update_config(SIMPLE_DP_CONFIG, reload_expected=True)
-        dp = self.valves_manager.valves[self.DP_ID].dp  # pylint: disable=invalid-name
+        dp = self.valves_manager.valves[self.DP_ID].dp
         self.assertFalse(dp.stack)
         self.update_config(CONFIG, reload_expected=True)
         self.set_stack_port_up(5)
-        dp = self.valves_manager.valves[self.DP_ID].dp  # pylint: disable=invalid-name
+        dp = self.valves_manager.valves[self.DP_ID].dp
         self.assertTrue(dp.stack.is_root())
 
     def test_topo(self):
         """Test DP is assigned appropriate edge/root states"""
-        dp = self.valves_manager.valves[self.DP_ID].dp  # pylint: disable=invalid-name
+        dp = self.valves_manager.valves[self.DP_ID].dp
         self.assertTrue(dp.stack.is_root())
         self.assertFalse(dp.stack.is_edge())
 
@@ -1128,7 +1128,7 @@ class ValveEdgeStackTestCase(ValveTestBases.ValveTestNetwork):
 
     def test_topo(self):
         """Test DP is assigned appropriate edge/root states"""
-        dp = self.valves_manager.valves[self.DP_ID].dp  # pylint: disable=invalid-name
+        dp = self.valves_manager.valves[self.DP_ID].dp
         self.assertFalse(dp.stack.is_root())
         self.assertTrue(dp.stack.is_edge())
 
@@ -1274,7 +1274,7 @@ class ValveStackGraphBreakTestCase(ValveStackLoopTest):
     def _set_max_lldp_lost(self, new_value):
         """Set the interface config option max_lldp_lost"""
         config = yaml.load(self.CONFIG, Loader=yaml.SafeLoader)
-        for dp in config['dps'].values():  # pylint: disable=invalid-name
+        for dp in config['dps'].values():
             for interface in dp['interfaces'].values():
                 if 'stack' in interface:
                     interface['max_lldp_lost'] = new_value
@@ -3121,7 +3121,7 @@ dps:
 
     def test_topo(self):
         """Test topology functions."""
-        dp = self.valves_manager.valves[self.DP_ID].dp  # pylint: disable=invalid-name
+        dp = self.valves_manager.valves[self.DP_ID].dp
         self.assertTrue(dp.stack.is_root())
         self.assertFalse(dp.stack.is_edge())
 
@@ -3563,7 +3563,7 @@ dps:
     def test_timeout(self):
         """Test stack health on health timeouts"""
         dps = [valve.dp for valve in self.valves_manager.valves.values()]
-        for dp in dps:  # pylint: disable=invalid-name
+        for dp in dps:
             for port in dp.ports.values():
                 if port.lacp:
                     port.actor_up()
@@ -3587,7 +3587,7 @@ dps:
     def test_lacp_down(self):
         """Test stack health on LACP ports being DOWN"""
         dps = [valve.dp for valve in self.valves_manager.valves.values()]
-        for dp in dps:  # pylint: disable=invalid-name
+        for dp in dps:
             for port in dp.ports.values():
                 if port.lacp:
                     port.actor_up()
@@ -3615,7 +3615,7 @@ dps:
     def test_stack_port_down(self):
         """Test stack health on stack ports being DOWN"""
         dps = [valve.dp for valve in self.valves_manager.valves.values()]
-        for dp in dps:  # pylint: disable=invalid-name
+        for dp in dps:
             for port in dp.ports.values():
                 if port.lacp:
                     port.actor_up()
@@ -3722,7 +3722,7 @@ dps:
     def test_sw3_lacp(self):
         """Test LACP health metrics with SW3"""
         dps = [valve.dp for valve in self.valves_manager.valves.values()]
-        for dp in dps:  # pylint: disable=invalid-name
+        for dp in dps:
             for port in dp.ports.values():
                 if port.lacp:
                     port.actor_up()
@@ -3739,7 +3739,7 @@ dps:
     def test_sw1_lacp_down(self):
         """Test LACP health metrics with SW1"""
         dps = [valve.dp for valve in self.valves_manager.valves.values()]
-        for dp in dps:  # pylint: disable=invalid-name
+        for dp in dps:
             for port in dp.ports.values():
                 if port.lacp:
                     port.actor_up()
@@ -3769,7 +3769,7 @@ dps:
     def test_sw2_lacp_down(self):
         """Test LACP health metrics with SW2"""
         dps = [valve.dp for valve in self.valves_manager.valves.values()]
-        for dp in dps:  # pylint: disable=invalid-name
+        for dp in dps:
             for port in dp.ports.values():
                 if port.lacp:
                     port.actor_up()
@@ -3800,7 +3800,7 @@ dps:
     def test_sw1_stack_down(self):
         """Test stack health metrics with SW1"""
         dps = [valve.dp for valve in self.valves_manager.valves.values()]
-        for dp in dps:  # pylint: disable=invalid-name
+        for dp in dps:
             for port in dp.ports.values():
                 if port.lacp:
                     port.actor_up()
@@ -3827,7 +3827,7 @@ dps:
     def test_sw2_stack_down(self):
         """Test stack health metrics with SW2"""
         dps = [valve.dp for valve in self.valves_manager.valves.values()]
-        for dp in dps:  # pylint: disable=invalid-name
+        for dp in dps:
             for port in dp.ports.values():
                 if port.lacp:
                     port.actor_up()
@@ -3928,7 +3928,7 @@ dps:
     def test_lacp_root_nomination(self):
         """Test root selection health"""
         dps = [valve.dp for valve in self.valves_manager.valves.values()]
-        for dp in dps:  # pylint: disable=invalid-name
+        for dp in dps:
             for port in dp.ports.values():
                 if port.lacp:
                     port.actor_up()
@@ -3977,7 +3977,7 @@ dps:
     def test_stack_root_nomination(self):
         """Test root selection health"""
         dps = [valve.dp for valve in self.valves_manager.valves.values()]
-        for dp in dps:  # pylint: disable=invalid-name
+        for dp in dps:
             for port in dp.ports.values():
                 if port.lacp:
                     port.actor_up()
@@ -4087,7 +4087,7 @@ dps:
     def test_root_nomination(self):
         """Test root selection health"""
         dps = [valve.dp for valve in self.valves_manager.valves.values()]
-        for dp in dps:  # pylint: disable=invalid-name
+        for dp in dps:
             for port in dp.ports.values():
                 if port.lacp:
                     port.actor_up()
@@ -4203,7 +4203,7 @@ dps:
 
     def test_stack(self):
         """Test getting config for stack with correct config"""
-        dp = self.valves_manager.valves[1].dp  # pylint: disable=invalid-name
+        dp = self.valves_manager.valves[1].dp
         stack_conf = yaml.safe_load(dp.stack.to_conf())
         self.assertIsInstance(stack_conf, dict)
         self.assertIn('priority', stack_conf)
@@ -4216,7 +4216,7 @@ dps:
 
     def test_dp_stack(self):
         """Test getting config for DP with correct subconfig stack"""
-        dp = self.valves_manager.valves[1].dp  # pylint: disable=invalid-name
+        dp = self.valves_manager.valves[1].dp
         dp_conf = yaml.safe_load(dp.to_conf())
         stack_conf = yaml.safe_load(dp.stack.to_conf())
         self.assertIn('stack', dp_conf)


### PR DESCRIPTION
The initial pylint clean-ups : relating to white-listing startUp / teadDown / dp names