### PR TITLE
Use a single Facuet instance for FaucetUntaggedMaxHostsTest (#3925)

### DIFF
--- a/tests/integration/mininet_tests.py
+++ b/tests/integration/mininet_tests.py
@@ -2697,6 +2697,8 @@ class FaucetTaggedAndUntaggedSameVlanGroupTest(FaucetTaggedAndUntaggedSameVlanTe
 
 class FaucetUntaggedMaxHostsTest(FaucetUntaggedTest):
 
+    NUM_FAUCET_CONTROLLERS = 1
+
     CONFIG_GLOBAL = """
 vlans:
     100:


### PR DESCRIPTION
Currently there is a delay in the startup of multiple Faucet controllers
that is causing this test to fail as a result of unsynchronized state.
For now, limit this test to a single Faucet instance.