### PR TITLE
Remove python3.5 support; update to mostly f-strings

### DIFF
--- a/.github/workflows/tests-unit.yml
+++ b/.github/workflows/tests-unit.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9]
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2
@@ -55,10 +55,6 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - if: matrix.python-version == 3.5
-        name: Upgrade setuptools for python-3.5
-        run: |
-          pip3 install --upgrade setuptools
       - name: Install dependencies
         run: |
           ./docker/pip_deps.sh
@@ -70,7 +66,7 @@ jobs:
       - if: ${{ matrix.python-version == env.CODECOV_PY_VER }}
         name: Upload codecov
         uses: codecov/codecov-action@v2
-      - if: ${{ matrix.python-version != 3.5 && (env.FILES_CHANGED == 'all' || env.RQ_FILES_CHANGED || env.PY_FILES_CHANGED) }}
+      - if: ${{ env.FILES_CHANGED == 'all' || env.RQ_FILES_CHANGED || env.PY_FILES_CHANGED }}
         name: Run pytype
         run: |
           ./docker/pip_deps.sh --extra-requirements="codecheck-requirements.txt"

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,9 +1,7 @@
 [MASTER]
-# TODO: remove consider-using-f-string when python3.5 is gone.
 disable=
     fixme,
-    import-error,
-    consider-using-f-string
+    import-error
 
 [FORMAT]
 max-line-length=120

--- a/clib/clib_mininet_test_main.py
+++ b/clib/clib_mininet_test_main.py
@@ -167,7 +167,7 @@ def check_dependencies():
     for (binary, binary_get_version, binary_present_re,
          binary_version_re, binary_minversion) in EXTERNAL_DEPENDENCIES:
         binary_args = [binary] + binary_get_version
-        required_binary = f'required binary/library {" ".join(binary_args)}')
+        required_binary = f'required binary/library {" ".join(binary_args)}'
         try:
             with subprocess.Popen(
                     binary_args,

--- a/clib/clib_mininet_test_main.py
+++ b/clib/clib_mininet_test_main.py
@@ -125,24 +125,24 @@ def import_hw_config():
         if os.path.isfile(config_file_name):
             break
     if os.path.isfile(config_file_name):
-        print('Using config from %s' % config_file_name)
+        print(f'Using config from {config_file_name}')
     else:
-        print('Cannot find %s in %s' % (HW_SWITCH_CONFIG_FILE, CONFIG_FILE_DIRS))
+        print(f'Cannot find {HW_SWITCH_CONFIG_FILE} in {CONFIG_FILE_DIRS}')
         sys.exit(-1)
     try:
         with open(config_file_name, 'r', encoding='utf-8') as config_file:
             config = yaml.safe_load(config_file)
     except IOError:
-        print('Could not load YAML config data from %s' % config_file_name)
+        print(f'Could not load YAML config data from {config_file_name}')
         sys.exit(-1)
     if config.get('hw_switch', False):
         unknown_keys = set(config.keys()) - set(ALL_HW_CONFIG.keys())
         if unknown_keys:
-            print('unknown config %s in %s' % (unknown_keys, config_file_name))
+            print(f'unknown config {unknown_keys} in {config_file_name}')
             sys.exit(-1)
         missing_required_keys = set(REQUIRED_HW_CONFIG.keys()) - set(config.keys())
         if missing_required_keys:
-            print('missing required config: %s' % missing_required_keys)
+            print(f'missing required config: {missing_required_keys}')
             sys.exit(-1)
         for config_key, config_value in config.items():
             valid_types = ALL_HW_CONFIG[config_key]
@@ -150,15 +150,12 @@ def import_hw_config():
                 config_value for valid_type in valid_types
                 if isinstance(config_value, valid_type)]
             if not valid_values:
-                print('%s (%s) must be of type %s in %s' % (
-                    config_key, config_value,
-                    valid_types, config_file_name))
+                print(f'{config_key} ({config_value}) must be of type {valid_types} in {config_file_name}')
                 sys.exit(-1)
         dp_ports = config['dp_ports']
         if len(dp_ports) < REQUIRED_TEST_PORTS:
-            print('At least %u dataplane ports are required, '
-                  '%d are provided in %s.' %
-                  (REQUIRED_TEST_PORTS, len(dp_ports), config_file_name))
+            print(f'At least {REQUIRED_TEST_PORTS} dataplane ports are required, '
+                  f'{len(dp_ports)} are provided in {config_file_name}.')
             sys.exit(-1)
         return config
     return None
@@ -170,8 +167,7 @@ def check_dependencies():
     for (binary, binary_get_version, binary_present_re,
          binary_version_re, binary_minversion) in EXTERNAL_DEPENDENCIES:
         binary_args = [binary] + binary_get_version
-        required_binary = 'required binary/library %s' % (
-            ' '.join(binary_args))
+        required_binary = f'required binary/library {" ".join(binary_args)}')
         try:
             with subprocess.Popen(
                     binary_args,
@@ -187,31 +183,28 @@ def check_dependencies():
             # Might have run successfully, need to parse output
             pass
         except OSError:
-            print('could not run %s' % required_binary)
+            print(f'could not run {required_binary}')
             return False
         present_match = re.search(binary_present_re, binary_output)
         if not present_match:
-            print('%s not present or did not return expected string %s (%s)' % (
-                required_binary, binary_present_re, binary_output))
+            print(f'{required_binary} not present or did not return expected string '
+                  f'{binary_present_re} ({binary_output})')
             return False
         if binary_version_re:
             version_match = re.search(binary_version_re, binary_output)
             if version_match is None:
-                print('could not get version from %s (%s)' % (
-                    required_binary, binary_output))
+                print(f'could not get version from {required_binary} ({binary_output})')
                 return False
             try:
                 binary_version = version_match.group(1)
             except ValueError:
-                print('cannot parse version %s for %s' % (
-                    version_match, required_binary))
+                print(f'cannot parse version {version_match} for {required_binary}')
                 return False
             if binary == 'fuser' and binary_version == 'UNKNOWN':
                 # Workaround for psmisc 23.3
                 return True
             if version.parse(binary_version) < version.parse(binary_minversion):
-                print('%s version %s is less than required version %s' % (
-                    required_binary, binary_version, binary_minversion))
+                print(f'{required_binary} version {binary_version} is less than required version {binary_minversion}')
                 return False
     return True
 
@@ -334,16 +327,13 @@ def pipeline_superset_report(decoded_pcap_logs):
             parse_flow(flow_lines)
 
     for table in sorted(table_matches):
-        print('table: %u' % table)
-        print('  matches: %s (max %u)' % (
-            sorted(table_matches[table]), table_matches_max[table]))
-        print('  table_instructions: %s (max %u)' % (
-            sorted(table_instructions[table]), table_instructions_max[table]))
-        print('  table_actions: %s (max %u)' % (
-            sorted(table_actions[table]), table_actions_max[table]))
+        print(f'table: {table}')
+        print(f'  matches: {sorted(table_matches[table])} (max {table_matches_max[table]})')
+        print(f'  table_instructions: {sorted(table_instructions[table])} (max {table_instructions_max[table]})')
+        print(f'  table_actions: {sorted(table_actions[table])} (max {table_actions_max[table]})')
     if group_actions:
         print('group bucket actions:')
-        print('  %s' % sorted(group_actions))
+        print(f'  {sorted(group_actions)}')
 
 
 def filter_test_hardware(test_obj, hw_config):
@@ -399,7 +389,7 @@ def expand_tests(modules, requested_test_classes, regex_test_classes, excluded_t
             if test_name.endswith('Test') and test_name.startswith('Faucet'):
                 if not filter_test_hardware(test_obj, hw_config):
                     continue
-                print('adding test %s' % test_name)
+                print(f'adding test {test_name}')
                 test_suite = make_suite(
                     test_obj, hw_config, root_tmpdir, ports_sock, max_loadavg(),
                     port_order, start_port)
@@ -420,7 +410,7 @@ def expand_tests(modules, requested_test_classes, regex_test_classes, excluded_t
             parallel_test_suites = []
         if parallel_test_suites:
             seed = time.time()
-            print('seeding parallel test shuffle with %f' % seed)
+            print(f'seeding parallel test shuffle with {seed}')
             random.seed(seed)
             random.shuffle(parallel_test_suites)
             for test_suite in parallel_test_suites:
@@ -488,7 +478,7 @@ def run_parallel_test_suites(root_tmpdir, resultclass, parallel_tests):
     results = []
     if parallel_tests.countTestCases():
         max_parallel_tests = min(parallel_tests.countTestCases(), max_loadavg())
-        print('running maximum of %u parallel tests' % max_parallel_tests)
+        print(f'running maximum of {max_parallel_tests} parallel tests')
         parallel_runner = test_runner(root_tmpdir, resultclass)
         parallel_suite = ConcurrentTestSuite(
             parallel_tests, fork_for_tests(max_parallel_tests))
@@ -564,8 +554,8 @@ def report_results(results, hw_config, report_json_filename):
 
 def run_test_suites(debug, report_json_filename, hw_config, root_tmpdir,
                     resultclass, single_tests, parallel_tests, sanity_result):
-    print('running %u tests in parallel and %u tests serial' % (
-        parallel_tests.countTestCases(), single_tests.countTestCases()))
+    print(f'running {parallel_tests.countTestCases()} tests in parallel and '
+          f'{single_tests.countTestCases()} tests serial')
     results = []
     results.append(sanity_result)
     results.extend(run_parallel_test_suites(root_tmpdir, resultclass, parallel_tests))
@@ -588,7 +578,7 @@ def start_port_server(root_tmpdir, start_free_ports, min_free_ports):
             break
         time.sleep(1)
     if not os.path.exists(ports_sock):
-        print('ports server did not start (%s not created)' % ports_sock)
+        print(f'ports server did not start ({ports_sock} not created)')
         sys.exit(-1)
     return ports_sock
 
@@ -637,7 +627,7 @@ def clean_test_dirs(root_tmpdir, all_successful, sanity, keep_logs, dumpfail):
         if not keep_logs or not os.listdir(root_tmpdir):
             shutil.rmtree(root_tmpdir)
     else:
-        print('\nlog/debug files for failed tests are in %s\n' % root_tmpdir)
+        print(f'\nlog/debug files for failed tests are in {root_tmpdir}\n')
         if not keep_logs:
             if sanity:
                 test_dirs = glob.glob(os.path.join(root_tmpdir, '*'))
@@ -657,7 +647,7 @@ def run_tests(modules, hw_config, requested_test_classes, regex_test_classes, du
         print('Testing hardware, forcing test serialization')
         serial = True
     root_tmpdir = tempfile.mkdtemp(prefix='faucet-tests-', dir='/var/tmp')
-    print('Logging test results in %s' % root_tmpdir)
+    print(f'Logging test results in {root_tmpdir}')
     start_free_ports = 10
     min_free_ports = 200
     if serial:
@@ -778,7 +768,7 @@ def parse_args():
         regex_test_classes = None
         if args.regex:
             regex_test_classes = re.compile(args.regex)
-            print('Running tests on classes matching %s' % args.regex)
+            print(f'Running tests on classes matching {args.regex}')
     except(KeyError, IndexError, ValueError):
         parser.print_usage()
         sys.exit(-1)
@@ -798,7 +788,7 @@ def parse_args():
 def test_main(modules):
     """Test main."""
 
-    print('testing module %s' % modules)
+    print(f'testing module {modules}')
 
     (requested_test_classes, regex_test_classes, clean, dumpfail, debug, keep_logs, nocheck,
      serial, repeat, excluded_test_classes, report_json_filename, port_order,
@@ -821,7 +811,7 @@ def test_main(modules):
             sys.exit(-1)
 
     print('port order: -o', ','.join(str(i) for i in port_order))
-    print('start port: --port %s' % start_port)
+    print(f'start port: --port {start_port}')
 
     hw_config = import_hw_config()
 

--- a/clib/clib_mininet_tests.py
+++ b/clib/clib_mininet_tests.py
@@ -59,12 +59,12 @@ class FaucetTcpdumpHelperTest(FaucetSimpleTest):
     def _terminate_with_zero(self, tcpdump_helper):
         term_returns = tcpdump_helper.terminate()
         self.assertEqual(
-            0, term_returns, msg='terminate code not 0: %d' % term_returns)
+            0, term_returns, msg=f'terminate code not 0: {term_returns}')
 
     def _terminate_with_nonzero(self, tcpdump_helper):
         term_returns = tcpdump_helper.terminate()
         self.assertNotEqual(
-            0, term_returns, msg='terminate code is 0: %d' % term_returns)
+            0, term_returns, msg=f'terminate code is 0: {term_returns}')
 
     def test_tcpdump_execute(self):
         """Check tcpdump filter monitors ping using execute"""
@@ -73,10 +73,10 @@ class FaucetTcpdumpHelperTest(FaucetSimpleTest):
         to_host = self.net.hosts[1]
         tcpdump_filter = ('icmp')
         tcpdump_helper = TcpdumpHelper(to_host, tcpdump_filter, [
-            lambda: from_host.cmd('ping -c1 %s' % to_host.IP())])
+            lambda: from_host.cmd(f'ping -c1 {to_host.IP()}')])
         tcpdump_txt = tcpdump_helper.execute()
         self.assertTrue(re.search(
-            '%s: ICMP echo request' % to_host.IP(), tcpdump_txt))
+            f'{to_host.IP()}: ICMP echo request', tcpdump_txt))
         self._terminate_with_zero(tcpdump_helper)
 
     def test_tcpdump_pcap(self):
@@ -88,11 +88,11 @@ class FaucetTcpdumpHelperTest(FaucetSimpleTest):
         pcap_file = os.path.join(self.tmpdir, 'out.pcap')
         tcpdump_helper = TcpdumpHelper(
             to_host, tcpdump_filter,
-            [lambda: from_host.cmd('ping -c3 %s' % to_host.IP())],
+            [lambda: from_host.cmd(f'ping -c3 {to_host.IP()}')],
             pcap_out=pcap_file, packets=None)
         tcpdump_helper.execute()
         self._terminate_with_zero(tcpdump_helper)
-        result = from_host.cmd('tcpdump -en -r %s' % pcap_file)
+        result = from_host.cmd(f'tcpdump -en -r {pcap_file}')
         self.assertEqual(result.count('ICMP echo reply'), 3, 'three icmp echo replies')
 
     def test_tcpdump_noblock(self):
@@ -103,7 +103,7 @@ class FaucetTcpdumpHelperTest(FaucetSimpleTest):
         tcpdump_filter = ('icmp')
         tcpdump_helper = TcpdumpHelper(
             to_host, tcpdump_filter,
-            [lambda: from_host.cmd('ping -c10 %s' % to_host.IP())],
+            [lambda: from_host.cmd(f'ping -c10 {to_host.IP()}')],
             blocking=False, packets=None)
         count = 0
         while tcpdump_helper.next_line():
@@ -118,14 +118,14 @@ class FaucetTcpdumpHelperTest(FaucetSimpleTest):
         to_host = self.net.hosts[1]
         tcpdump_filter = ('icmp')
         tcpdump_helper = TcpdumpHelper(to_host, tcpdump_filter, [
-            lambda: from_host.cmd('ping -c5 -i2 %s' % to_host.IP())])
+            lambda: from_host.cmd(f'ping -c5 -i2 {to_host.IP()}')])
 
         self.assertTrue(re.search('proto ICMP', tcpdump_helper.next_line()))
         next_line = tcpdump_helper.next_line()
-        self.assertTrue(re.search('%s: ICMP echo request' % to_host.IP(), next_line), next_line)
+        self.assertTrue(re.search(f'{to_host.IP()}: ICMP echo request', next_line), next_line)
         self.assertTrue(re.search('proto ICMP', tcpdump_helper.next_line()))
         next_line = tcpdump_helper.next_line()
-        self.assertTrue(re.search('%s: ICMP echo reply' % from_host.IP(), next_line), next_line)
+        self.assertTrue(re.search(f'{from_host.IP()}: ICMP echo reply', next_line), next_line)
         self.assertFalse(re.search('ICMP', tcpdump_helper.next_line()))
         while tcpdump_helper.next_line():
             pass
@@ -154,7 +154,7 @@ class FaucetDockerHostTest(FaucetSimpleTest):
 
         self.assertTrue(
             count == self.N_EXTENDED,
-            'Found %d containers, expected %d' % (count, self.N_EXTENDED))
+            f'Found {count} containers, expected {self.N_EXTENDED}')
 
         self.assertTrue(
             os.path.exists(

--- a/clib/config_generator.py
+++ b/clib/config_generator.py
@@ -97,7 +97,7 @@ class FaucetTopoGenerator(Topo):
         for i, dpid in self.dpids_by_id.items():
             switch_name = self.switches_by_id[i]
             ports = self.ports[switch_name].keys()
-            port_maps[dpid] = {'port_%d' % i: port for i, port in enumerate(ports)}
+            port_maps[dpid] = {f'port_{i}': port for i, port in enumerate(ports)}
         return port_maps
 
     def create_port_maps(self):
@@ -137,7 +137,7 @@ class FaucetTopoGenerator(Topo):
     @staticmethod
     def vlan_name(i):
         """VLAN name"""
-        return 'vlan-%i' % (i + 1)
+        return f'vlan-{i+1}'
 
     @staticmethod
     def vlan_vid(i):
@@ -147,7 +147,7 @@ class FaucetTopoGenerator(Topo):
     @staticmethod
     def router_name(i):
         """Router name"""
-        return 'router-%s' % (i + 1)
+        return f'router-{i + 1}'
 
     def __init__(self, *args, **kwargs):
         self.switches_by_id = {}
@@ -165,8 +165,7 @@ class FaucetTopoGenerator(Topo):
             string.ascii_letters + string.digits))
         id_a = int(ports_served / len(id_chars))
         id_b = ports_served - (id_a * len(id_chars))
-        return '%s%s' % (
-            id_chars[id_a], id_chars[id_b])
+        return f'{id_chars[id_a]}{id_chars[id_b]}'
 
     @staticmethod
     def extend_port_order(port_order=None, max_length=16):
@@ -253,7 +252,7 @@ class FaucetTopoGenerator(Topo):
         """
         sid_prefix = self._generate_sid_prefix()
         switch_cls = FaucetSwitch
-        switch_name = 's%s' % sid_prefix
+        switch_name = f's{sid_prefix}'
         if switch_index == 0 and self.hw_dpid:
             self.hw_name = switch_name
             self.dpids_by_id[switch_index] = self.hw_dpid
@@ -406,28 +405,28 @@ class FaucetTopoGenerator(Topo):
                 # Link is to an outside network, so treat it as a output only link with more
                 #   specific options defined in the options dictionary
                 interface_config = {
-                    'name': 'b%u' % src_port,
-                    'description': 'output only %s' % link_name,
+                    'name': f'{src_port}',
+                    'description': f'output only {link_name}',
                 }
             elif isinstance(vlans, int):
                 # Untagged link
                 interface_config = {
-                    'name': 'b%u' % src_port,
-                    'description': 'untagged %s' % link_name,
+                    'name': f'b{src_port}',
+                    'description': f'untagged {link_name}',
                     'native_vlan': self.vlan_name(vlans)
                 }
             elif isinstance(vlans, list):
                 # Tagged link
                 interface_config = {
-                    'name': 'b%u' % src_port,
-                    'description': 'tagged %s' % link_name,
+                    'name': f'b{src_port}',
+                    'description': f'tagged {link_name}',
                     'tagged_vlans': [self.vlan_name(vlan) for vlan in vlans]
                 }
             elif dst_node and dst_port:
                 # Stack link
                 interface_config = {
-                    'name': 'b%u' % src_port,
-                    'description': 'stack %s' % link_name,
+                    'name': f'b{src_port}',
+                    'description': f'stack {link_name}',
                     'stack': {
                         'dp': dst_node,
                         'port': dst_port
@@ -436,11 +435,11 @@ class FaucetTopoGenerator(Topo):
             elif vlans is None:
                 # output only link or coprocessor, leave to more specific options to handle
                 interface_config = {
-                    'name': 'b%u' % src_port,
-                    'description': 'output only %s' % link_name,
+                    'name': f'b{src_port}',
+                    'description': f'output only {link_name}',
                 }
             else:
-                raise GenerationError('Unknown %s link type %s' % (type_, vlans))
+                raise GenerationError(f'Unknown {type} link type {vlans}')
             if options:
                 for option_key, option_value in options.items():
                     interface_config[option_key] = option_value
@@ -460,7 +459,7 @@ class FaucetTopoGenerator(Topo):
                     src_port, dst_port = link_info['port2'], link_info['port1']
                 else:
                     src_port, dst_port = link_info['port1'], link_info['port2']
-                link_name = 'link #%s to %s:%s' % (link_key, dst_node, dst_port)
+                link_name = f'link #{link_key} to {dst_node}:{dst_port}'
                 options = {}
                 dst_id = dst_info['switch_n']
                 if link_options and (src_id, dst_id) in link_options:
@@ -470,7 +469,7 @@ class FaucetTopoGenerator(Topo):
             else:
                 # Generate host-switch config link
                 src_port, dst_port = link_info['port1'], None
-                link_name = 'link #%s to %s' % (link_key, dst_node)
+                link_name = f'link #{link_key} to {dst_node}'
                 host_n = dst_info['host_n']
                 if host_options and host_n in host_options:
                     options = host_options[host_n]
@@ -586,4 +585,4 @@ class FaucetFakeOFTopoGenerator(FaucetTopoGenerator):
     @staticmethod
     def dp_dpid(i):
         """DP DPID"""
-        return '%u' % (i + 1)
+        return f'{i + 1}'

--- a/clib/docker_host.py
+++ b/clib/docker_host.py
@@ -100,7 +100,7 @@ class DockerHost(Host):
         base_cmd = ["docker", "run", "-ti", "--privileged", "--entrypoint", "env",
                     "-h", self.name, "--name", self.container]
         opt_args = [f'--net={self.network}']
-        env_vars = self.env_vars + [f"TERM=dumb", "PS1={self.ps1}"]
+        env_vars = self.env_vars + ["TERM=dumb", f"PS1={self.ps1}"]
         env_args = reduce(operator.add, (['--env', var] for var in env_vars), [])
         vol_args = reduce(operator.add, (['-v', var] for var in self.vol_maps), ['-v', tmp_volume])
         image_args = [self.image, "bash", "--norc", "-is", "mininet:" + self.name]

--- a/clib/fakeoftable.py
+++ b/clib/fakeoftable.py
@@ -189,7 +189,7 @@ class FakeOFNetwork:
             if not found:
                 # Packet not reached destination, so continue traversing
                 if trace:
-                    sys.stderr.write('FakeOFTable %s: %s\n' % (dp_id, pkt))
+                    sys.stderr.write(f'FakeOFTable {dp_id}: {pkt}\n')
                 port_outputs = self.tables[dp_id].get_port_outputs(pkt, trace=trace)
                 valve = self.valves_manager.valves[dp_id]
                 for out_port, out_pkts in port_outputs.items():
@@ -219,7 +219,7 @@ class FakeOFNetwork:
                         elif trace:
                             # Output to non-stack port, can ignore this output
                             sys.stderr.write(
-                                'Ignoring non-stack output %s:%s\n' % (valve.dp.name, out_port))
+                                f'Ignoring non-stack output {valve.dp.name}:{out_port}\n')
             if trace:
                 sys.stderr.write('\n')
         return found
@@ -270,13 +270,13 @@ class FakeOFTable:
         def _add(ofmsg, group_id):
             if group_id in self.groups:
                 raise FakeOFTableException(
-                    'group already in group table: %s' % ofmsg)
+                    f'group already in group table: {ofmsg}')
             self.groups[group_id] = ofmsg
 
         def _modify(ofmsg, group_id):
             if group_id not in self.groups:
                 raise FakeOFTableException(
-                    'group not in group table: %s' % ofmsg)
+                    f'group not in group table: {ofmsg}')
             self.groups[group_id] = ofmsg
 
         _groupmod_handlers = {
@@ -298,15 +298,12 @@ class FakeOFTable:
             if table_id == ofp.OFPTT_ALL:
                 if ofmsg.match.items() and not self.tfm:
                     raise FakeOFTableException(
-                        'got %s with matches before TFM that defines tables'
-                        % ofmsg)
+                        f'got {ofmsg} with matches before TFM that defines tables')
                 return
 
             if tfm_body is None:
                 raise FakeOFTableException(
-                    'got %s before TFM that defines table %u' % (
-                        ofmsg, table_id
-                    )
+                    f'got {ofmsg} before TFM that defines table {table_id}'
                 )
 
         def _add(table, flowmod):
@@ -333,9 +330,7 @@ class FakeOFTable:
                     table.remove(fte)
                     break
                 if flowmod.overlaps(fte):
-                    raise FakeOFTableException(
-                        'Overlapping flowmods {} and {}'.format(
-                            flowmod, fte))
+                    raise FakeOFTableException(f'Overlapping flowmods {flowmod} and {fte}')
             table.append(flowmod)
 
         def _del(table, flowmod):
@@ -386,8 +381,7 @@ class FakeOFTable:
             for table in tables:
                 entries = len(table)
                 if entries > tfm_body.max_entries:
-                    tfm_table_details = '%s : table %u %s full (%u/%u)' % (
-                        self.dp_id, table_id, tfm_body.name, entries, tfm_body.max_entries)
+                    tfm_table_details = f'self.dp_id: table {table_id} {tfm_body.name} full ({entries}/{tfm_body.max_entries})'
                     flow_dump = '\n\n'.join(
                         (tfm_table_details, str(ofmsg), str(tfm_body)))
                     raise FakeOFTableException(flow_dump)
@@ -464,7 +458,7 @@ class FakeOFTable:
                 matching_fte = fte
                 break
         if trace:
-            sys.stderr.write('%s: %s\n' % (table_id, matching_fte))
+            sys.stderr.write(f'{table_id}: {matching_fte}\n')
         return matching_fte
 
     def _process_instruction(self, match, instruction):
@@ -515,7 +509,7 @@ class FakeOFTable:
             elif action.type == ofp.OFPAT_GROUP:
                 # Group mod so make sure that we process the group buckets
                 if action.group_id not in self.groups:
-                    raise FakeOFTableException('output group not in group table: %s' % action)
+                    raise FakeOFTableException(f'output group not in group table: {action}')
                 buckets = self.groups[action.group_id].buckets
                 for bucket in buckets:
                     bucket_outputs, _, _ = self._process_instruction(packet_dict, bucket)
@@ -568,8 +562,8 @@ class FakeOFTable:
         if next_table:
             pending_actions = []
         if pending_actions:
-            raise FakeOFTableException('flow performs actions on packet after \
-                                       output with no goto: %s' % matching_fte)
+            raise FakeOFTableException(f'flow performs actions on packet after \
+                                       output with no goto: {matching_fte}')
         return outputs, packet_dict, next_table
 
     def get_output(self, match, trace=False):
@@ -699,7 +693,7 @@ class FakeOFTable:
             # if a flowmod is found, make modifications to the match values and
             # determine if another lookup is necessary
             if trace:
-                sys.stderr.write('%d: %s\n' % (table_id, matching_fte))
+                sys.stderr.write(f'{table_id}: {matching_fte}\n')
             if matching_fte:
                 for instruction in matching_fte.instructions:
                     instructions.append(instruction)
@@ -772,7 +766,7 @@ class FakeOFTable:
 
         if trace:
             sys.stderr.write(
-                'tracing packet flow %s matching to port %s, vid %s\n' % (match, port, vid))
+                f'tracing packet flow {match} matching to port {port}, vid {vid}\n')
 
         # vid_stack represents the packet's vlan stack, innermost label listed
         # first
@@ -797,7 +791,7 @@ class FakeOFTable:
                 elif action.type == ofp.OFPAT_GROUP:
                     if action.group_id not in self.groups:
                         raise FakeOFTableException(
-                            'output group not in group table: %s' % action)
+                            f'output group not in group table: {action}')
                     buckets = self.groups[action.group_id].buckets
                     for bucket in buckets:
                         bucket_vid_stack = vid_stack
@@ -831,7 +825,7 @@ class FakeOFTable:
     def __str__(self):
         string = ''
         for table_id, table in enumerate(self.tables):
-            string += '\n----- Table %u -----\n' % (table_id)
+            string += f'\n----- Table {table_id} -----\n'
             string += '\n'.join(sorted([str(flowmod) for flowmod in table]))
         return string
 
@@ -883,8 +877,7 @@ class FlowMod:
         for instruction in self.instructions:
             if instruction.type in instruction_types:
                 raise FakeOFTableException(
-                    'FlowMod with Multiple instructions of the '
-                    'same type: {}'.format(self.instructions))
+                    f'FlowMod with Multiple instructions of the same type: {self.instructions}')
             instruction_types.add(instruction.type)
 
     def out_port_matches(self, other):
@@ -1050,7 +1043,7 @@ class FlowMod:
                 if mask is not None and mask != -1:
                     mask_str = str(mask)
         if mask_str:
-            result += "/{}".format(mask_str)
+            result += f"/{mask_str}"
         return result
 
     def _pretty_action_str(self, action):
@@ -1069,7 +1062,7 @@ class FlowMod:
             else:
                 value = str(action.port)
         elif isinstance(action, parser.OFPActionSetField):
-            name = 'set_{}'.format(action.key)
+            name = f'set_{action.key}'
             value = self._pretty_field_str(action.key, action.value)
         else:
             name, attr = actions_names_attrs[type(action).__name__]
@@ -1077,40 +1070,39 @@ class FlowMod:
                 value = getattr(action, attr)
         result = name
         if value:
-            result += " {}".format(value)
+            result += f" {value}"
         return result
 
     def __str__(self):
-        result = 'Priority: {0} | Match: '.format(self.priority)
+        result = f'Priority: {self.priority} | Match: '
 
         for key in sorted(self.match_values.keys()):
             val = self.match_values[key]
             mask = self.match_masks[key]
-            result += " {} {},".format(
-                key, self._pretty_field_str(key, val, mask))
+            result += f" {key} {self._pretty_field_str(key, val, mask)},"
         result = result.rstrip(',')
         result += " | Instructions :"
         if not self.instructions:
             result += ' drop'
         for instruction in self.instructions:
             if isinstance(instruction, parser.OFPInstructionGotoTable):
-                result += ' goto {}'.format(instruction.table_id)
+                result += f' goto {instruction.table_id}'
             elif isinstance(instruction, parser.OFPInstructionActions):
                 for action in instruction.actions:
-                    result += " {},".format(self._pretty_action_str(action))
+                    result += f" {self._pretty_action_str(action)},"
             else:
                 result += str(instruction)
         result = result.rstrip(',')
         return result
 
     def __repr__(self):
-        string = 'priority: {0} cookie: {1}'.format(self.priority, self.cookie)
+        string = f'priority: {self.priority} cookie: {self.cookie}'
         for key in sorted(self.match_values.keys()):
             mask = self.match_masks[key]
-            string += ' {0}: {1}'.format(key, self.match_values[key])
+            string += f' {key}: {self.match_values[key]}'
             if mask.int != -1:  # pytype: disable=attribute-error
-                string += '/{0}'.format(mask)
-        string += ' Instructions: {0}'.format(str(self.instructions))
+                string += f'/{mask}'
+        string += f' Instructions: {str(self.instructions)}'
         return string
 
 

--- a/clib/mininet_test_base.py
+++ b/clib/mininet_test_base.py
@@ -2159,9 +2159,9 @@ dbs:
         tcpdump_filter = (
             f'not ether src {mirror_mac} and ether proto 0x888e')
         eap_conf_cmd = (
-            'echo "eapol_version=2\nap_scan=0\nnetwork={\n'
-            'key_mgmt=IEEE8021X\neap=MD5\nidentity=\\"login\\"\n'
-            f'password=\\"password\\"\n}\n" > {tmp_eap_conf}')
+            f'echo "eapol_version=2\nap_scan=0\nnetwork={{\n'
+            f'key_mgmt=IEEE8021X\neap=MD5\nidentity=\\"login\\"\n'
+            f'password=\\"password\\"\n}}\n" > {tmp_eap_conf}')
         wpa_supplicant_cmd = mininet_test_util.timeout_cmd(
             f'wpa_supplicant -c{tmp_eap_conf} -Dwired -i{first_host.defaultIntf().name} -d', 3)
         tcpdump_txt = self.tcpdump_helper(

--- a/clib/mininet_test_base.py
+++ b/clib/mininet_test_base.py
@@ -1011,7 +1011,7 @@ dps:
 faucet_configs:
     - {faucet_config_file}
 watchers:
-    {self.get_gauage_watcher_config()}
+    {self.get_gauge_watcher_config()}
 dbs:
     stats_file:
         type: 'text'

--- a/clib/mininet_test_base.py
+++ b/clib/mininet_test_base.py
@@ -209,7 +209,7 @@ class FaucetTestBase(unittest.TestCase):
     def _set_vars(self):
         """Set controller additional variables"""
         for c_index in range(self.NUM_FAUCET_CONTROLLERS):
-            self._set_var('faucet-%s' % c_index, 'FAUCET_PROMETHEUS_PORT',
+            self._set_var(f'faucet-{c_index}', 'FAUCET_PROMETHEUS_PORT',
                           str(self.faucet_prom_ports[c_index]))
 
     def _set_var_path(self, controller, var, path):
@@ -223,25 +223,25 @@ class FaucetTestBase(unittest.TestCase):
         self.event_sock_dir = tempfile.mkdtemp()
         self.event_socks = []
         for c_index in range(self.NUM_FAUCET_CONTROLLERS):
-            event_sock = os.path.join(self.event_sock_dir, 'event-%s.sock' % c_index)
+            event_sock = os.path.join(self.event_sock_dir, f'event-{c_index}.sock')
             self.event_socks.append(event_sock)
 
-            self._set_var('faucet-%s' % c_index, 'FAUCET_LOG_LEVEL', str(self.LOG_LEVEL))
-            self._set_var('faucet-%s' % c_index, 'FAUCET_CONFIG_STAT_RELOAD', self.STAT_RELOAD)
-            self._set_var('faucet-%s' % c_index, 'FAUCET_EVENT_SOCK', event_sock)
-            self._set_var('faucet-%s' % c_index, 'FAUCET_EVENT_SOCK_HEARTBEAT',
+            self._set_var(f'faucet-{c_index}', 'FAUCET_LOG_LEVEL', str(self.LOG_LEVEL))
+            self._set_var(f'faucet-{c_index}', 'FAUCET_CONFIG_STAT_RELOAD', self.STAT_RELOAD)
+            self._set_var(f'faucet-{c_index}', 'FAUCET_EVENT_SOCK', event_sock)
+            self._set_var(f'faucet-{c_index}', 'FAUCET_EVENT_SOCK_HEARTBEAT',
                           self.EVENT_SOCK_HEARTBEAT)
-            self._set_var('faucet-%s' % c_index, 'FAUCET_PROMETHEUS_ADDR',
+            self._set_var(f'faucet-{c_index}', 'FAUCET_PROMETHEUS_ADDR',
                           mininet_test_util.LOCALHOSTV6)
-            self._set_var_path('faucet-%s' % c_index, 'FAUCET_CONFIG', 'faucet.yaml')
-            self._set_var_path('faucet-%s' % c_index, 'FAUCET_LOG', 'faucet-%s.log' % c_index)
-            self._set_var_path('faucet-%s' % c_index, 'FAUCET_EXCEPTION_LOG',
-                               'faucet-%s-exception.log' % c_index)
+            self._set_var_path(f'faucet-{c_index}', 'FAUCET_CONFIG', 'faucet.yaml')
+            self._set_var_path(f'faucet-{c_index}', 'FAUCET_LOG', f'faucet-{c_index}.log')
+            self._set_var_path(f'faucet-{c_index}', 'FAUCET_EXCEPTION_LOG',
+                               f'faucet-{c_index}-exception.log')
         for c_index in range(self.NUM_GAUGE_CONTROLLERS):
-            self._set_var_path('gauge-%s' % c_index, 'GAUGE_CONFIG', 'gauge.yaml')
-            self._set_var_path('gauge-%s' % c_index, 'GAUGE_LOG', 'gauge-%s.log' % c_index)
-            self._set_var_path('gauge-%s' % c_index, 'GAUGE_EXCEPTION_LOG',
-                               'gauge-%s-exception.log' % c_index)
+            self._set_var_path(f'gauge-{c_index}', 'GAUGE_CONFIG', 'gauge.yaml')
+            self._set_var_path(f'gauge-{c_index}', 'GAUGE_LOG', f'gauge-{c_index}.log')
+            self._set_var_path(f'gauge-{c_index}', 'GAUGE_EXCEPTION_LOG',
+                               f'gauge-{c_index}-exception.log')
         self.faucet_config_path = self.env['faucet-0']['FAUCET_CONFIG']
         self.gauge_config_path = self.env['gauge-0']['GAUGE_CONFIG']
         self.debug_log_path = os.path.join(
@@ -286,7 +286,7 @@ class FaucetTestBase(unittest.TestCase):
         # as an alternative we might possibly use something like
         # `with popen(cmd...) as proc`to clean up on exceptions
         controller.cmd(mininet_test_util.timeout_cmd(
-            'nc -U %s > %s &' % (sock, self.event_log), timeout))
+            f'nc -U {sock} > {self.event_log} &', timeout))
 
     # pylint: disable=inconsistent-return-statements
     def _wait_until_matching_event(self, match_func, timeout=30):
@@ -337,8 +337,8 @@ class FaucetTestBase(unittest.TestCase):
                     number = intf_conf.get('number', port_no)
                     if isinstance(number, int):
                         port_no = number
-                    assert isinstance(number, int), '%u %s' % (intf_key, orig_intf_conf)
-                    intf_name = 'b%u' % port_no
+                    assert isinstance(number, int), f'{intf_key} {orig_intf_conf}'
+                    intf_name = f'b{port_no}'
                     intf_conf.update({'name': intf_name, 'description': intf_name})
                     remap_interfaces_yaml[intf_key] = intf_conf
                 yaml_conf_remap['dps'][dp_key]['interfaces'] = remap_interfaces_yaml
@@ -358,7 +358,7 @@ class FaucetTestBase(unittest.TestCase):
             conf_file_tmp_str = conf_file_tmp.read()
             assert new_conf_str == conf_file_tmp_str
         if os.path.exists(yaml_path):
-            shutil.copyfile(yaml_path, '%s.%f' % (yaml_path, time.time()))
+            shutil.copyfile(yaml_path, f'{yaml_path}.{time.time()}')
         os.rename(conf_file_tmp_name, yaml_path)
 
     def _init_faucet_config(self):
@@ -398,8 +398,8 @@ class FaucetTestBase(unittest.TestCase):
             load = os.getloadavg()[0]
             if load < self.max_test_load:
                 return
-            output('load average too high %f, waiting' % load)
-        self.fail('load average %f consistently too high' % load)
+            output(f'load average too high {load}, waiting')
+        self.fail(f'load average {load} consistently too high')
 
     def _allocate_config_ports(self):
         for port_name in self.config_ports:
@@ -409,7 +409,7 @@ class FaucetTestBase(unittest.TestCase):
                     port = mininet_test_util.find_free_port(
                         self.ports_sock, self._test_name())
                     self.config_ports[port_name] = port
-                    output('allocating port %u for %s' % (port, port_name))
+                    output(f'allocating port {port} for {port_name}')
 
     def _allocate_faucet_ports(self):
         for c_index in range(self.NUM_FAUCET_CONTROLLERS):
@@ -461,7 +461,7 @@ class FaucetTestBase(unittest.TestCase):
 
     @staticmethod
     def hostns(host):
-        return '%s' % host.name
+        return f'{host.name}'
 
     def dump_switch_flows(self, switch):
         """Dump switch information to tmpdir"""
@@ -469,13 +469,12 @@ class FaucetTestBase(unittest.TestCase):
                 'dump-flows', 'dump-groups', 'dump-meters',
                 'dump-group-stats', 'dump-ports', 'dump-ports-desc',
                 'meter-stats'):
-            switch_dump_name = os.path.join(self.tmpdir, '%s-%s.log' % (switch.name, dump_cmd))
+            switch_dump_name = os.path.join(self.tmpdir, f'{switch.name}-{dump_cmd}.log')
             # TODO: occasionally fails with socket error.
-            switch.cmd('%s %s %s > %s' % (self.OFCTL, dump_cmd, switch.name, switch_dump_name),
-                       success=None)
+            switch.cmd(f'{self.OFCTL} {dump_cmd} {switch.name} > {switch_dump_name}', success=None)
         for other_cmd in ('show', 'list controller', 'list manager'):
-            other_dump_name = os.path.join(self.tmpdir, '%s.log' % other_cmd.replace(' ', ''))
-            switch.cmd('%s %s > %s' % (self.VSCTL, other_cmd, other_dump_name))
+            other_dump_name = os.path.join(self.tmpdir, f'{other_cmd.replace(" ", "")}.log')
+            switch.cmd(f'{self.VSCTL} {other_cmd} > {other_dump_name}')
 
     # pylint: disable=arguments-differ
     def tearDown(self, ignore_oferrors=False):
@@ -484,15 +483,15 @@ class FaucetTestBase(unittest.TestCase):
         if self.NETNS:
             for host in self.hosts_name_ordered()[:1]:
                 if self.get_host_netns(host):
-                    self.quiet_commands(host, ['ip netns del %s' % self.hostns(host)])
+                    self.quiet_commands(host, [f'ip netns del {self.hostns(host)}'])
         first_switch = self.first_switch()
         if first_switch:
-            self.first_switch().cmd('ip link > %s' % os.path.join(self.tmpdir, 'ip-links.log'))
+            self.first_switch().cmd(f'ip link > {os.path.join(self.tmpdir, "ip-links.log")}')
         switch_names = []
         for switch in self.net.switches:
             switch_names.append(switch.name)
             self.dump_switch_flows(switch)
-            switch.cmd('%s del-br %s' % (self.VSCTL, switch.name))
+            switch.cmd(f'{self.VSCTL} del-br {switch.name}')
         self._stop_net()
         self.net = None
         if self.event_sock_dir and os.path.exists(self.event_sock_dir):
@@ -530,7 +529,7 @@ class FaucetTestBase(unittest.TestCase):
             # Verify version is logged.
             self.assertTrue(
                 self.matching_lines_from_file(r'^.+version\s+(\S+)$', logfile),
-                msg='no version logged in %s' % logfile)
+                msg=f'no version logged in {logfile}'
             # Verify no OFErrors.
             oferrors += '\n\n'.join(self.matching_lines_from_file(r'^.+(OFError.+)$', logfile))
             if not ignore_oferrors:
@@ -542,17 +541,17 @@ class FaucetTestBase(unittest.TestCase):
         def _cmd(cmd):
             with subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE) as proc:
                 stdout, stderr = proc.communicate()
-                self.assertFalse(stdout, msg='%s: %s' % (stdout, cmd))
-                self.assertFalse(stderr, msg='%s: %s' % (stderr, cmd))
+                self.assertFalse(stdout, msg=f'{stdout}: {cmd}')
+                self.assertFalse(stderr, msg=f'{stdout}: {cmd}')
 
         _cmd('ebtables --f OUTPUT')
         for phys_port in self.switch_map.values():
             phys_mac = self.get_mac_of_intf(phys_port)
             for cmd in (
-                    'ip link set dev %s up' % phys_port,
-                    'ip -4 addr flush dev %s' % phys_port,
-                    'ip -6 addr flush dev %s' % phys_port,
-                    'ebtables -A OUTPUT -s %s -o %s -j DROP' % (phys_mac, phys_port)):
+                    f'ip link set dev {phys_port} up',
+                    f'ip -4 addr flush dev {phys_port}',
+                    f'ip -6 addr flush dev {phys_port}',
+                    f'ebtables -A OUTPUT -s {phys_mac} -o {phys_port} -j DROP'):
                 _cmd(cmd)
 
     def _attach_physical_switch(self):
@@ -585,7 +584,7 @@ class FaucetTestBase(unittest.TestCase):
             # and blocked traffic to/from its meaningless MAC
             hw_mac = self.get_mac_of_intf(hw_name)
             self.assertFalse(hw_mac in hw_macs,
-                             'duplicate hardware MAC %s' % hw_mac)
+                             f'duplicate hardware MAC {hw_mac}')
             hw_macs.add(hw_mac)
             # Create mininet Intf and attach it to the switch
             hw_intf = HWIntf(hw_name, node=switch)
@@ -595,11 +594,11 @@ class FaucetTestBase(unittest.TestCase):
             src, dst = hw_port, ovs_port
             for flow in (
                     # Drop anything to or from the meaningless hw_mac
-                    'eth_src=%s,priority=2,actions=drop' % hw_mac,
-                    'eth_dst=%s,priority=2,actions=drop' % hw_mac,
+                    f'eth_src={hw_mac},priority=2,actions=drop',
+                    f'eth_dst={hw_mac},priority=2,actions=drop',
                     # Forward traffic bidirectionally src <-> dst
-                    'in_port=%u,priority=1,actions=output:%u' % (src, dst),
-                    'in_port=%u,priority=1,actions=output:%u' % (dst, src)):
+                    f'in_port={src},priority=1,actions=output:{dst}',
+                    f'in_port={dst},priority=1,actions=output:{src}'):
                 switch.cmd(self.OFCTL, 'add-flow', switch, flow)
 
     def create_port_map(self, dpid):
@@ -653,13 +652,12 @@ class FaucetTestBase(unittest.TestCase):
             for port_name, port in self.config_ports.items():
                 if port is not None and not port_name.startswith('gauge'):
                     if not self._get_controller().listen_port(port):
-                        return 'faucet not listening on %u (%s)' % (
-                            port, port_name)
+                        return f'faucet not listening on {port} ({port_name})'
         return self._start_gauge_check()
 
     def _create_faucet_controller(self, index, intf, ipv6):
         port = self.faucet_of_ports[index]
-        name = 'faucet-%s' % index
+        name = f'faucet-{index}'
         faucet_controller = self.CONTROLLER_CLASS(
             name=name, tmpdir=self.tmpdir,
             controller_intf=intf,
@@ -677,7 +675,7 @@ class FaucetTestBase(unittest.TestCase):
 
     def _create_gauge_controller(self, index, intf, ipv6):
         port = self.gauge_of_ports[index]
-        name = 'gauge-%s' % index
+        name = f'gauge-{index}'
         gauge_controller = mininet_test_topo.Gauge(
             name=name, tmpdir=self.tmpdir,
             env=self.env[name],
@@ -756,7 +754,7 @@ class FaucetTestBase(unittest.TestCase):
             # Existing controllers will be reused on the next cycle
             self._stop_net()
             last_error_txt += '\n\n' + self._dump_controller_logs()
-            error('%s: %s' % (self._test_name(), last_error_txt))
+            error(f'{self._test_name()}: {last_error_txt}')
             time.sleep(mininet_test_util.MIN_PORT_AGE)
 
         if last_error_txt is not None:
@@ -771,15 +769,14 @@ class FaucetTestBase(unittest.TestCase):
             for host in self.hosts_name_ordered()[:1]:
                 hostns = self.hostns(host)
                 if self.get_host_netns(host):
-                    self.quiet_commands(host, ['ip netns del %s' % hostns])
-                self.quiet_commands(host, ['ip netns add %s' % hostns])
+                    self.quiet_commands(host, [f'ip netns del {hostns}'])
+                self.quiet_commands(host, [f'ip netns add {hostns}'])
 
         self.post_start_net()
 
     def _ofctl_rest_url(self, req):
         """Return control URL for Ryu ofctl module."""
-        return 'http://[%s]:%u/%s' % (
-            mininet_test_util.LOCALHOSTV6, self._get_controller().ofctl_port, req)
+        return f'http://[{mininet_test_util.LOCALHOSTV6}]:{self._get_controller().ofctl_port}/{req}'
 
     @staticmethod
     def _ofctl(req, params=None):
@@ -837,8 +834,8 @@ class FaucetTestBase(unittest.TestCase):
 
     @staticmethod
     def _signal_proc_on_port(host, port, signal):
-        tcp_pattern = '%s/tcp' % port
-        fuser_out = host.cmd('fuser %s -k -%u' % (tcp_pattern, signal))
+        tcp_pattern = f'{port}/tcp'
+        fuser_out = host.cmd(f'fuser {tcp_pattern} -k -{signal}')
         return re.search(r'%s:\s+\d+' % tcp_pattern, fuser_out)
 
     def _get_ofchannel_logs(self):
@@ -874,7 +871,7 @@ class FaucetTestBase(unittest.TestCase):
         for c_index in range(self.NUM_FAUCET_CONTROLLERS):
             event_sock = self.event_socks[c_index]
             if event_sock and not os.path.exists(event_sock):
-                error('event socket %s not created\n' % event_sock)
+                error(f'event socket {event_sock} not created\n')
                 return False
         return True
 
@@ -917,8 +914,7 @@ class FaucetTestBase(unittest.TestCase):
             self.assertEqual(
                 '',
                 exception_contents,
-                msg='%s log contains %s' % (
-                    exception_log_name, exception_contents))
+                msg=f'{exception_log_name} log contains {exception_contents}')
 
     @staticmethod
     def tcpdump_helper(*args, **kwargs):
@@ -926,44 +922,39 @@ class FaucetTestBase(unittest.TestCase):
 
     @staticmethod
     def scapy_template(packet, iface, count=1):
-        return ('python3 -c \"from scapy.all import * ; sendp(%s, iface=\'%s\', count=%u)"' % (
-            packet, iface, count))
+        return (f'python3 -c \"from scapy.all import * ; sendp({packet}, iface=\'{iface}\', count={count})"')
 
     def scapy_base_udp(self, mac, iface, src_ip, dst_ip, dport, sport, count=1, dst=None):
         if dst is None:
             dst = 'ff:ff:ff:ff:ff:ff'
         return self.scapy_template(
-            ('Ether(dst=\'%s\', src=\'%s\', type=%u) / '
-             'IP(src=\'%s\', dst=\'%s\') / UDP(dport=%s,sport=%s) ' % (
-                 dst, mac, IPV4_ETH, src_ip, dst_ip, dport, sport)),
+            (f'Ether(dst=\'{dst}\', src=\'{mac}\', type={IPV4_ETH}) / '
+             f'IP(src=\'{src_ip}\', dst=\'{dst_ip}\') / UDP(dport={dport},sport={sport}) '),
             iface, count)
 
     def scapy_dhcp(self, mac, iface, count=1, dst=None):
         if dst is None:
             dst = 'ff:ff:ff:ff:ff:ff'
         return self.scapy_template(
-            ('Ether(dst=\'%s\', src=\'%s\', type=%u) / '
+            (f'Ether(dst=\'{dst}\', src=\'{mac}\', type={IPV4_ETH}) / '
              'IP(src=\'0.0.0.0\', dst=\'255.255.255.255\') / UDP(dport=67,sport=68) / '
-             'BOOTP(op=1) / DHCP(options=[(\'message-type\', \'discover\'), (\'end\')])') % (
-                 dst, mac, IPV4_ETH),
+             'BOOTP(op=1) / DHCP(options=[(\'message-type\', \'discover\'), (\'end\')])'),
             iface, count)
 
     def scapy_icmp(self, mac, iface, src_ip, dst_ip, count=1, dst=None):
         if dst is None:
             dst = 'ff:ff:ff:ff:ff:ff'
         return self.scapy_template(
-            ('Ether(dst=\'%s\', src=\'%s\', type=%u) / '
-             'IP(src=\'%s\', dst=\'%s\') / ICMP()') % (
-                dst, mac, IPV4_ETH, src_ip, dst_ip),
+            (f'Ether(dst=\'{dst}\', src=\'{mac}\', type={IPV4_ETH}) / '
+             f'IP(src=\'{src_ip}\', dst=\'{dst_ip}\') / ICMP()'),
             iface, count)
 
     def scapy_dscp(self, src_mac, dst_mac, dscp_value, iface, count=1):
         # creates a packet with L2-L4 headers using scapy
         return self.scapy_template(
-            ('Ether(dst=\'%s\', src=\'%s\', type=%u) / '
-             'IP(src=\'0.0.0.0\', dst=\'255.255.255.255\', tos=%s) / UDP(dport=67,sport=68) / '
-             'BOOTP(op=1)') % (
-                 dst_mac, src_mac, IPV4_ETH, dscp_value),
+            (f'Ether(dst=\'{dst_mac}\', src=\'{src_mac}\', type={IPV4_ETH}) / '
+             f'IP(src=\'0.0.0.0\', dst=\'255.255.255.255\', tos={dscp_value}) / UDP(dport=67,sport=68) / '
+             'BOOTP(op=1)'),
             iface, count)
 
     def scapy_bcast(self, host, count=1):
@@ -993,51 +984,46 @@ dps:
             int(dpid), hardware, random.randint(1, 2**64 - 1))
 
     def get_gauge_watcher_config(self):
-        return """
+        return f"""
     port_stats:
-        dps: ['%s']
+        dps: ['{self.DP_NAME}']
         type: 'port_stats'
         interval: 5
         db: 'stats_file'
     port_state:
-        dps: ['%s']
+        dps: ['{self.DP_NAME}']
         type: 'port_state'
         interval: 5
         db: 'state_file'
     flow_table:
-        dps: ['%s']
+        dps: ['{self.DP_NAME}']
         type: 'flow_table'
         interval: 5
         db: 'flow_dir'
-""" % (self.DP_NAME, self.DP_NAME, self.DP_NAME)
+"""
 
     def get_gauge_config(self, faucet_config_file,
                          monitor_stats_file,
                          monitor_state_file,
                          monitor_flow_table_dir):
         """Build Gauge config."""
-        return """
+        return f"""
 faucet_configs:
-    - %s
+    - {faucet_config_file}
 watchers:
-    %s
+    {self.get_gauage_watcher_config()}
 dbs:
     stats_file:
         type: 'text'
-        file: %s
+        file: {monitor_stats_file}
     state_file:
         type: 'text'
-        file: %s
+        file: {monitor_state_file}
     flow_dir:
         type: 'text'
-        path: %s
-%s
-""" % (faucet_config_file,
-            self.get_gauge_watcher_config(),
-            monitor_stats_file,
-            monitor_state_file,
-            monitor_flow_table_dir,
-            self.GAUGE_CONFIG_DBS)
+        path: {monitor_flow_table_dir}
+{self.GAUGE_CONFIG_DBS}
+"""
 
     @staticmethod
     def get_exabgp_conf(peer, peer_config=''):
@@ -1055,7 +1041,7 @@ dbs:
     def get_all_groups_desc_from_dpid(self, dpid, timeout=2):
         int_dpid = mininet_test_util.str_int_dpid(dpid)
         return self._ofctl_get(
-            int_dpid, 'stats/groupdesc/%s' % int_dpid, timeout)
+            int_dpid, f'stats/groupdesc/{int_dpid}', timeout)
 
     def get_all_flows_from_dpid(self, dpid, table_id, timeout=10, match=None):
         """Return all flows from DPID."""
@@ -1065,7 +1051,7 @@ dbs:
         if match is not None:
             params['match'] = match
         return self._ofctl_post(
-            int_dpid, 'stats/flow/%s' % int_dpid, timeout, params=params)
+            int_dpid, f'stats/flow/{int_dpid}', timeout, params=params)
 
     @staticmethod
     def _port_stat(port_stats, port):
@@ -1079,24 +1065,24 @@ dbs:
         """Return port stats for a port."""
         int_dpid = mininet_test_util.str_int_dpid(dpid)
         port_stats = self._ofctl_get(
-            int_dpid, 'stats/port/%s/%s' % (int_dpid, port), timeout)
+            int_dpid, f'stats/port/{int_dpid}/{port}', timeout)
         return self._port_stat(port_stats, port)
 
     def get_port_desc_from_dpid(self, dpid, port, timeout=2):
         """Return port desc for a port."""
         int_dpid = mininet_test_util.str_int_dpid(dpid)
         port_stats = self._ofctl_get(
-            int_dpid, 'stats/portdesc/%s/%s' % (int_dpid, port), timeout)
+            int_dpid, f'stats/portdesc/{int_dpid}/{port}', timeout)
         return self._port_stat(port_stats, port)
 
     def get_all_meters_from_dpid(self, dpid):
         """Return all meters from DPID"""
         int_dpid = mininet_test_util.str_int_dpid(dpid)
         return self._ofctl_get(
-            int_dpid, 'stats/meterconfig/%s' % int_dpid, timeout=10)
+            int_dpid, f'stats/meterconfig/{int_dpid}', timeout=10)
 
     def wait_matching_in_group_table(self, action, group_id, timeout=10):
-        groupdump = os.path.join(self.tmpdir, 'groupdump-%s.txt' % self.dpid)
+        groupdump = os.path.join(self.tmpdir, f'groupdump-{self.dpid}.txt')
         for _ in range(timeout):
             group_dump = self.get_all_groups_desc_from_dpid(self.dpid, 1)
             with open(groupdump, 'w', encoding='utf-8') as groupdump_file:
@@ -1111,7 +1097,7 @@ dbs:
 
     # TODO: Should this have meter_confs as well or can we just match meter_ids
     def get_matching_meters_on_dpid(self, dpid):
-        meterdump = os.path.join(self.tmpdir, 'meterdump-%s.log' % dpid)
+        meterdump = os.path.join(self.tmpdir, f'meterdump-{dpid}.log')
         meter_dump = self.get_all_meters_from_dpid(dpid)
         with open(meterdump, 'w', encoding='utf-8') as meterdump_file:
             meterdump_file.write(str(meter_dump))
@@ -1136,7 +1122,7 @@ dbs:
                         del match[new_match]
             return match
 
-        flowdump = os.path.join(self.tmpdir, 'flowdump-%s.log' % dpid)
+        flowdump = os.path.join(self.tmpdir, f'flowdump-{dpid}.log')
         match = to_old_match(match)
         match_set = None
         exact_mask_match_set = None
@@ -1265,7 +1251,7 @@ dbs:
                 dpid, match, table_id, timeout=timeout,
                 actions=actions, hard_timeout=hard_timeout, cookie=cookie,
                 ofa_match=ofa_match),
-            msg=('match: %s table_id: %u actions: %s' % (match, table_id, actions)))
+            msg=(f'match: {match} table_id: {table_id} actions: {actions}'))
 
     def wait_until_no_matching_flow(self, match, table_id, timeout=10,
                                     actions=None, hard_timeout=0, cookie=None,
@@ -1291,7 +1277,7 @@ dbs:
         for eth_field, table_id in (
                 ('dl_src', self._ETH_SRC_TABLE),
                 ('dl_dst', self._ETH_DST_TABLE)):
-            match = {eth_field: '%s' % mac}
+            match = {eth_field: f'{mac}'}
             match_hard_timeout = 0
             if table_id == self._ETH_SRC_TABLE:
                 if in_port is not None:
@@ -1311,19 +1297,17 @@ dbs:
                 val = self.scrape_prometheus_var(
                     port_var, labels=port_labels,
                     controller=self.gauge_controller.name, dpid=True, retries=3)
-                self.assertIsNotNone(val, '%s missing for port %s' % (port_var, port))
+                self.assertIsNotNone(val, f'{port_var} missing for port {port}')
                 port_counters[port][port_var] = val
             # Require port to be up and reporting non-zero speed.
             speed = self.scrape_prometheus_var(
                 'of_port_curr_speed', labels=port_labels,
                 controller=self.gauge_controller.name, retries=3)
-            self.assertTrue(speed and speed > 0, msg='%s %s: %s' % (
-                'of_port_curr_speed', port_labels, speed))
+            self.assertTrue(speed and speed > 0, msg=f'of_port_curr_speed {port_labels}: {speed}')
             state = self.scrape_prometheus_var(
                 'of_port_state', labels=port_labels,
                 controller=self.gauge_controller.name, retries=3)
-            self.assertFalse(state & ofp.OFPPS_LINK_DOWN, msg='%s %s: %s' % (
-                'of_port_state', port_labels, state))
+            self.assertFalse(state & ofp.OFPPS_LINK_DOWN, msg=f'of_port_state {port_labels}: {state}')
         return port_counters
 
     def wait_ports_updating(self, ports, port_vars, stimulate_counters_func=None):
@@ -1353,7 +1337,7 @@ dbs:
 
         end_time = time.time()
 
-        error('counter latency up to %u sec\n' % (end_time - start_time))
+        error(f'counter latency up to {end_time - start_time} sec\n')
         return not ports_not_updated
 
     @staticmethod
@@ -1389,7 +1373,7 @@ dbs:
 
     @staticmethod
     def get_host_intf_mac(host, intf):
-        return host.cmd('cat /sys/class/net/%s/address' % intf).strip()
+        return host.cmd(f'cat /sys/class/net/{intf}/address').strip()
 
     def get_host_netns(self, host):
         hostns = self.hostns(host)
@@ -1437,7 +1421,7 @@ dbs:
             if self.host_learned(host, timeout=1, in_port=in_port, hard_timeout=hard_timeout):
                 return
             learn_result = self.stimulate_host_learn(host)
-        self.fail('Could not learn host %s (%s): %s' % (host, host.MAC(), learn_result))
+        self.fail(f'Could not learn host {host} ({host.MAC()}): {learn_result}')
 
     def get_prom_port(self, controller=None):
         if controller is None:
@@ -1451,11 +1435,9 @@ dbs:
 
     def _prometheus_url(self, controller):
         if 'faucet' in controller:
-            return 'http://[%s]:%u' % (
-                self.get_prom_addr(), self.get_prom_port())
+            return f'http://[{self.get_prom_addr()}]:{self.get_prom_port()}'
         if 'gauge' in controller:
-            return 'http://[%s]:%u' % (
-                self.get_prom_addr(), self.config_ports['gauge_prom_port'])
+            return f'http://[{self.get_prom_addr()}]:{self.config_ports['gauge_prom_port']}'
         raise NotImplementedError
 
     def scrape_prometheus(self, controller=None, timeout=15, var=None, verify_consistent=False):
@@ -1483,7 +1465,7 @@ dbs:
                 prom_raw = requests.get(url, {}, timeout=timeout).text
             except (requests.exceptions.ConnectionError, requests.exceptions.ReadTimeout):
                 return []
-            log_filename = os.path.join(self.tmpdir, '%s-prometheus.log' % controller_name)
+            log_filename = os.path.join(self.tmpdir, f'{controller_name}-prometheus.log')
             with open(log_filename, 'w', encoding='utf-8') as prom_log:
                 prom_log.write(prom_raw)
             prom_lines = [
@@ -1522,15 +1504,14 @@ dbs:
                     self.assertEqual(var_a, var_b)
                     val_a = int(float(match_a.group(2)))
                     val_b = int(float(match_b.group(2)))
-                    self.assertEqual(val_a, val_b, msg='%s %s inconsistent' %
-                                     (prom_line_a, prom_line_b))
+                    self.assertEqual(val_a, val_b, msg=f'{prom_line_a} {prom_line_b} inconsistent')
 
     def parse_prom_var(self, prom_line):
         """Parse prometheus variable, return tuple of variable name, variable value"""
         prom_line_match = self._PROM_LINE_RE.match(prom_line)
         self.assertIsNotNone(
             prom_line_match,
-            msg='Invalid prometheus line %s' % prom_line)
+            msg=f'Invalid prometheus line {prom_line}')
         prom_var = prom_line_match.group(1)
         prom_val = int(float(prom_line_match.group(2)))
         return (prom_var, prom_val)
@@ -1589,7 +1570,7 @@ dbs:
             if labels:
                 label_values = []
                 for label, value in sorted(labels.items()):
-                    label_values.append('%s="%s"' % (label, value))
+                    label_values.append(f'{label}="{value}"')
                 label_values_re = r'\{%s\}' % r'\S+'.join(label_values)
         var_re = re.compile(r'^%s%s$' % (var, label_values_re))
         for i in range(retries):
@@ -1628,7 +1609,7 @@ dbs:
             found_watcher_files = set()
         missing_watcher_files = watcher_files - found_watcher_files
         self.assertEqual(
-            missing_watcher_files, set(), msg='Gauge missing logs: %s' % missing_watcher_files)
+            missing_watcher_files, set(), msg=f'Gauge missing logs: {missing_watcher_files}')
         self.hup_controller(self.gauge_controller.name)
         self.verify_no_exception(self.env[self.faucet_controllers[0].name]['FAUCET_EXCEPTION_LOG'])
 
@@ -1639,12 +1620,12 @@ dbs:
                 r'faucet_config\S+name=\"flood\"', r'faucet_pbr_version\S+version='):
             self.assertTrue(
                 re.search(r'%s\S+\s+[1-9]+' % nonzero_var, prom_out),
-                msg='expected %s to be nonzero (%s)' % (nonzero_var, prom_out))
+                msg=f'expected {nonzero_var} to be nonzero ({prom_out})')
         for zero_var in (
                 'of_errors', 'of_dp_disconnections'):
             self.assertTrue(
                 re.search(r'%s\S+\s+0' % zero_var, prom_out),
-                msg='expected %s to be present and zero (%s)' % (zero_var, prom_out))
+                msg=f'expected {zero_var} to be present and zero ({prom_out})')
 
     def get_configure_count(self, retries=5, controller=None):
         """Return the number of times FAUCET has processed a reload request."""
@@ -1694,11 +1675,10 @@ dbs:
                 self.assertFalse(
                     cold_start, msg='host cache is not maintained with cold start')
                 self.assertTrue(
-                    new_mac_table, msg='no host cache for VLAN %u' % host_cache)
+                    new_mac_table, msg=f'no host cache for VLAN {host_cache}')
                 self.assertEqual(
                     old_mac_table, new_mac_table,
-                    msg='host cache for VLAN %u not same over reload (old %s, new %s)' % (
-                        host_cache, old_mac_table, new_mac_table))
+                    msg=f'host cache for VLAN {host_cache} not same over reload (old {old_mac_table}, new {new_mac_table})')
             else:
                 verify_faucet_reconf_func()
             return
@@ -1790,8 +1770,7 @@ dbs:
                 host_b, tcpdump_filter,
                 [partial(host_a.cmd, scapy_cmd)],
                 packets=1, timeout=2)
-            msg = '%s (%s) -> %s (%s): %s' % (
-                host_a, host_a.MAC(), host_b, host_b.MAC(), tcpdump_txt)
+            msg = f'{host_a} ({host_a.MAC()}) -> {host_b} ({host_b.MAC()}): {tcpdump_txt}'
             received_no_packets = self.tcpdump_rx_packets(tcpdump_txt, packets=0)
             received_packets = received_packets or not received_no_packets
             if received_packets:
@@ -1812,7 +1791,7 @@ dbs:
             host_a, host_b = hosts
         tcpdump_filter = ' and '.join((
             'ether dst host ff:ff:ff:ff:ff:ff',
-            'ether src host %s' % host_a.MAC(),
+            f'ether src host {host_a.MAC()}',
             'udp'))
         scapy_cmd = self.scapy_bcast(host_a, count=packets)
         return self._verify_xcast(broadcast_expected, packets, tcpdump_filter,
@@ -1824,36 +1803,35 @@ dbs:
         if hosts is not None:
             host_a, host_b = hosts
         tcpdump_filter = ' and '.join((
-            'ether dst %s' % host_b.MAC(),
-            'ether src %s' % host_a.MAC(),
+            f'ether dst {host_b.MAC()}',
+            f'ether src {host_a.MAC()}',
             'udp'))
         scapy_cmd = self.scapy_template(
-            ('Ether(src=\'%s\', dst=\'%s\', type=%u) / '
-             'IP(src=\'%s\', dst=\'%s\') / UDP(dport=67,sport=68)') % (
-                 host_a.MAC(), host_b.MAC(), IPV4_ETH,
-                 host_a.IP(), host_b.IP()), host_a.defaultIntf(), count=packets)
+            (f'Ether(src=\'{host_a.MAC()}\', dst=\'{host_b.MAC()}\', type={IPV4_ETH}) / '
+             f'IP(src=\'{host_a.IP()}\', dst=\'{host_b.IP()}\') / UDP(dport=67,sport=68)'),
+                host_a.defaultIntf(), count=packets)
         return self._verify_xcast(unicast_expected, packets, tcpdump_filter,
                                   scapy_cmd, host_a, host_b)
 
     def verify_empty_caps(self, cap_files):
         cap_file_cmds = [
-            'tcpdump -n -v -A -r %s 2> /dev/null' % cap_file for cap_file in cap_files]
+            f'tcpdump -n -v -A -r {cap_file for cap_file in cap_files} 2> /dev/null']
         self.quiet_commands(self.net.controllers[0], cap_file_cmds)
 
     def verify_no_bcast_to_self(self, timeout=3):
         bcast_cap_files = []
         tcpdump_timeout = timeout * len(self.hosts_name_ordered()) * 2
         for host in self.hosts_name_ordered():
-            tcpdump_filter = '-Q in ether src %s' % host.MAC()
-            bcast_cap_file = os.path.join(self.tmpdir, '%s-bcast.cap' % host)
+            tcpdump_filter = f'-Q in ether src {host.MAC()}'
+            bcast_cap_file = os.path.join(self.tmpdir, f'{host}-bcast.cap')
             bcast_cap_files.append(bcast_cap_file)
             host.cmd(mininet_test_util.timeout_cmd(
-                'tcpdump -U -n -c 1 -i %s -w %s %s &' % (
-                    host.defaultIntf(), bcast_cap_file, tcpdump_filter), tcpdump_timeout))
+                f'tcpdump -U -n -c 1 -i {host.defaultIntf()} -w {bcast_cap_file} {tcpdump_filter} &',
+                    tcpdump_timeout))
         for host in self.hosts_name_ordered():
             for bcast_cmd in (
-                    ('ndisc6 -w1 fe80::1 %s' % host.defaultIntf()),
-                    ('ping -b -i0.1 -c3 %s' % self.ipv4_vip_bcast())):
+                    (f'ndisc6 -w1 fe80::1 {host.defaultIntf()}'),
+                    (f'ping -b -i0.1 -c3 {self.ipv4_vip_bcast()}')):
                 host.cmd(mininet_test_util.timeout_cmd(bcast_cmd, timeout))
         self.verify_empty_caps(bcast_cap_files)
 
@@ -1865,7 +1843,7 @@ dbs:
             'IP(src=\'10.0.0.100\', dst=\'10.0.0.255\')/'
             'UDP(dport=9)/'
             'b\'hello\'')
-        tcpdump_filter = '-Q in ether src %s' % unicast_mac1
+        tcpdump_filter = f'-Q in ether src {unicast_mac1}'
         for host in self.hosts_name_ordered():
             host.cmd(
                 self.scapy_template(
@@ -1890,13 +1868,12 @@ dbs:
         fping_bin = 'fping'
         if faucet_vip.version == 6:
             fping_bin = 'fping6'
-        fping_cli = '%s %s -b %u -c %u -i %u %s' % (
-            fping_bin, self.FPING_ARGS_SHORT, size, total_packets,
-            packet_interval_ms, faucet_vip.ip)
+        fping_cli = f'{fping_pin} {self.FPING_ARGS_SHORT} -b {size}' \
+                    f' -c {total_packets} -i {packet_interval_ms} {faucet_vip.ip}'
         timeout = int(((1000.0 / packet_interval_ms) * total_packets) * 1.5)
         fping_out = host.cmd(mininet_test_util.timeout_cmd(
             fping_cli, timeout))
-        error('%s: %s' % (self._test_name(), fping_out))
+        error(f'{self._test_name()}: {fping_out}')
         self.assertTrue(
             re.search(r'\s+[1-9][0-9]* ICMP Echo Replies received', fping_out),
             msg=fping_out)
@@ -1910,7 +1887,7 @@ dbs:
             port_vlan_hosts_learned = 0
             prom_macs_learned = 0
             for port in ports:
-                port_no = self.port_map['port_%u' % port]
+                port_no = self.port_map[f'port_{port}']
                 labels = {'vlan': str(vlan)}
                 labels.update(self.port_labels(port_no))
                 port_vlan_hosts_learned += self.scrape_prometheus_var(
@@ -1957,7 +1934,7 @@ dbs:
             mac_intf_ipv4s = []
             for i in range(0, max_hosts):
                 host = other_hosts[i % len(other_hosts)]
-                mac_intf = 'mac%u' % i
+                mac_intf = f'mac{i}'
                 mac_ipv4 = str(test_ipas[i])
                 mac_intf_ipv4s.append((host, mac_intf, mac_ipv4))
             return mac_intf_ipv4s
@@ -1975,10 +1952,10 @@ dbs:
         learn_hosts = min_hosts
         successful_learn_hosts = 0
 
-        fping_prefix = 'fping %s -q -c 1' % self.FPING_ARGS_SHORT
+        fping_prefix = f'fping {self.FPING_ARGS_SHORT} -q -c 1'
         pps_ms = 1e3 / learn_pps
         while learn_hosts <= max_hosts and successful_learn_hosts < max_hosts:
-            error('will learn %u hosts\n' % learn_hosts)
+            error(f'will learn {learn_hosts} hosts\n')
             start_time = time.time()
             learn_host_list = mac_intf_ipv4s[successful_learn_hosts:learn_hosts]
             random.shuffle(learn_host_list)
@@ -1987,7 +1964,7 @@ dbs:
                 fping_conf_start = time.time()
                 self.add_macvlan(host, mac_intf, mac_ipv4, ipm=test_net.prefixlen)
                 simplify_intf_conf(host, mac_intf)
-                host.cmd('%s -I%s %s' % (fping_prefix, mac_intf, str(learn_ip)))
+                host.cmd(f'{fping_prefix} -I{mac_intf} {str(learn_ip)}')
                 fping_ms = (time.time() - fping_conf_start) * 1e3
                 if fping_ms < pps_ms:
                     time.sleep((pps_ms - fping_ms) / 1e3)
@@ -2006,7 +1983,7 @@ dbs:
                         error('.')
                         random_unverified_ips = list(unverified_ips)
                         random.shuffle(random_unverified_ips)
-                        fping_cmd = '%s %s' % (fping_prefix, ' '.join(random_unverified_ips))
+                        fping_cmd = f'{fping_prefix} {" ".join(random_unverified_ips)}'
                         fping_lines = first_host.cmd(fping_cmd).splitlines()
                         for fping_line in fping_lines:
                             loss_match = loss_re.match(fping_line)
@@ -2020,7 +1997,7 @@ dbs:
                         else:
                             break
                     if unverified_ips:
-                        error('could not verify connectivity for all hosts: %s\n' % unverified_ips)
+                        error(f'could not verify connectivity for all hosts: {unverified_ips}\n')
                         return False
 
                 return self.wait_for_prometheus_var(
@@ -2030,8 +2007,7 @@ dbs:
             if verify_connectivity(learn_hosts):
                 learn_time = time.time() - start_time
                 # dump_packet_counters()
-                error('verified %u hosts learned in %u sec\n' % (
-                    learn_hosts, learn_time))
+                error(f'verified {learn_hosts} hosts learned in {learn_time} sec\n')
                 successful_learn_hosts = learn_hosts
                 learn_hosts = min(learn_hosts * 2, max_hosts)
             else:
@@ -2044,11 +2020,10 @@ dbs:
         for first_host, second_host in (
                 (vlan_first_host, vlan_second_host),
                 (vlan_second_host, vlan_first_host)):
-            tcpdump_filter = 'ether host %s or ether host %s' % (
-                first_host.MAC(), second_host.MAC())
+            tcpdump_filter = f'ether host {first_host.MAC()} or ether host {second_host.MAC()}'
             tcpdump_txt = self.tcpdump_helper(
                 other_vlan_host, tcpdump_filter, [
-                    partial(first_host.cmd, 'arp -d %s' % second_host.IP()),
+                    partial(first_host.cmd, f'arp -d {second_host.IP()}'),
                     partial(first_host.cmd, ' '.join((self.FPINGS_ARGS_ONE, second_host.IP())))],
                 packets=1)
             self.verify_no_packets(tcpdump_txt)
@@ -2060,9 +2035,8 @@ dbs:
             self.require_host_learned(host)
         self.retry_net_ping(hosts=(first_host, second_host))
         tcpdump_filter = (
-            '(ether src %s or ether src %s) and '
-            '(icmp[icmptype] == 8 or icmp[icmptype] == 0)') % (
-                first_host.MAC(), second_host.MAC())
+            f'(ether src {first_host.MAC()} or ether src {second_host.MAC()}) and '
+            '(icmp[icmptype] == 8 or icmp[icmptype] == 0)')
         first_ping_second = ' '.join((self.FPINGS_ARGS_ONE, second_host.IP()))
         expected_pings = 2
         max_expected_pings = 2
@@ -2072,10 +2046,10 @@ dbs:
             mirror_host, tcpdump_filter, [
                 partial(first_host.cmd, first_ping_second)], packets=(max_expected_pings + 1))
         self.assertTrue(re.search(
-            '%s: ICMP echo request' % second_host.IP(), tcpdump_txt),
+            f'{second_host.IP()}: ICMP echo request', tcpdump_txt),
             msg=tcpdump_txt)
         self.assertTrue(re.search(
-            '%s: ICMP echo reply' % first_host.IP(), tcpdump_txt),
+            f'{first_host.IP()}: ICMP echo reply', tcpdump_txt),
             msg=tcpdump_txt)
         received_pings = self.match_tcpdump_rx_packets(tcpdump_txt)
         self.assertGreaterEqual(received_pings, expected_pings)
@@ -2090,19 +2064,19 @@ dbs:
                 self.require_host_learned(host)
             self.retry_net_ping(hosts=(first_host, second_host))
         tcpdump_filter = (
-            'ether src %s and ether dst ff:ff:ff:ff:ff:ff and '
-            'icmp[icmptype] == 8') % second_host.MAC()
+            f'ether src {second_host.MAC()} and ether dst ff:ff:ff:ff:ff:ff and '
+            'icmp[icmptype] == 8')
         if tagged:
-            tcpdump_filter = 'vlan and %s' % tcpdump_filter
+            tcpdump_filter = f'vlan and {tcpdump_filter}'
         else:
-            tcpdump_filter = '%s and not vlan' % tcpdump_filter
-        second_ping_bcast = 'ping -c3 -b %s' % self.ipv4_vip_bcast()
+            tcpdump_filter = f'{tcpdump_filter} and not vlan'
+        second_ping_bcast = f'ping -c3 -b {self.ipv4_vip_bcast()}'
         tcpdump_txt = self.tcpdump_helper(
             mirror_host, tcpdump_filter, [
                 partial(second_host.cmd, second_ping_bcast)],
             packets=1)
         self.assertTrue(re.search(
-            '%s: ICMP echo request' % self.ipv4_vip_bcast(), tcpdump_txt),
+            f'{self.ipv4_vip_bcast()}: ICMP echo request', tcpdump_txt),
             msg=tcpdump_txt)
 
     def verify_ping_mirrored_multi(self, ping_pairs, mirror_host, both_mirrored=False):
@@ -2132,8 +2106,8 @@ dbs:
 
         mirror_mac = mirror_host.MAC()
         tcpdump_filter = (
-            'not ether src %s and '
-            '(icmp[icmptype] == 8 or icmp[icmptype] == 0)') % mirror_mac
+            f'not ether src {mirror_mac} and '
+            '(icmp[icmptype] == 8 or icmp[icmptype] == 0)')
 
         # Calculate the execpted number of pings we need
         # to capture to validate port mirroring
@@ -2152,10 +2126,10 @@ dbs:
 
         for hosts in ping_pairs:
             self.assertTrue(re.search(
-                '%s > %s: ICMP echo request' % (hosts[0].IP(), hosts[1].IP()), tcpdump_txt),
+                f'{hosts[0].IP()} > {hosts[1].IP()}: ICMP echo request', tcpdump_txt),
                 msg=tcpdump_txt)
             self.assertTrue(re.search(
-                '%s > %s: ICMP echo reply' % (hosts[1].IP(), hosts[0].IP()), tcpdump_txt),
+                f'{hosts[1].IP()} > {hosts[0].IP()}: ICMP echo reply', tcpdump_txt),
                 msg=tcpdump_txt)
 
         received_pings = self.match_tcpdump_rx_packets(tcpdump_txt)
@@ -2183,16 +2157,13 @@ dbs:
         mirror_mac = mirror_host.MAC()
         tmp_eap_conf = os.path.join(self.tmpdir, 'eap.conf')
         tcpdump_filter = (
-            'not ether src %s and ether proto 0x888e' % mirror_mac)
+            f'not ether src {mirror_mac} and ether proto 0x888e')
         eap_conf_cmd = (
             'echo "eapol_version=2\nap_scan=0\nnetwork={\n'
             'key_mgmt=IEEE8021X\neap=MD5\nidentity=\\"login\\"\n'
-            'password=\\"password\\"\n}\n" > %s' % tmp_eap_conf)
+            f'password=\\"password\\"\n}\n" > {tmp_eap_conf}'
         wpa_supplicant_cmd = mininet_test_util.timeout_cmd(
-            'wpa_supplicant -c%s -Dwired -i%s -d' % (
-                tmp_eap_conf,
-                first_host.defaultIntf().name),
-            3)
+            f'wpa_supplicant -c{tmp_eap_conf} -Dwired -i{first_host.defaultIntf().name} -d', 3)
         tcpdump_txt = self.tcpdump_helper(
             mirror_host, tcpdump_filter, [
                 partial(first_host.cmd, eap_conf_cmd),
@@ -2206,9 +2177,9 @@ dbs:
 
     def bogus_mac_flooded_to_port1(self):
         first_host, second_host, third_host = self.hosts_name_ordered()[0:3]
-        unicast_flood_filter = 'ether host %s' % self.BOGUS_MAC
-        static_bogus_arp = 'arp -s %s %s' % (first_host.IP(), self.BOGUS_MAC)
-        curl_first_host = 'curl -m 5 http://%s' % first_host.IP()
+        unicast_flood_filter = f'ether host {self.BOGUS_MAC}'
+        static_bogus_arp = f'arp -s {first_host.IP()} {self.BOGUS_MAC}'
+        curl_first_host = f'curl -m 5 http://{first_host.IP()}'
         tcpdump_txt = self.tcpdump_helper(
             first_host, unicast_flood_filter,
             [lambda: second_host.cmd(static_bogus_arp),
@@ -2218,8 +2189,7 @@ dbs:
 
     def ladvd_cmd(self, ladvd_args, repeats=1, timeout=3):
         ladvd_mkdir = 'mkdir -p /var/run/ladvd'
-        ladvd_all_args = ['%s %s' % (
-            mininet_test_util.timeout_cmd(self.LADVD, timeout), ladvd_args)] * repeats
+        ladvd_all_args = [f'{mininet_test_util.timeout_cmd(self.LADVD, timeout)} {ladvd_args}'] * repeats
         ladvd_cmd = ';'.join([ladvd_mkdir] + ladvd_all_args)
         return ladvd_cmd
 
@@ -2280,7 +2250,7 @@ dbs:
                     break
                 time.sleep(1)
             self.assertNotEqual(
-                start_configure_count, configure_count, 'FAUCET %s did not reconfigure' % cont_name)
+                start_configure_count, configure_count, f'FAUCET {cont_name} did not reconfigure')
             if cold_start is not None:
                 old_count = old_counts[i]
                 if change_expected:
@@ -2294,14 +2264,14 @@ dbs:
                         time.sleep(1)
                     self.assertTrue(
                         new_count > old_count,
-                        msg='FAUCET %s %s did not increment: %u' % (cont_name, var, new_count))
+                        msg=f'FAUCET {cont_name} {var} did not increment: {new_count}')
                 else:
                     new_count = int(
                         self.scrape_prometheus_var(var, controller=cont_name,
                                                    dpid=dpid, default=0))
                     self.assertEqual(
                         old_count, new_count,
-                        msg='FAUCET %s %s incremented: %u' % (cont_name, var, new_count))
+                        msg=f'FAUCET {cont_name} {var} incremented: {new_count}')
             self.wait_for_prometheus_var('faucet_config_applied', 1,
                                          controller=cont_name, dpid=None, timeout=30)
             self.wait_dp_status(1, controller=cont_name)
@@ -2329,7 +2299,7 @@ dbs:
             if self.get_host_port_stats(hosts_switch_ports) != first:
                 return
             time.sleep(1)
-        self.fail('port stats for %s never updated' % hosts_switch_ports)
+        self.fail(f'port stats for {hosts_switch_ports} never updated')
 
     def of_bytes_mbps(self, start_port_stats, end_port_stats, var, seconds):
         return (end_port_stats[var] - start_port_stats[var]) * 8 / seconds / self.ONEMBPS
@@ -2360,8 +2330,7 @@ dbs:
                 iperf_to_max = 0
                 if max_of_mbps:
                     iperf_to_max = iperf_mbps / max_of_mbps
-                msg = 'iperf: %fmbps, of: %fmbps (%f)' % (
-                    iperf_mbps, max_of_mbps, iperf_to_max)
+                msg = f'iperf: {iperf_mbps}mbps, of: {max_of_mbps}mbps ({iperf_to_max})'
                 error(msg)
                 if ((iperf_to_max < (1.0 - prop))
                         or (iperf_to_max > (1.0 + prop))):
@@ -2373,7 +2342,7 @@ dbs:
 
     @staticmethod
     def port_labels(port_no):
-        port_name = 'b%u' % port_no
+        port_name = f'b{port_no}'
         return {'port': port_name, 'port_description': port_name}
 
     def set_dpid_names(self, dpid_names):
@@ -2421,7 +2390,7 @@ dbs:
     def quiet_commands(self, host, commands):
         for command in commands:
             result = host.cmd(command)
-            self.assertEqual('', result, msg='%s: %s' % (command, result))
+            self.assertEqual('', result, msg=f'{command}: {result}')
 
     def _config_tableids(self):
         # Wait for VLAN table to appear, rapidly scrape the rest.
@@ -2464,46 +2433,42 @@ dbs:
     @staticmethod
     def get_mac_of_intf(intf, host=None):
         """Get MAC address of a port."""
-        address_file_name = '/sys/class/net/%s/address' % intf
+        address_file_name = f'/sys/class/net/{intf}/address'
         if host is None:
             with open(address_file_name, encoding='utf-8') as address_file:
                 address = address_file.read()
         else:
-            address = host.cmd('cat %s' % address_file_name)
+            address = host.cmd(f'cat {address_file_name}')
         return address.strip().lower()
 
     def add_macvlan(self, host, macvlan_intf, ipa=None, ipm=24, mac=None, mode='vepa'):
         if mac is None:
             mac = ''
         else:
-            mac = 'address %s' % mac
+            mac = f'address {mac}'
         add_cmds = [
-            'ip link add %s link %s %s type macvlan mode %s' % (
-                macvlan_intf, host.defaultIntf(), mac, mode),
-            'ip link set dev %s up' % macvlan_intf]
+            f'ip link add {macvlan_intf} link {host.defaultIntf()} {mac} type macvlan mode {mode}',
+            f'ip link set dev {macvlan_intf} up']
         if ipa:
             add_cmds.append(
-                'ip address add %s/%s brd + dev %s' % (ipa, ipm, macvlan_intf))
+                f'ip address add {ipa}/{ipm} brd + dev {macvlan_intf}')
         self.quiet_commands(host, add_cmds)
 
     def del_macvlan(self, host, macvlan_intf):
         self.quiet_commands(host, [
-            host.cmd('ip link del link %s %s' % (
-                host.defaultIntf(), macvlan_intf))])
+            host.cmd(f'ip link del link {host.defaultIntf()} {macvlan_intf}')])
 
     def add_host_ipv6_address(self, host, ip_v6, intf=None):
         """Add an IPv6 address to a Mininet host."""
         if intf is None:
             intf = host.intf()
         self.quiet_commands(host, [
-            host.cmd('ip -6 addr add %s dev %s' % (ip_v6, intf))])
+            host.cmd(f'ip -6 addr add {ip_v6} dev {intf}')])
 
     def add_host_route(self, host, ip_dst, ip_gw):
         """Add an IP route to a Mininet host."""
-        host.cmd('ip -%u route del %s' % (
-            ip_dst.version, ip_dst.network.with_prefixlen))
-        add_cmd = 'ip -%u route add %s via %s' % (
-            ip_dst.version, ip_dst.network.with_prefixlen, ip_gw)
+        host.cmd(f'ip -{ip_dst.version} route del {ip_dst.network.with_prefixlen}')
+        add_cmd = f'ip -{ip_dst.version} route add {ip_dst.network.with_prefixle} via {ip_gw}'
         self.quiet_commands(host, (add_cmd,))
 
     def _ip_ping(self, host, dst, retries, timeout=500,
@@ -2513,8 +2478,7 @@ dbs:
         if intf is None:
             intf = host.defaultIntf()
         good_ping = r'xmt/rcv/%%loss = %u/%u/0%%' % (count, count)
-        ping_cmd = '%s %s -c%u -I%s -t%u %s' % (
-            fping_bin, self.FPING_ARGS, count, intf, timeout, dst)
+        ping_cmd = f'{fping_bin} {self.FPING_ARGS} -c{count} -I{intf} -t{timeout} {dst}'
         if require_host_learned:
             self.require_host_learned(host)
         pause = timeout / 1e3
@@ -2525,8 +2489,7 @@ dbs:
                 break
             time.sleep(pause)
             pause *= 2
-        self.assertEqual(ping_result, expected_result, msg='%s %s: %s' % (
-            ping_cmd, ping_result, ping_out))
+        self.assertEqual(ping_result, expected_result, msg=f'{ping_cmd} {ping_result}: {ping_out}')
 
     def one_ipv4_ping(self, host, dst, retries=3, timeout=1000, intf=None,
                       require_host_learned=True, expected_result=True):
@@ -2585,7 +2548,7 @@ dbs:
             if loss <= required_loss:
                 return
             time.sleep(1)
-        self.fail('ping %f loss > required loss %f' % (loss, required_loss))
+        self.fail(f'ping {loss} loss > required loss {required_loss}')
 
     @staticmethod
     def tcp_port_free(host, port, ipv=4):
@@ -2602,7 +2565,7 @@ dbs:
             if listen_out is None:
                 return
             time.sleep(1)
-        self.fail('%s busy on port %u (%s)' % (host, port, listen_out))
+        self.fail(f'{host} busy on port {port} ({listen_out})')
 
     def wait_for_tcp_listen(self, host, port, timeout=10, ipv=4):
         """Wait for a host to start listening on a port."""
@@ -2611,12 +2574,12 @@ dbs:
             if listen_out is not None:
                 return
             time.sleep(1)
-        self.fail('%s never listened on port %u' % (host, port))
+        self.fail(f'{host} never listened on port {port}')
 
     def serve_str_on_tcp_port(self, host, port, serve_str='hello', timeout=20):
         """Serve str on a TCP port on a host."""
         host.cmd(mininet_test_util.timeout_cmd(
-            'echo %s | nc -l %s %u &' % (serve_str, host.IP(), port), timeout))
+            f'echo {serve_str} | nc -l {host.IP()} {timeout} &')
         self.wait_for_tcp_listen(host, port)
 
     def wait_nonzero_packet_count_flow(self, match, table_id, timeout=15,
@@ -2632,14 +2595,13 @@ dbs:
                 return
             time.sleep(1)
         if flow:
-            self.fail('DPID %s flow %s matching %s table ID %s had zero packet count' %
-                      (dpid, flow, match, table_id))
+            self.fail(f'DPID {dpid} flow {flow} matching {match} table ID {table_id} had zero packet count')
         else:
-            self.fail('no flow matching %s table ID %s' % (match, table_id))
+            self.fail(f'no flow matching {match} table ID {table_id}')
 
     def verify_tp_dst_blocked(self, port, first_host, second_host, table_id=0, mask=None):
         """Verify that a TCP port on a host is blocked from another host."""
-        client_cmd = mininet_test_util.timeout_cmd('nc %s %u' % (second_host.IP(), port), 5)
+        client_cmd = mininet_test_util.timeout_cmd(f'nc {second_host.IP()} {port}', 5)
         self.serve_str_on_tcp_port(second_host, port)
         self.quiet_commands(first_host, (client_cmd,))
         if table_id is None:
@@ -2659,7 +2621,7 @@ dbs:
         """Verify that a TCP port on a host is NOT blocked from another host."""
         serve_str = ''.join(random.choice(string.ascii_letters) for i in range(8))
         self.serve_str_on_tcp_port(second_host, port, serve_str=serve_str)
-        client_str = first_host.cmd('nc -w 10 %s %u' % (second_host.IP(), port)).strip()
+        client_str = first_host.cmd(f'nc -w 10 {second_host.IP()} {port}').strip()
         self.assertEqual(serve_str, client_str)
         if table_id is None:
             return
@@ -2667,15 +2629,13 @@ dbs:
             {'tp_dst': int(port), 'dl_type': IPV4_ETH, 'ip_proto': 6}, table_id)
 
     def bcast_dst_blocked_helper(self, port, first_host, second_host, success_re, retries):
-        tcpdump_filter = 'udp and ether src %s and ether dst %s' % (
-            first_host.MAC(), "ff:ff:ff:ff:ff:ff")
+        tcpdump_filter = f'udp and ether src {first_host.MAC()} and ether dst ff:ff:ff:ff:ff:ff'
         target_addr = str(self.FAUCET_VIPV4.network.broadcast_address)
         for _ in range(retries):
             tcpdump_txt = self.tcpdump_helper(
                 second_host, tcpdump_filter, [
                     partial(first_host.cmd, (
-                        'date | socat - udp-datagram:%s:%d,broadcast' % (
-                            target_addr, port)))],
+                        f'date | socat - udp-datagram:{target_addr}:{port},broadcast'))],
                 packets=1)
             if re.search(success_re, tcpdump_txt):
                 return True
@@ -2702,14 +2662,14 @@ dbs:
 
     def start_exabgp(self, exabgp_conf, timeout=30, log_prefix=''):
         """Start exabgp process on controller host."""
-        exabgp_conf_file_name = os.path.join(self.tmpdir, '%sexabgp.conf' % log_prefix)
-        exabgp_log = os.path.join(self.tmpdir, '%sexabgp.log' % log_prefix)
-        exabgp_out = os.path.join(self.tmpdir, '%sexabgp.out' % log_prefix)
+        exabgp_conf_file_name = os.path.join(self.tmpdir, f'{log_prefix}exabgp.conf')
+        exabgp_log = os.path.join(self.tmpdir, f'{log_prefix}exabgp.log')
+        exabgp_out = os.path.join(self.tmpdir, f'{log_prefix}exabgp.out')
         exabgp_env = ' '.join((
             'exabgp.daemon.user=root',
             'exabgp.log.all=true',
             'exabgp.log.level=DEBUG',
-            'exabgp.log.destination=%s' % exabgp_log,
+            f'exabgp.log.destination={exabgp_log}',
         ))
         bgp_port = self.config_ports['bgp_port']
         exabgp_conf = exabgp_conf % {'bgp_port': bgp_port}
@@ -2718,16 +2678,15 @@ dbs:
         controller = self._get_controller()
         # Ensure exabgp only attempts one connection.
         exabgp_cmd = mininet_test_util.timeout_cmd(
-            'exabgp %s --once -d 2>&1 > %s &' % (
-                exabgp_conf_file_name, exabgp_out), 300)
-        exabgp_cli = 'env %s %s' % (exabgp_env, exabgp_cmd)
+            f'exabgp {exabgp_conf_file_name} --once -d 2>&1 > {exabgp_out} &', 300)
+        exabgp_cli = f'env {exabgp_env} {exabgp_cmd}'
         controller.cmd(exabgp_cli)
         for _ in range(timeout):
             if os.path.exists(exabgp_log):
                 break
             time.sleep(1)
         self.assertTrue(
-            os.path.exists(exabgp_log), msg='exabgp (%s) did not start' % exabgp_cli)
+            os.path.exists(exabgp_log), msg=f'exabgp ({exabgp_cli}) did not start')
         return (exabgp_log, exabgp_out)
 
     def wait_bgp_up(self, neighbor, vlan, exabgp_log, exabgp_err):
@@ -2747,7 +2706,7 @@ dbs:
             if os.path.exists(log_name):
                 with open(log_name, encoding='utf-8') as log:
                     exabgp_log_content.append(log.read())
-        self.fail('exabgp did not peer with FAUCET: %s' % '\n'.join(exabgp_log_content))
+        self.fail(f'exabgp did not peer with FAUCET: {"\n".join(exabgp_log_content)}')
 
     @staticmethod
     def matching_lines_from_file(exp, log_name):
@@ -2766,7 +2725,7 @@ dbs:
                 if len(lines) >= count:
                     return lines
             time.sleep(1)
-        self.fail('%s not found in %s (%d/%d)' % (exp, log_name, len(lines), count))
+        self.fail(f'{exp} not found in {log_name} ({len(lines)}/{count})')
 
     def wait_until_no_matching_lines_from_file(self, exp, log_name, timeout=30, count=1):
         """Require (count) matching lines to be non-existent in file."""
@@ -2776,7 +2735,7 @@ dbs:
             if os.path.exists(log_name):
                 lines = self.matching_lines_from_file(exp, log_name)
                 if len(lines) >= count:
-                    return self.fail('%s found in %s (%d/%d)' % (exp, log_name, len(lines), count))
+                    return self.fail(f'{exp} found in {log_name} ({len(lines)}/{count})')
             time.sleep(1)
         return lines
 
@@ -2817,18 +2776,17 @@ dbs:
                             wpa_ctrl_socket_path=''):
         """Start wpasupplicant process on Mininet host."""
         wpasupplicant_conf_file_name = os.path.join(
-            self.tmpdir, '%swpasupplicant.conf' % log_prefix)
+            self.tmpdir, f'{log_prefix}wpasupplicant.conf')
         wpasupplicant_log = os.path.join(
-            self.tmpdir, '%swpasupplicant.log' % log_prefix)
+            self.tmpdir, f'{log_prefix}wpasupplicant.log')
         with open(wpasupplicant_conf_file_name, 'w', encoding='utf-8') as wpasupplicant_conf_file:
             wpasupplicant_conf_file.write(wpasupplicant_conf)
         wpa_ctrl_socket = ''
         if wpa_ctrl_socket_path:
-            wpa_ctrl_socket = '-C %s' % wpa_ctrl_socket_path
+            wpa_ctrl_socket = f'-C {wpa_ctrl_socket_path}'
         wpasupplicant_cmd = mininet_test_util.timeout_cmd(
-            'wpa_supplicant -dd -t -c %s -i %s -D wired -f %s %s &' % (
-                wpasupplicant_conf_file_name, host.defaultIntf(), wpasupplicant_log,
-                wpa_ctrl_socket), 300)
+            f'wpa_supplicant -dd -t -c {wpasupplicant_conf_file_name}' \
+            f' -i {host.defaultIntf()} -D wired -f {wpasupplicant_log} {wpa_ctrl_socket} &', 300)
         host.cmd(wpasupplicant_cmd)
         for _ in range(timeout):
             if os.path.exists(wpasupplicant_log):
@@ -2836,7 +2794,7 @@ dbs:
             time.sleep(1)
         self.assertTrue(
             os.path.exists(wpasupplicant_log),
-            msg='wpasupplicant (%s) did not start' % wpasupplicant_cmd)
+            msg=f'wpasupplicant ({wpasupplicant_cmd}) did not start')
         return wpasupplicant_log
 
     def ping_all_when_learned(self, retries=3, hard_timeout=1):
@@ -2852,8 +2810,7 @@ dbs:
         self.assertEqual(0, loss)
 
     def match_table(self, prefix):
-        exp_prefix = '%s/%s' % (
-            prefix.network_address, prefix.netmask)
+        exp_prefix = f'{prefix.network_address}/{prefix_netmask}'
         if prefix.version == 6:
             nw_dst_match = {'ipv6_dst': exp_prefix, 'dl_type': IPV6_ETH}
             table_id = self._IPV6_FIB_TABLE
@@ -2867,7 +2824,7 @@ dbs:
                                nonzero_packets=False):
         """Verify a route has been added as a flow."""
         nw_dst_match, table_id = self.match_table(prefix)
-        nexthop_action = 'SET_FIELD: {eth_dst:%s}' % nexthop
+        nexthop_action = f'SET_FIELD: {{eth_dst:{nexthop}}}'
         if vlan_vid is not None:
             nw_dst_match['dl_vlan'] = str(vlan_vid)
         if nonzero_packets:
@@ -2883,16 +2840,14 @@ dbs:
         """Add an IPv4 alias address to a host."""
         if intf is None:
             intf = host.intf()
-        del_cmd = 'ip addr del %s dev %s' % (
-            alias_ip.with_prefixlen, intf)
-        add_cmd = 'ip addr add %s dev %s label %s:1' % (
-            alias_ip.with_prefixlen, intf, intf)
+        del_cmd = f'ip addr del {alias_ip.with_prefixlen} dev {intf}'
+        add_cmd = f'ip addr add {alias_ip.with_prefixlen} dev {intf} label {intf}:1'
         host.cmd(del_cmd)
         self.quiet_commands(host, (add_cmd,))
 
     @staticmethod
     def _ip_neigh(host, ipa, ip_ver):
-        neighbors = host.cmd('ip -%u neighbor show %s' % (ip_ver, ipa))
+        neighbors = host.cmd(f'ip -{ip_ver} neighbor show {ipa}')
         neighbors_fields = neighbors.split()
         if len(neighbors_fields) >= 5:
             return neighbors.split()[4]
@@ -2903,8 +2858,7 @@ dbs:
             if self._ip_neigh(host, ipa, ip_ver) == mac:
                 return
             time.sleep(1)
-        self.fail(
-            'could not verify %s resolved to %s' % (ipa, mac))
+        self.fail(f'could not verify {ipa} resolved to {mac}')
 
     def verify_ipv4_host_learned_mac(self, host, ipa, mac, retries=3):
         self._verify_host_learned_mac(host, ipa, 4, mac, retries)
@@ -2953,24 +2907,22 @@ dbs:
         for _ in range(3):
             port = mininet_test_util.find_free_port(
                 self.ports_sock, self._test_name())
-            iperf_base_cmd = 'iperf -f M -p %u' % port
+            iperf_base_cmd = f'iperf -f M -p {port}'
             if server_ip.version == 6:
                 iperf_base_cmd += ' -V'
-            iperf_server_cmd = '%s -s -B %s' % (iperf_base_cmd, server_ip)
+            iperf_server_cmd = f'{iperf_base_cmd} -s -B {server_ip}'
             iperf_server_cmd = mininet_test_util.timeout_cmd(
                 iperf_server_cmd, timeout)
             server_start_exp = r'Server listening on TCP port %u' % port
             iperf_client_cmd = mininet_test_util.timeout_cmd(
-                '%s -y c -c %s -B %s -t %u' % (iperf_base_cmd, server_ip, client_ip, seconds),
-                timeout)
+                f'{iperf_base_cmd} -y c -c {server_ip} -B {client_ip} -t {seconds}', timeout)
             iperf_mbps = run_iperf(iperf_server_cmd, server_host, server_start_exp, port)
             if iperf_mbps is not None and iperf_mbps > 0:
                 return iperf_mbps
             time.sleep(1)
         if iperf_mbps == -1:
-            self.fail('iperf client %s did not connect to server %s' % (
-                iperf_client_cmd, iperf_server_cmd))
-        self.fail('iperf server %s never started' % iperf_server_cmd)
+            self.fail(f'iperf client {iperf_client_cmd} did not connect to server {iperf_server_cmd}')
+        self.fail(f'iperf server {iperf_server_cmd} never started')
 
     def verify_ipv4_routing(self, first_host, first_host_routed_ip,
                             second_host, second_host_routed_ip):
@@ -2998,7 +2950,7 @@ dbs:
                  first_host, first_host_routed_ip.ip)):
             iperf_mbps = self.iperf(
                 client_host, client_ip, server_host, server_ip, 5)
-            error('%s: %u mbps to %s\n' % (self._test_name(), iperf_mbps, server_ip))
+            error(f'{self._test_name()}: {iperf_mbps} mbps to {server_ip}\n')
             self.assertGreater(iperf_mbps, 1)
         # verify packets matched routing flows
         self.wait_for_route_as_flow(
@@ -3032,7 +2984,7 @@ dbs:
     @staticmethod
     def host_drop_all_ips(host):
         for ipv in (4, 6):
-            host.cmd('ip -%u addr flush dev %s' % (ipv, host.defaultIntf()))
+            host.cmd(f'ip -{ipv} addr flush dev {host.defaultIntf()}')
 
     def setup_ipv6_hosts_addresses(self, first_host, first_host_ip,
                                    first_host_routed_ip, second_host,
@@ -3040,7 +2992,7 @@ dbs:
         """Configure host IPv6 addresses for testing."""
         for host in first_host, second_host:
             for intf in ('lo', host.intf()):
-                host.cmd('ip -6 addr flush dev %s' % intf)
+                host.cmd(f'ip -6 addr flush dev {intf}')
         self.add_host_ipv6_address(first_host, first_host_ip)
         self.add_host_ipv6_address(second_host, second_host_ip)
         self.add_host_ipv6_address(first_host, first_host_routed_ip, intf='lo')
@@ -3073,7 +3025,7 @@ dbs:
                  first_host, first_host_routed_ip.ip)):
             iperf_mbps = self.iperf(
                 client_host, client_ip, server_host, server_ip, 5)
-            error('%s: %u mbps to %s\n' % (self._test_name(), iperf_mbps, server_ip))
+            error(f'{self._test_name()}: {iperf_mbps} mbps to {server_ip}\n')
             self.assertGreater(iperf_mbps, 1)
         self.one_ipv6_ping(first_host, second_host_ip.ip)
         self.verify_ipv6_host_learned_mac(
@@ -3122,5 +3074,4 @@ dbs:
             if 'FAUCET_LOG' in cont_env:
                 lines = self.matching_lines_from_file(
                     pattern, cont_env['FAUCET_LOG'])
-                self.assertGreater(len(lines), 0, msg='%s not found in %s' %
-                                   (pattern, cont_env['FAUCET_LOG']))
+                self.assertGreater(len(lines), 0, msg=f'{pattern} not found in {cont_env["FAUCET_LOG"]}')

--- a/clib/mininet_test_base.py
+++ b/clib/mininet_test_base.py
@@ -2579,7 +2579,7 @@ dbs:
     def serve_str_on_tcp_port(self, host, port, serve_str='hello', timeout=20):
         """Serve str on a TCP port on a host."""
         host.cmd(mininet_test_util.timeout_cmd(
-            f'echo {serve_str} | nc -l {host.IP()} {timeout} &')
+            f'echo {serve_str} | nc -l {host.IP()} {port} &', timeout))
         self.wait_for_tcp_listen(host, port)
 
     def wait_nonzero_packet_count_flow(self, match, table_id, timeout=15,

--- a/clib/mininet_test_base.py
+++ b/clib/mininet_test_base.py
@@ -1868,7 +1868,7 @@ dbs:
         fping_bin = 'fping'
         if faucet_vip.version == 6:
             fping_bin = 'fping6'
-        fping_cli = f'{fping_pin} {self.FPING_ARGS_SHORT} -b {size}' \
+        fping_cli = f'{fping_bin} {self.FPING_ARGS_SHORT} -b {size}' \
                     f' -c {total_packets} -i {packet_interval_ms} {faucet_vip.ip}'
         timeout = int(((1000.0 / packet_interval_ms) * total_packets) * 1.5)
         fping_out = host.cmd(mininet_test_util.timeout_cmd(
@@ -2810,7 +2810,7 @@ dbs:
         self.assertEqual(0, loss)
 
     def match_table(self, prefix):
-        exp_prefix = f'{prefix.network_address}/{prefix_netmask}'
+        exp_prefix = f'{prefix.network_address}/{prefix.netmask}'
         if prefix.version == 6:
             nw_dst_match = {'ipv6_dst': exp_prefix, 'dl_type': IPV6_ETH}
             table_id = self._IPV6_FIB_TABLE

--- a/clib/mininet_test_base.py
+++ b/clib/mininet_test_base.py
@@ -1815,7 +1815,7 @@ dbs:
 
     def verify_empty_caps(self, cap_files):
         cap_file_cmds = [
-            f'tcpdump -n -v -A -r {cap_file for cap_file in cap_files} 2> /dev/null']
+            'tcpdump -n -v -A -r %s 2> /dev/null' % cap_file for cap_file in cap_files]
         self.quiet_commands(self.net.controllers[0], cap_file_cmds)
 
     def verify_no_bcast_to_self(self, timeout=3):

--- a/clib/mininet_test_base.py
+++ b/clib/mininet_test_base.py
@@ -529,7 +529,7 @@ class FaucetTestBase(unittest.TestCase):
             # Verify version is logged.
             self.assertTrue(
                 self.matching_lines_from_file(r'^.+version\s+(\S+)$', logfile),
-                msg=f'no version logged in {logfile}'
+                msg=f'no version logged in {logfile}')
             # Verify no OFErrors.
             oferrors += '\n\n'.join(self.matching_lines_from_file(r'^.+(OFError.+)$', logfile))
             if not ignore_oferrors:

--- a/clib/mininet_test_base.py
+++ b/clib/mininet_test_base.py
@@ -2161,7 +2161,7 @@ dbs:
         eap_conf_cmd = (
             'echo "eapol_version=2\nap_scan=0\nnetwork={\n'
             'key_mgmt=IEEE8021X\neap=MD5\nidentity=\\"login\\"\n'
-            f'password=\\"password\\"\n}\n" > {tmp_eap_conf}'
+            f'password=\\"password\\"\n}\n" > {tmp_eap_conf}')
         wpa_supplicant_cmd = mininet_test_util.timeout_cmd(
             f'wpa_supplicant -c{tmp_eap_conf} -Dwired -i{first_host.defaultIntf().name} -d', 3)
         tcpdump_txt = self.tcpdump_helper(

--- a/clib/mininet_test_base.py
+++ b/clib/mininet_test_base.py
@@ -2468,7 +2468,7 @@ dbs:
     def add_host_route(self, host, ip_dst, ip_gw):
         """Add an IP route to a Mininet host."""
         host.cmd(f'ip -{ip_dst.version} route del {ip_dst.network.with_prefixlen}')
-        add_cmd = f'ip -{ip_dst.version} route add {ip_dst.network.with_prefixle} via {ip_gw}'
+        add_cmd = f'ip -{ip_dst.version} route add {ip_dst.network.with_prefixlen} via {ip_gw}'
         self.quiet_commands(host, (add_cmd,))
 
     def _ip_ping(self, host, dst, retries, timeout=500,

--- a/clib/mininet_test_base.py
+++ b/clib/mininet_test_base.py
@@ -2706,7 +2706,7 @@ dbs:
             if os.path.exists(log_name):
                 with open(log_name, encoding='utf-8') as log:
                     exabgp_log_content.append(log.read())
-        self.fail(f'exabgp did not peer with FAUCET: {"\n".join(exabgp_log_content)}')
+        self.fail('exabgp did not peer with FAUCET: %s' % '\n'.join(exabgp_log_content))
 
     @staticmethod
     def matching_lines_from_file(exp, log_name):

--- a/clib/mininet_test_base.py
+++ b/clib/mininet_test_base.py
@@ -1437,7 +1437,7 @@ dbs:
         if 'faucet' in controller:
             return f'http://[{self.get_prom_addr()}]:{self.get_prom_port()}'
         if 'gauge' in controller:
-            return f'http://[{self.get_prom_addr()}]:{self.config_ports['gauge_prom_port']}'
+            return f'http://[{self.get_prom_addr()}]:{self.config_ports["gauge_prom_port"]}'
         raise NotImplementedError
 
     def scrape_prometheus(self, controller=None, timeout=15, var=None, verify_consistent=False):

--- a/clib/mininet_test_base_topo.py
+++ b/clib/mininet_test_base_topo.py
@@ -575,7 +575,7 @@ class FaucetTopoTestBase(FaucetTestBase):
             self.validate_with_externals_down(dp_name)
         except AssertionError:
             asserted = True
-        self.assertTrue(asserted, f'Did not fail as expected for {dp_name}'
+        self.assertTrue(asserted, f'Did not fail as expected for {dp_name}')
 
     def verify_intervlan_routing(self):
         """Verify intervlan routing but for LAG host use bond interface"""

--- a/clib/mininet_test_topo.py
+++ b/clib/mininet_test_topo.py
@@ -85,7 +85,7 @@ class FaucetHost(CPULimitedHost):
         opts += f' --interface={interface}'
         opts += f' --dhcp-leasefile={dhcp_leasefile}'
         opts += f' --log-facility={log_facility}'
-        opts += f' --pid-file=pid_file'
+        opts += f' --pid-file={pid_file}'
         opts += ' --conf-file='
         return self.cmd(cmd + opts)
 

--- a/clib/mininet_test_util.py
+++ b/clib/mininet_test_util.py
@@ -211,7 +211,7 @@ def serve_ports(ports_socket, start_free_ports, min_free_ports):
             response_str = ''
             if isinstance(response, int):
                 response = [response]
-            response_str = ''.join([f'{i for i in response}\n'])
+            response_str = ''.join(['%u\n' % i for i in response])
             connection.sendall(response_str.encode())  # pylint: disable=no-member
         connection.close()
 

--- a/clib/mininet_test_util.py
+++ b/clib/mininet_test_util.py
@@ -35,8 +35,7 @@ def lsof_tcp_listening_cmd(port, ipv, state, terse):
     terse_arg = ''
     if terse:
         terse_arg = '-t'
-    return 'lsof -b -P -n %s -sTCP:%s -i %u -a -i tcp:%u' % (
-        terse_arg, state, ipv, port)
+    return f'lsof -b -P -n {terse_arg} -sTCP:{state} -i {ipv} -a -i tcp:{port}'
 
 
 def lsof_udp_listening_cmd(port, terse):
@@ -44,8 +43,7 @@ def lsof_udp_listening_cmd(port, terse):
     terse_arg = ''
     if terse:
         terse_arg = '-t'
-    return 'lsof -b -P -n %s -i udp:%u -a' % (
-        terse_arg, port)
+    return f'lsof -b -P -n {terse_arg} -i udp:{port} -a'
 
 
 def tcp_listening_cmd(port, ipv=4, state='LISTEN', terse=True):
@@ -103,14 +101,14 @@ def test_server_request(ports_socket, name, command):
     assert name is not None
     sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
     sock.connect(ports_socket)
-    sock.sendall(('%s,%s\n' % (command, name)).encode())
-    output('%s %s\n' % (name, command))
+    sock.sendall((f'{command},{name}\n').encode())
+    output(f'{name} {command}\n')
     buf = receive_sock_line(sock)
     responses = [int(i) for i in buf.split('\n')]
     sock.close()
     if len(responses) == 1:
         responses = responses[0]
-    output('%s %s: %u\n' % (name, command, responses))
+    output(f'{name} {command}: {responses}\n')
     return responses
 
 
@@ -126,7 +124,7 @@ def find_free_port(ports_socket, name):
         port = test_server_request(ports_socket, request_name, GETPORT)
         if not tcp_listening(port):
             return port
-        error('port %u is busy, try another' % port)
+        error(f'port {port} is busy, try another')
 
 
 def find_free_udp_port(ports_socket, name):
@@ -135,7 +133,7 @@ def find_free_udp_port(ports_socket, name):
         port = test_server_request(ports_socket, request_name, GETPORT)
         if not udp_listening(port):
             return port
-        error('port %u is busy, try another' % port)
+        error(f'port {port} is busy, try another')
 
 
 def return_free_ports(ports_socket, name):
@@ -213,16 +211,16 @@ def serve_ports(ports_socket, start_free_ports, min_free_ports):
             response_str = ''
             if isinstance(response, int):
                 response = [response]
-            response_str = ''.join(['%u\n' % i for i in response])
+            response_str = ''.join([f'{i for i in response}\n'])
             connection.sendall(response_str.encode())  # pylint: disable=no-member
         connection.close()
 
 
 def timeout_cmd(cmd, timeout):
     """Return a command line prefaced with a timeout wrappers and stdout/err unbuffered."""
-    return 'timeout -sKILL %us stdbuf -o0 -e0 %s' % (timeout, cmd)
+    return f'timeout -sKILL {timeout}s stdbuf -o0 -e0 {cmd}'
 
 
 def timeout_soft_cmd(cmd, timeout):
     """Same as timeout_cmd buf using SIGTERM on timeout."""
-    return 'timeout %us stdbuf -o0 -e0 %s' % (timeout, cmd)
+    return f'timeout {timeout}s stdbuf -o0 -e0 {cmd}'

--- a/clib/tcpdump_helper.py
+++ b/clib/tcpdump_helper.py
@@ -34,8 +34,7 @@ class TcpdumpHelper:
         tcpdump_flags += ' -Z root'
         tcpdump_flags += f' -c {packets if packets else ""}'
         tcpdump_flags += f' -w {pcap_out if pcap_out else ""}'
-        tcpdump_cmd = f'tcpdump -i {self.intf_name} {tcpdump_flags}' \
-            f' --immediate-mode -e -n -U {tcpdump_filter}'
+        tcpdump_cmd = f'tcpdump -i {self.intf_name} {tcpdump_flags} --immediate-mode -e -n -U {tcpdump_filter}'
         pipe_cmd = tcpdump_cmd
         if timeout:
             pipe_cmd = mininet_test_util.timeout_soft_cmd(tcpdump_cmd, timeout)

--- a/clib/tcpdump_helper.py
+++ b/clib/tcpdump_helper.py
@@ -32,9 +32,10 @@ class TcpdumpHelper:
 
         tcpdump_flags = vflags
         tcpdump_flags += ' -Z root'
-        tcpdump_flags += f' -c {packets if packets else ""}'
-        tcpdump_flags += f' -w {pcap_out if pcap_out else ""}'
-        tcpdump_cmd = f'tcpdump -i {self.intf_name} {tcpdump_flags} --immediate-mode -e -n -U {tcpdump_filter}'
+        tcpdump_flags += ' -c %u' % packets if packets else ''
+        tcpdump_flags += ' -w %s' % pcap_out if pcap_out else ''
+        tcpdump_cmd = 'tcpdump -i %s %s --immediate-mode -e -n -U %s' % (
+            self.intf_name, tcpdump_flags, tcpdump_filter)
         pipe_cmd = tcpdump_cmd
         if timeout:
             pipe_cmd = mininet_test_util.timeout_soft_cmd(tcpdump_cmd, timeout)

--- a/clib/tcpdump_helper.py
+++ b/clib/tcpdump_helper.py
@@ -32,10 +32,10 @@ class TcpdumpHelper:
 
         tcpdump_flags = vflags
         tcpdump_flags += ' -Z root'
-        tcpdump_flags += ' -c %u' % packets if packets else ''
-        tcpdump_flags += ' -w %s' % pcap_out if pcap_out else ''
-        tcpdump_cmd = 'tcpdump -i %s %s --immediate-mode -e -n -U %s' % (
-            self.intf_name, tcpdump_flags, tcpdump_filter)
+        tcpdump_flags += f' -c {packets if packets else ""}'
+        tcpdump_flags += f' -w {pcap_out if pcap_out else ""}'
+        tcpdump_cmd = f'tcpdump -i {self.intf_name} {tcpdump_flags}'
+                      f' --immediate-mode -e -n -U {tcpdump_filter}'
         pipe_cmd = tcpdump_cmd
         if timeout:
             pipe_cmd = mininet_test_util.timeout_soft_cmd(tcpdump_cmd, timeout)
@@ -50,8 +50,7 @@ class TcpdumpHelper:
             shell=False)
 
         if self.stream():
-            debug('tcpdump_helper stream fd %s %s' % (
-                self.stream().fileno(), self.intf_name))
+            debug(f'tcpdump_helper stream fd {self.stream().fileno()} {self.intf_name)}'
 
         self.readbuf = ''
         self.set_blocking(blocking)
@@ -81,7 +80,7 @@ class TcpdumpHelper:
                 line = self.next_line()
                 if not line:
                     break
-                debug('tcpdump_helper fd %d line "%s"' % (self.stream().fileno(), line))
+                debug(f'tcpdump_helper fd {self.stream().fileno()} line "{line}"')
                 tcpdump_txt += line.strip()
         return tcpdump_txt
 
@@ -91,7 +90,7 @@ class TcpdumpHelper:
             return -1
 
         try:
-            debug('tcpdump_helper terminate fd %s' % self.stream().fileno())
+            debug(f'tcpdump_helper terminate fd {self.stream().fileno()}')
             self.pipe.terminate()
             result = self.pipe.wait()
             if result == 124:
@@ -101,8 +100,7 @@ class TcpdumpHelper:
             self.pipe = None
             return result
         except EnvironmentError as err:
-            error('Error closing tcpdump_helper fd %d: %s' % (
-                self.pipe.stdout.fileno(), err))
+            error(f'Error closing tcpdump_helper fd {self.pipe.stdout.fileno()}: {err}')
             return -2
 
     def readline(self):
@@ -131,13 +129,13 @@ class TcpdumpHelper:
             try:
                 line = self.readline()
             except OSError as err:
-                if err.errno == errno.EWOULDBLOCK or err.errno == errno.EAGAIN:
+                if err.errno in (errno.EWOULDBLOCK, errno.EAGAIN):
                     return ''
                 raise
-            assert line or self.started, 'tcpdump did not start: %s' % self.last_line.strip()
+            assert line or self.started, f'tcpdump did not start: {self.last_line.strip()}'
             if self.started:
                 return line
-            if re.search('listening on %s' % self.intf_name, line):
+            if re.search(f'listening on {self.intf_name}', line):
                 self.started = True
                 # When we see tcpdump start, then call provided functions.
                 if self.funcs is not None:

--- a/clib/tcpdump_helper.py
+++ b/clib/tcpdump_helper.py
@@ -50,7 +50,7 @@ class TcpdumpHelper:
             shell=False)
 
         if self.stream():
-            debug(f'tcpdump_helper stream fd {self.stream().fileno()} {self.intf_name)}')
+            debug(f'tcpdump_helper stream fd {self.stream().fileno()} {self.intf_name}')
 
         self.readbuf = ''
         self.set_blocking(blocking)

--- a/clib/tcpdump_helper.py
+++ b/clib/tcpdump_helper.py
@@ -34,8 +34,8 @@ class TcpdumpHelper:
         tcpdump_flags += ' -Z root'
         tcpdump_flags += f' -c {packets if packets else ""}'
         tcpdump_flags += f' -w {pcap_out if pcap_out else ""}'
-        tcpdump_cmd = f'tcpdump -i {self.intf_name} {tcpdump_flags}'
-                      f' --immediate-mode -e -n -U {tcpdump_filter}'
+        tcpdump_cmd = f'tcpdump -i {self.intf_name} {tcpdump_flags}' \
+            f' --immediate-mode -e -n -U {tcpdump_filter}'
         pipe_cmd = tcpdump_cmd
         if timeout:
             pipe_cmd = mininet_test_util.timeout_soft_cmd(tcpdump_cmd, timeout)

--- a/clib/tcpdump_helper.py
+++ b/clib/tcpdump_helper.py
@@ -50,7 +50,7 @@ class TcpdumpHelper:
             shell=False)
 
         if self.stream():
-            debug(f'tcpdump_helper stream fd {self.stream().fileno()} {self.intf_name)}'
+            debug(f'tcpdump_helper stream fd {self.stream().fileno()} {self.intf_name)}')
 
         self.readbuf = ''
         self.set_blocking(blocking)

--- a/clib/valve_test_lib.py
+++ b/clib/valve_test_lib.py
@@ -1408,7 +1408,7 @@ class ValveTestBases:
                     match, in_port, valve_vlan, ofp.OFPP_IN_PORT)
                 self.assertEqual(
                     in_port.hairpin, hairpin_output,
-                    msg=f'hairpin flooding incorrect (expected {in_port.hairping} got {hairpin_output})')
+                    msg=f'hairpin flooding incorrect (expected {in_port.hairpin} got {hairpin_output})')
 
                 for port in valve_vlan.get_ports():
                     output = _verify_flood_to_port(match, port, valve_vlan)

--- a/clib/valve_test_lib.py
+++ b/clib/valve_test_lib.py
@@ -2605,18 +2605,20 @@ meters:
 
         def create_config(self):
             """Create the config file"""
-            self.CONFIG = f"""
+            self.CONFIG = """
     vlans:
         vlan100:
             vid: 0x100
-            faucet_mac: '{self.VLAN100_FAUCET_MAC}'
-            faucet_vips: ['{self.VLAN100_FAUCET_VIP_SPACE}']
+            faucet_mac: '%s'
+            faucet_vips: ['%s']
         vlan200:
             vid: 0x200
-            faucet_mac: '{self.VLAN200_FAUCET_MAC}'
-            faucet_vips: ['{self.VLAN200_FAUCET_VIP_SPACE}']
-    {self.base_config()}
-           """
+            faucet_mac: '%s'
+            faucet_vips: ['%s']
+    %s
+           """ % (self.VLAN100_FAUCET_MAC, self.VLAN100_FAUCET_VIP_SPACE,
+                  self.VLAN200_FAUCET_MAC, self.VLAN200_FAUCET_VIP_SPACE,
+                  self.base_config())
 
         def setup_stack_routing(self):
             """Create a stacking config file."""

--- a/clib/valve_test_lib.py
+++ b/clib/valve_test_lib.py
@@ -297,10 +297,10 @@ DOT1X_ACL_CONFIG = """
             noauth_acl: noauth_acl
 """ + BASE_DP1_CONFIG
 
-CONFIG = f"""
+CONFIG = """
 dps:
     s1:
-{DP1_CONFIG}
+%s
         interfaces:
             p1:
                 number: 1
@@ -410,13 +410,13 @@ vlans:
         vid: 0x300
     v400:
         vid: 0x400
-"""
+""" % DP1_CONFIG
 
 
-STACK_CONFIG = f"""
+STACK_CONFIG = """
 dps:
     s1:
-{DP1_CONFIG}
+%s
         stack:
             priority: 1
         interfaces:
@@ -472,12 +472,12 @@ dps:
 vlans:
     v100:
         vid: 0x100
-    """
+    """ % DP1_CONFIG
 
-STACK_LOOP_CONFIG = f"""
+STACK_LOOP_CONFIG = """
 dps:
     s1:
-{BASE_DP1_CONFIG}
+%s
         interfaces:
             1:
                 description: p1
@@ -493,7 +493,7 @@ dps:
                 description: p3
                 native_vlan: v100
     s2:
-{BASE_DP_CONFIG}
+%s
         faucet_dp_mac: 0e:00:00:00:01:02
         dp_id: 0x2
         interfaces:
@@ -511,7 +511,7 @@ dps:
                 description: p3
                 native_vlan: v100
     s3:
-{BASE_DP_CONFIG}
+%s
         faucet_dp_mac: 0e:00:00:00:01:03
         dp_id: 0x3
         stack:
@@ -533,7 +533,7 @@ dps:
 vlans:
     v100:
         vid: 0x100
-"""
+""" % (BASE_DP1_CONFIG, BASE_DP_CONFIG, BASE_DP_CONFIG)
 
 
 class ValveTestBases:
@@ -2143,11 +2143,11 @@ class ValveTestBases:
 
         def test_dp_acl_deny(self):
             """Test DP acl denies forwarding"""
-            acl_config = f"""
+            acl_config = """
 dps:
     s1:
         dp_acls: [drop_non_ospf_ipv4]
-{DP1_CONFIG}
+%s
         interfaces:
             p2:
                 number: 2
@@ -2185,7 +2185,7 @@ meters:
                         rate: 1
                     }
                 ]
-"""
+""" % DP1_CONFIG
 
             drop_match = {
                 'in_port': 2,
@@ -2208,11 +2208,11 @@ meters:
 
         def test_dp_acl_deny_ordered(self):
             """Test DP acl denies forwarding"""
-            acl_config = f"""
+            acl_config = """
 dps:
     s1:
         dp_acls: [drop_non_ospf_ipv4]
-{DP1_CONFIG}
+%s
         interfaces:
             p2:
                 number: 2
@@ -2250,7 +2250,7 @@ meters:
                         rate: 1
                     }
                 ]
-"""
+""" % DP1_CONFIG
 
             drop_match = {
                 'in_port': 2,
@@ -2273,10 +2273,10 @@ meters:
 
         def test_port_acl_deny(self):
             """Test that port ACL denies forwarding."""
-            acl_config = f"""
+            acl_config = """
 dps:
     s1:
-{DP1_CONFIG}
+%s
         interfaces:
             p2:
                 number: 2
@@ -2312,7 +2312,7 @@ meters:
                         rate: 1
                     }
                 ]
-"""
+""" % DP1_CONFIG
 
             drop_match = {
                 'in_port': 2,

--- a/codecheck-requirements.txt
+++ b/codecheck-requirements.txt
@@ -1,4 +1,4 @@
 -r docs/requirements.txt
 flake8==3.9.2
-pylint==2.10.2
+pylint==2.11.1
 pytype==2021.9.9

--- a/debian/control
+++ b/debian/control
@@ -23,7 +23,7 @@ Build-Depends: debhelper (>=9),
                python3-pytricia,
 Standards-Version: 3.9.6
 Homepage: https://github.com/faucetsdn/faucet
-X-Python3-Version: >= 3.4
+X-Python3-Version: >= 3.6
 Vcs-Git: https://github.com/faucetsdn/faucet.git
 Vcs-Browser: https://github.com/faucetsdn/faucet
 
@@ -40,7 +40,7 @@ Depends: python3-influxdb (>= 2.12.0),
          python3-beka (>= 0.3.5), python3-beka (<< 0.3.6),
          python3-chewie (>= 0.0.22), python3-chewie (<< 0.0.23),
          python3-pytricia (>= 1.0.0),
-         python3:any (>= 3.5~),
+         python3:any (>= 3.6~),
 Suggests: python-faucet-doc, faucet, gauge
 Description: source code for faucet and gauge (Python3)
  Python3 library that contains the source code for the Faucet open source

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -206,28 +206,28 @@ def generate_prometheus_metric_table(_):
     }
 
     for module in ["faucet", "gauge"]:
-        block_text[module] = """\
-.. list-table:: {} prometheus metrics
+        block_text[module] = f"""
+.. list-table:: {module.title()} prometheus metrics
     :widths: 40 10 55
     :header-rows: 1
 
     * - Metric
       - Type
       - Description
-""".format(module.title())
+"""
 
         # pylint: disable=protected-access
         for metric in metrics[module]._reg.collect():
             if metric.type == "counter":
-                metric_name = "{}_total".format(metric.name)
+                metric_name = f"{metric.name}_total"
             else:
                 metric_name = metric.name
 
-            block_text[module] += """\
-    * - {}
-      - {}
-      - {}
-""".format(metric_name, metric.type, metric.documentation)
+            block_text[module] += f"""
+    * - {metric_name}
+      - {metric.type}
+      - {metric.documentation}
+"""
 
         with open(output_path[module], 'w', encoding='utf-8') as output_file:
             output_file.write(block_text[module])

--- a/faucet/__main__.py
+++ b/faucet/__main__.py
@@ -89,12 +89,12 @@ def parse_args(sys_args):
     for ryu_arg in RYU_OPTIONAL_ARGS:
         if len(ryu_arg) >= 3:
             args.add_argument(
-                '--ryu-%s' % ryu_arg[0],
+                f'--ryu-{ryu_arg[0]}',
                 help=ryu_arg[1],
                 default=ryu_arg[2])
         else:
             args.add_argument(
-                '--ryu-%s' % ryu_arg[0],
+                f'--ryu-{ryu_arg[0]}',
                 help=ryu_arg[1])
 
     return args.parse_args(sys_args)
@@ -103,7 +103,7 @@ def parse_args(sys_args):
 def print_version():
     """Print version number and exit."""
     version = VersionInfo('faucet').semantic_version().release_string()
-    message = 'Faucet %s' % version
+    message = f'Faucet {version}'
     print(message)
 
 
@@ -136,7 +136,7 @@ def build_ryu_args(argv):
         if arg == 'ryu_config_file' and not os.path.isfile(val):
             continue
         arg_name = arg.replace('ryu_', '').replace('_', '-')
-        ryu_args.append('--%s=%s' % (arg_name, val))
+        ryu_args.append(f'--{arg_name}={val}')
 
     # Running Faucet or Gauge?
     if args.gauge or os.path.basename(prog) == 'gauge':

--- a/faucet/__main__.py
+++ b/faucet/__main__.py
@@ -24,10 +24,10 @@ import sys
 
 from pbr.version import VersionInfo
 
-if sys.version_info < (3,) or sys.version_info < (3, 5):
+if sys.version_info < (3,) or sys.version_info < (3, 6):
     raise ImportError("""You are trying to run faucet on python {py}
 
-Faucet is not compatible with python {py}, please upgrade to python 3.5 or newer."""
+Faucet is not compatible with python {py}, please upgrade to python 3.6 or newer."""
                       .format(py='.'.join([str(v) for v in sys.version_info[:3]])))
 
 RYU_OPTIONAL_ARGS = [

--- a/faucet/acl.py
+++ b/faucet/acl.py
@@ -375,6 +375,7 @@ The output action contains a dictionary with the following elements:
                     tunnel_reverse and tunnel_direction,
                     (f'Tunnel ACL {self._id} cannot contain values for the fields'
                      '`bi_directional` and `reverse` at the same time')
+                )
                 # Resolve the tunnel items
                 dst_dp, dst_port, tunnel_id = resolve_tunnel_objects(
                     tunnel_dp, tunnel_port, tunnel_id)

--- a/faucet/acl.py
+++ b/faucet/acl.py
@@ -397,7 +397,7 @@ The output action contains a dictionary with the following elements:
                 port = resolve_port_cb(port_name)
                 test_config_condition(
                     not port,
-                    (f'ACL (+self._id}) output port undefined in DP: {self.dp_id}')
+                    (f'ACL ({self._id}) output port undefined in DP: {self.dp_id}')
                 )
                 result[output_action] = port
             elif output_action == 'ports':

--- a/faucet/acl.py
+++ b/faucet/acl.py
@@ -139,7 +139,7 @@ The output action contains a dictionary with the following elements:
             conf = {}
         else:
             raise InvalidConfigError(
-                'ACL conf is an invalid type %s' % _id)
+                f'ACL conf is an invalid type {_id}')
         conf['rules'] = []
         for rule in rules:
             normalized_rule = rule
@@ -148,7 +148,7 @@ The output action contains a dictionary with the following elements:
                 if normalized_rule is None:
                     normalized_rule = {k: v for k, v in rule.items() if v is not None}
             test_config_condition(not isinstance(normalized_rule, dict), (
-                'ACL rule is %s not %s (%s)' % (type(normalized_rule), dict, rules)))
+                f'ACL rule is {type(normalized_rule)} not {dict} ({rules})'))
             conf['rules'].append(normalized_rule)
         super().__init__(_id, dp_id, conf)
 
@@ -158,7 +158,7 @@ The output action contains a dictionary with the following elements:
 
     def check_config(self):
         test_config_condition(
-            not self.rules, 'no rules found for ACL %s' % self._id)
+            not self.rules, f'no rules found for ACL {self._id}')
         for rule in self.rules:
             self._check_conf_types(rule, self.rule_types)
             for rule_field, rule_conf in rule.items():
@@ -169,7 +169,7 @@ The output action contains a dictionary with the following elements:
                 elif rule_field == 'actions':
                     test_config_condition(
                         not rule_conf,
-                        'Missing rule actions in ACL %s' % self._id)
+                        f'Missing rule actions in ACL {self._id}')
                     self._check_conf_types(rule_conf, self.actions_types)
                     for action_name, action_conf in rule_conf.items():
                         if action_name == 'output':
@@ -281,7 +281,7 @@ The output action contains a dictionary with the following elements:
                     # Fetch tunnel items from the tunnel output dict
                     test_config_condition(
                         'dp' not in tunnel,
-                        'ACL (%s) tunnel DP not defined' % self._id)
+                        f'ACL ({self._id}) tunnel DP not defined')
                     tunnel_dp = tunnel['dp']
                     tunnel_port = tunnel.get('port', None)
                     tunnel_id = tunnel.get('tunnel_id', None)
@@ -292,8 +292,8 @@ The output action contains a dictionary with the following elements:
                     tunnel_reverse = tunnel.get('reverse', False)
                     test_config_condition(
                         tunnel_reverse and tunnel_direction,
-                        ('Tunnel ACL %s cannot contain values for the fields'
-                         '`bi_directional` and `reverse` at the same time' % self._id))
+                        (f'Tunnel ACL {self._id} cannot contain values for the fields'
+                         '`bi_directional` and `reverse` at the same time'))
                     # Resolve the tunnel items
                     dst_dp, dst_port, tunnel_id = resolve_tunnel_objects(
                         tunnel_dp, tunnel_port, tunnel_id)
@@ -315,14 +315,14 @@ The output action contains a dictionary with the following elements:
                     port = resolve_port_cb(port_name)
                     test_config_condition(
                         not port,
-                        'ACL (%s) output port undefined in DP: %s' % (self._id, self.dp_id))
+                        f'ACL ({self._id}) output port undefined in DP: {self.dp_id}')
                     result.append({key: port})
                 elif key == 'ports':
                     resolved_ports = [
                         resolve_port_cb(p) for p in value]
                     test_config_condition(
                         None in resolved_ports,
-                        'ACL (%s) output port(s) not defined in DP: %s' % (self._id, self.dp_id))
+                        f'ACL ({self._id}) output port(s) not defined in DP: {self.dp_id}')
                     result.append({key: resolved_ports})
                 elif key == 'failover':
                     failover = value
@@ -335,8 +335,7 @@ The output action contains a dictionary with the following elements:
                                 resolve_port_cb(p) for p in failover_values]
                             test_config_condition(
                                 None in resolved_ports,
-                                'ACL (%s) failover port(s) not defined in DP: %s' % (
-                                    self._id, self.dp_id))
+                                f'ACL ({self._id}) failover port(s) not defined in DP: {self.dp_id}')
                             failover_dict[failover_name] = resolved_ports
                         else:
                             failover_dict[failover_name] = failover_values
@@ -353,17 +352,17 @@ The output action contains a dictionary with the following elements:
         result = {}
         test_config_condition(
             'vlan_vid' in action_conf and 'vlan_vids' in action_conf,
-            'ACL %s has both vlan_vid and vlan_vids defined' % self._id)
+            f'ACL {self._id} has both vlan_vid and vlan_vids defined')
         test_config_condition(
             'port' in action_conf and 'ports' in action_conf,
-            'ACL %s has both port and ports defined' % self._id)
+            f'ACL {self._id} has both port and ports defined')
         for output_action, output_action_values in action_conf.items():
             if output_action == 'tunnel':
                 tunnel = output_action_values
                 # Fetch tunnel items from the tunnel output dict
                 test_config_condition(
                     'dp' not in tunnel,
-                    'ACL (%s) tunnel DP not defined' % self._id)
+                    f'ACL ({self._id}) tunnel DP not defined')
                 tunnel_dp = tunnel['dp']
                 tunnel_port = tunnel.get('port', None)
                 tunnel_id = tunnel.get('tunnel_id', None)
@@ -374,8 +373,8 @@ The output action contains a dictionary with the following elements:
                 tunnel_reverse = tunnel.get('reverse', False)
                 test_config_condition(
                     tunnel_reverse and tunnel_direction,
-                    ('Tunnel ACL %s cannot contain values for the fields'
-                     '`bi_directional` and `reverse` at the same time' % self._id))
+                    (f'Tunnel ACL {self._id} cannot contain values for the fields'
+                     '`bi_directional` and `reverse` at the same time')
                 # Resolve the tunnel items
                 dst_dp, dst_port, tunnel_id = resolve_tunnel_objects(
                     tunnel_dp, tunnel_port, tunnel_id)
@@ -397,8 +396,7 @@ The output action contains a dictionary with the following elements:
                 port = resolve_port_cb(port_name)
                 test_config_condition(
                     not port,
-                    ('ACL (%s) output port undefined in DP: %s'
-                     % (self._id, self.dp_id))
+                    (f'ACL (+self._id}) output port undefined in DP: {self.dp_id}')
                 )
                 result[output_action] = port
             elif output_action == 'ports':
@@ -406,8 +404,7 @@ The output action contains a dictionary with the following elements:
                     resolve_port_cb(p) for p in output_action_values]
                 test_config_condition(
                     None in resolved_ports,
-                    ('ACL (%s) output port(s) not defined in DP: %s'
-                     % (self._id, self.dp_id))
+                    (f'ACL ({self._id}) output port(s) not defined in DP: {self.dp_id}')
                 )
                 result[output_action] = resolved_ports
             elif output_action == 'failover':
@@ -421,8 +418,7 @@ The output action contains a dictionary with the following elements:
                             resolve_port_cb(p) for p in failover_values]
                         test_config_condition(
                             None in resolved_ports,
-                            ('ACL (%s) failover port(s) not defined in DP: %s'
-                             % (self._id, self.dp_id))
+                            (f'ACL ({self._id}) failover port(s) not defined in DP: {self.dp_id}')
                         )
                         result[output_action][failover_name] = resolved_ports
                     else:
@@ -446,8 +442,7 @@ The output action contains a dictionary with the following elements:
                         resolved_port = resolve_port_cb(action_conf)
                         test_config_condition(
                             resolved_port is None,
-                            ('ACL (%s) mirror port is not defined in DP: %s'
-                             % (self._id, self.dp_id))
+                            (f'ACL ({self._id}) mirror port is not defined in DP: {self.dp_id}')
                         )
                         resolved_actions[action_name] = resolved_port
                     elif action_name == 'output':

--- a/faucet/dp.py
+++ b/faucet/dp.py
@@ -481,7 +481,7 @@ configuration.
         """Configure FAUCET pipeline with tables."""
         valve_cl = SUPPORTED_HARDWARE.get(self.hardware, None)
         test_config_condition(
-            not valve_cl, f'hardware {self.hardare} must be in {list(SUPPORTED_HARDWARE)}')
+            not valve_cl, f'hardware {self.hardware} must be in {list(SUPPORTED_HARDWARE)}')
         if valve_cl is None:
             return
 

--- a/faucet/dp.py
+++ b/faucet/dp.py
@@ -1035,7 +1035,6 @@ configuration.
                     dst_port = dst_dp.resolve_port(dst_port_name)
                     test_config_condition(dst_port is None, (
                         f'Could not find referenced destination port ({dst_port_name}) for tunnel ACL {acl_in}'))
-                            dst_port_name, acl_in)))
                     test_config_condition(dst_port.stack is None, (
                         f'destination port {dst_port_name} for tunnel ACL {acl_in} cannot be a stack port'))
                     dst_port = dst_port.number

--- a/faucet/dp.py
+++ b/faucet/dp.py
@@ -1279,7 +1279,7 @@ configuration.
             if added_confs:
                 logger.info(f'{conf_name}s added: {added_confs}')
             if changed_confs:
-                logger.info(f'{conf_name}s changed: {changed_congs}')
+                logger.info(f'{conf_name}s changed: {changed_confs}')
         else:
             logger.info(f'no {conf_name} changes')
 

--- a/faucet/dp.py
+++ b/faucet/dp.py
@@ -352,13 +352,13 @@ configuration.
         """Check configuration of this dp"""
         super().check_config()
         test_config_condition(not isinstance(self.dp_id, int), (
-            'dp_id must be %s not %s' % (int, type(self.dp_id))))
+            f'dp_id must be {int} not {type(self.dp_id)}'))
         test_config_condition(self.dp_id < 0 or self.dp_id > 2**64 - 1, (
-            'DP ID %s not in valid range' % self.dp_id))
+            f'DP ID {self.dp_id} not in valid range'))
         test_config_condition(not netaddr.valid_mac(self.faucet_dp_mac), (
-            'invalid MAC address %s' % self.faucet_dp_mac))
+            f'invalid MAC address {self.faucet_dp_mac}'))
         test_config_condition(not (self.interfaces or self.interface_ranges), (
-            'DP %s must have at least one interface' % self))
+            f'DP {self} must have at least one interface'))
         test_config_condition(self.timeout < 15, 'timeout must be > 15')
         test_config_condition(self.timeout > 65535, 'timeout cannot be > than 65335')
         # To prevent L2 learning from timing out before L3 can refresh
@@ -392,7 +392,7 @@ configuration.
         if 'send_interval' not in self.lldp_beacon:
             self.lldp_beacon['send_interval'] = self.DEFAULT_LLDP_SEND_INTERVAL
         test_config_condition(self.lldp_beacon['send_interval'] < 1, (
-            'DP ID %s LLDP beacon send_interval not in valid range' % self.dp_id))
+            f'DP ID {self.dp_id} LLDP beacon send_interval not in valid range'))
         if 'max_per_interval' not in self.lldp_beacon:
             self.lldp_beacon['max_per_interval'] = self.DEFAULT_LLDP_MAX_PER_INTERVAL
         self.lldp_beacon = self._set_unknown_conf(
@@ -470,7 +470,7 @@ configuration.
             (table.table_id, str(table.table_config))
             for table in self.tables.values()])
         return '\n'.join([
-            'table ID %u %s' % (table_id, table_config)
+            f'table ID {table_id} {table_config}'
             for table_id, table_config in table_configs])
 
     def pipeline_tableids(self):
@@ -481,8 +481,7 @@ configuration.
         """Configure FAUCET pipeline with tables."""
         valve_cl = SUPPORTED_HARDWARE.get(self.hardware, None)
         test_config_condition(
-            not valve_cl, 'hardware %s must be in %s' % (
-                self.hardware, list(SUPPORTED_HARDWARE)))
+            not valve_cl, f'hardware {self.hardare} must be in {list(SUPPORTED_HARDWARE)}')
         if valve_cl is None:
             return
 
@@ -497,7 +496,7 @@ configuration.
         # Only configure IP routing tables if enabled.
         for vlan in self.vlans.values():
             for ipv in vlan.ipvs():
-                included_tables.add('ipv%u_fib' % ipv)
+                included_tables.add(f'ipv{ipv}_fib')
                 included_tables.add('vip')
         if valve_cl.STATIC_TABLE_IDS:
             included_tables.add('port_acl')
@@ -548,12 +547,12 @@ configuration.
                 set_fields = set(table_config.set_fields)
                 test_config_condition(
                     not set_fields.issubset(oxm_fields),
-                    'set_fields not all OpenFlow OXM fields %s' % (set_fields - oxm_fields))
+                    f'set_fields not all OpenFlow OXM fields {set_fields - oxm_fields}')
             if table_config.match_types:
                 matches = set(match for match, _ in table_config.match_types)
                 test_config_condition(
                     not matches.issubset(oxm_fields),
-                    'matches not all OpenFlow OXM fields %s' % (matches - oxm_fields))
+                    f'matches not all OpenFlow OXM fields {matches - oxm_fields}')
 
             scale_factor = 1.0
             # Need flows for internal/external.
@@ -887,7 +886,7 @@ configuration.
         def resolve_vlan(vlan_name):
             """Resolve VLAN by name or VID."""
             test_config_condition(not isinstance(vlan_name, (str, int)), (
-                'VLAN must be type %s or %s not %s' % (str, int, type(vlan_name))))
+                f'VLAN must be type {str} or {int} not {type(vlan_name)}'))
             if vlan_name in vlan_by_name:
                 return vlan_by_name[vlan_name]
             if vlan_name in self.vlans:
@@ -910,13 +909,13 @@ configuration.
                 for port in self.stack_ports():
                     stack_dp = port.stack['dp']
                     test_config_condition(stack_dp not in dp_by_name, (
-                        'stack DP %s not defined' % stack_dp))
+                        f'stack DP {stack_dp} not defined'))
                     port_stack_dp[port] = dp_by_name[stack_dp]
                 for port, dp in port_stack_dp.items():
                     port.stack['dp'] = dp
                     stack_port = dp.resolve_port(port.stack['port'])
                     test_config_condition(stack_port is None, (
-                        'stack port %s not defined in DP %s' % (port.stack['port'], dp.name)))
+                        f'stack port {port.stack["port"]} not defined in DP{dp.name}'))
                     port.stack['port'] = stack_port
 
         def resolve_mirror_destinations():
@@ -926,7 +925,7 @@ configuration.
                 if mirror_port.mirror is not None:
                     mirrored_ports = resolve_ports(mirror_port.mirror)
                     test_config_condition(len(mirrored_ports) != len(mirror_port.mirror), (
-                        'port mirror not defined in DP %s' % self.name))
+                        f'port mirror not defined in DP {self.name}'))
                     for mirrored_port in mirrored_ports:
                         mirror_from_port[mirrored_port].append(mirror_port)
 
@@ -950,7 +949,7 @@ configuration.
                 matches, set_fields, meter (3-Tuple): ACL matches, set fields and meter values
             """
             test_config_condition(acl_in not in self.acls, (
-                'missing ACL %s in DP: %s' % (acl_in, self.name)))
+                f'missing ACL {acl_in} in DP:{self.name}'))
             acl = self.acls[acl_in]
             tunnel_dsts_to_vlan = {}
 
@@ -997,12 +996,12 @@ configuration.
                     if tunnel_vlan:
                         # VLAN exists, i.e: user specified the VLAN so check if it is reserved
                         test_config_condition(not tunnel_vlan.reserved_internal_vlan, (
-                            'VLAN %s is required for use by tunnel %s but is not reserved' % (
-                                tunnel_vlan.name, tunnel_id_name)))
+                            f'VLAN {tunnel_vlan.name} is required for use by' \
+                            f' tunnel {tunnel_id_name} but is not reserved'))
                     else:
                         # VLAN does not exist, so the ID should be the VID the user wants
                         test_config_condition(isinstance(tunnel_id_name, str), (
-                            'Tunnel VLAN (%s) does not exist' % tunnel_id_name))
+                            f'Tunnel VLAN ({tunnel_id_name}) does not exist'))
                         # Create the tunnel VLAN object
                         tunnel_vlan = create_vlan(tunnel_id_name)
                         tunnel_vlan.reserved_internal_vlan = True
@@ -1010,8 +1009,8 @@ configuration.
                     if existing_tunnel_vlan is not None:
                         test_config_condition(
                             existing_tunnel_vlan == tunnel_vlan.vid,
-                            'Cannot have multiple tunnel IDs (%u, %u) to same destination %s' % (
-                                existing_tunnel_vlan.vid, tunnel_vlan.vid, resolved_dst))
+                            f'Cannot have multiple tunnel IDs ({existing_tunnel_vlan.vid},' \
+                            f' {tunnel_vlan.vid}) to same destination {resolved_dst}')
                 return tunnel_vlan
 
             def resolve_tunnel_objects(dst_dp_name, dst_port_name, tunnel_id_name):
@@ -1029,18 +1028,16 @@ configuration.
                 test_config_condition(vid is not None, 'Tunnels do not support VLAN-ACLs')
                 # Port & DP tunnel ACL
                 test_config_condition(dst_dp_name not in dp_by_name, (
-                    'Could not find referenced destination DP (%s) for tunnel ACL %s' % (
-                        dst_dp_name, acl_in)))
+                    f'Could not find referenced destination DP ({dst_dp_name}) for tunnel ACL {acl_in}'))
                 dst_dp = dp_by_name[dst_dp_name]
                 dst_port = None
                 if dst_port_name:
                     dst_port = dst_dp.resolve_port(dst_port_name)
                     test_config_condition(dst_port is None, (
-                        'Could not find referenced destination port (%s) for tunnel ACL %s' % (
+                        f'Could not find referenced destination port ({dst_port_name}) for tunnel ACL {acl_in}'))
                             dst_port_name, acl_in)))
                     test_config_condition(dst_port.stack is None, (
-                        'destination port %s for tunnel ACL %s cannot be a stack port' % (
-                            dst_port_name, acl_in)))
+                        f'destination port {dst_port_name} for tunnel ACL {acl_in} cannot be a stack port'))
                     dst_port = dst_port.number
                 dst_dp = dst_dp.name
                 resolved_dst = (dst_dp, dst_port)
@@ -1054,7 +1051,7 @@ configuration.
             acl.resolve_ports(resolve_port_cb, resolve_tunnel_objects)
             for meter_name in acl.get_meters():
                 test_config_condition(meter_name not in self.meters, (
-                    'meter %s is not configured' % meter_name))
+                    f'meter {meter_name} is not configured'))
                 acl_meters.add(meter_name)
             for port_no in acl.get_mirror_destinations():
                 port = self.ports[port_no]
@@ -1144,7 +1141,7 @@ configuration.
                 vids = {vlan.vid for vlan in self.vlans.values()}
                 test_config_condition(
                     self.global_vlan in vids,
-                    'global_vlan VID %s conflicts with existing VLAN' % self.global_vlan)
+                    f'global_vlan VID {self.global_vlan} conflicts with existing VLAN')
 
             # Check for overlapping VIP subnets or VLANs.
             all_router_vlans = set()
@@ -1154,7 +1151,7 @@ configuration.
                     lone_vlan = router.vlans[0]
                     test_config_condition(
                         lone_vlan in all_router_vlans,
-                        'single VLAN %s in more than one router' % lone_vlan)
+                        f'single VLAN {lone_vlan} in more than one router')
                 for vlan in router.vlans:
                     vips.update({vip for vip in vlan.faucet_vips if not vip.ip.is_link_local})
                 all_router_vlans.update(router.vlans)
@@ -1162,25 +1159,23 @@ configuration.
                     for other_vip in vips - set([vip]):
                         test_config_condition(
                             vip.ip in other_vip.network,
-                            'VIPs %s and %s overlap in router %s' % (
-                                vip, other_vip, router_name))
+                            f'VIPs {vip} and {other_vip} overlap in router {router_name}')
             bgp_routers = self.bgp_routers()
             if bgp_routers:
                 for bgp_router in bgp_routers:
                     bgp_vlan = bgp_router.bgp_vlan()
                     vlan_dp_ids = [str(dp.dp_id) for dp in dps if bgp_vlan.vid in dp.vlans]
                     test_config_condition(len(vlan_dp_ids) != 1, (
-                        'DPs (%s) sharing a BGP speaker VLAN (%s) is unsupported') % (
-                            ', '.join(vlan_dp_ids), bgp_vlan.vid))
+                        f'DPs ({", ".join(vlan_dp_ids)}) sharing a BGP speaker VLAN ({bgp_vlan.vid}) is unsupported'))
                     test_config_condition(bgp_router.bgp_server_addresses() != (
                         bgp_routers[0].bgp_server_addresses()), (
                             'BGP server addresses must all be the same'))
                 router_ids = {bgp_router.bgp_routerid() for bgp_router in bgp_routers}
                 test_config_condition(
-                    len(router_ids) != 1, 'BGP router IDs must all be the same: %s' % router_ids)
+                    len(router_ids) != 1, f'BGP router IDs must all be the same: {router_ids}')
                 bgp_ports = {bgp_router.bgp_port() for bgp_router in bgp_routers}
                 test_config_condition(
-                    len(bgp_ports) != 1, 'BGP ports must all be the same: %s' % bgp_ports)
+                    len(bgp_ports) != 1, f'BGP ports must all be the same: {bgp_ports}')
 
         if not self.stack_ports():
             # Revert back to None if there are no stack ports
@@ -1191,7 +1186,7 @@ configuration.
 
         test_config_condition(
             not self.vlans and not self.non_vlan_ports(),
-            'no VLANs referenced by interfaces in %s' % self.name)
+            f'no VLANs referenced by interfaces in {self.name}')
         dp_by_name = {dp.name: dp for dp in dps}
         vlan_by_name = {vlan.name: vlan for vlan in self.vlans.values()}
         loop_protect_external_ports = {
@@ -1263,18 +1258,16 @@ configuration.
                         new_conf, ignore_keys=(ignore_keys.union(['description']))):
                     same_confs.add(conf_id)
                     description_only_confs.add(conf_id)
-                    logger.info('%s %s description only changed' % (
-                        conf_name, conf_id))
+                    logger.info(f'{conf_name} {conf_id} description only changed')
                 else:
                     changed_confs.add(conf_id)
                     if diff:
-                        logger.info('%s %s changed: %s' % (
-                            conf_name, conf_id, old_conf.conf_diff(new_conf)))
+                        logger.info(f'{conf_name} {conf_id} changed: {old_conf.conf_diff(new_conf)}')
                     else:
-                        logger.info('%s %s changed' % (conf_name, conf_id))
+                        logger.info(f'{conf_name} {conf_id} changed')
             else:
                 added_confs.add(conf_id)
-                logger.info('%s %s added' % (conf_name, conf_id))
+                logger.info(f'{conf_name} {conf_id} added')
 
         for conf_id in same_confs:
             old_conf = subconf[conf_id]
@@ -1283,13 +1276,14 @@ configuration.
         changes = deleted_confs or added_confs or changed_confs
         if changes:
             if deleted_confs:
-                logger.info('%ss deleted: %s' % (conf_name, deleted_confs))
+                logger.info(f'{conf_name}s deleted: {deleted_confs}')
             if added_confs:
-                logger.info('%ss added: %s' % (conf_name, added_confs))
+                logger.info(f'{conf_name}s added: {added_confs}')
             if changed_confs:
-                logger.info('%ss changed: %s' % (conf_name, changed_confs))
+                logger.info(f'{conf_name}s changed: {changed_congs}')
         else:
-            logger.info('no %s changes' % conf_name)
+            logger.info(f'no {conf_name} changes')
+
 
         return (
             changes, deleted_confs, added_confs, changed_confs, same_confs, description_only_confs)
@@ -1411,8 +1405,7 @@ configuration.
                 old_port = self.ports[port_no]
                 new_port = new_dp.ports[port_no]
                 if old_port.mirror != new_port.mirror:
-                    logger.info('port %s mirror options changed: %s' % (
-                        port_no, new_port.mirror))
+                    logger.info(f'port {port_no} mirror options changed: {new_port.mirror}')
                     changed_ports.add(port_no)
                 # ACL changes
                 new_acl_ids = new_port.acls_in
@@ -1425,16 +1418,14 @@ configuration.
                     old_acl_ids = [acl._id for acl in old_acl_ids]
                 if port_acls_changed:
                     changed_acl_ports.add(port_no)
-                    logger.info('port %s ACL changed (ACL %s content changed)' % (
-                        port_no, port_acls_changed))
+                    logger.info(f'port {port_no} ACL changed (ACL {port_acls_changed} content changed)')
                 elif (old_acl_ids or new_acl_ids) and old_acl_ids != new_acl_ids:
                     changed_acl_ports.add(port_no)
-                    logger.info('port %s ACL changed (ACL %s to %s)' % (
-                        port_no, old_acl_ids, new_acl_ids))
+                    logger.info(f'port {port_no} ACL changed (ACL {old_acl_ids} to {new_acl_ids})')
 
             if changed_acl_ports:
                 same_ports -= changed_acl_ports
-                logger.info('ports where ACL only changed: %s' % changed_acl_ports)
+                logger.info(f'ports where ACL only changed: {changed_acl_ports}')
 
         same_ports -= changed_ports
         changed_vlans -= deleted_vlans
@@ -1445,7 +1436,7 @@ configuration.
             if vlan.faucet_vips:
                 changed_vlans_with_vips.append(vlan)
         if changed_vlans_with_vips:
-            logger.info('forcing cold start because %s has routing' % changed_vlans_with_vips)
+            logger.info(f'forcing cold start because {changed_vlans_with_vips} has routing')
             all_ports_changed = True
 
         return (all_ports_changed, deleted_ports,
@@ -1495,7 +1486,7 @@ configuration.
             logger.info('DP routers config changed - requires cold start')
         elif not self.ignore_subconf(
                 new_dp, ignore_keys=['interfaces', 'interface_ranges', 'routers']):
-            logger.info('DP config changed - requires cold start: %s' % self.conf_diff(new_dp))
+            logger.info(f'DP config changed - requires cold start: {self.conf_diff(new_dp)}')
         else:
             changed_acls = self._get_acl_config_changes(logger, new_dp)
             deleted_vlans, changed_vlans = self._get_vlan_config_changes(logger, new_dp)

--- a/faucet/faucet_dot1x.py
+++ b/faucet/faucet_dot1x.py
@@ -92,10 +92,10 @@ class FaucetDot1x:  # pylint: disable=too-many-instance-attributes
     # Loggin Methods
     def log_auth_event(self, valve, port_num, mac_str, status):
         """Log an authentication attempt event"""
-        self.metrics.inc_var('dp_dot1x_{}'.format(status), valve.dp.base_prom_labels())
-        self.metrics.inc_var('port_dot1x_{}'.format(status), valve.dp.port_labels(port_num))
+        self.metrics.inc_var(f'dp_dot1x_{status}', valve.dp.base_prom_labels())
+        self.metrics.inc_var(f'port_dot1x_{status}', valve.dp.port_labels(port_num))
         self.logger.info(
-            '{} from MAC {} on {}'.format(status.capitalize(), mac_str, port_num))
+            f'{status.capitalize()} from MAC {mac_str} on {port_num}')
         valve.dot1x_event({'AUTHENTICATION': {'dp_id': valve.dp.dp_id,
                                               'port': port_num,
                                               'eth_src': mac_str,
@@ -314,8 +314,7 @@ class FaucetDot1x:  # pylint: disable=too-many-instance-attributes
             for dot1x_port in valve.dp.dot1x_ports():
                 self.set_mac_str(valve, valve_index, dot1x_port.number)
                 self.logger.info(
-                    'dot1x enabled on %s (%s) port %s, NFV interface %s' % (
-                        valve.dp, valve_index, dot1x_port, dot1x_intf))
+                    f'dot1x enabled on {valve.dp} ({valve_index}) port {dot1x_port}, NFV interface {dot1x_intf}')
 
             valve.dot1x_event({'ENABLED': {'dp_id': valve.dp.dp_id}})
 
@@ -347,15 +346,13 @@ class FaucetDot1x:  # pylint: disable=too-many-instance-attributes
 
         acl = valve.dp.acls.get(acl_name, None)
         if dot1x_port.dot1x_dyn_acl and acl:
-            self.logger.info("DOT1X_DYN_ACL: Adding ACL '{0}' for port '{1}'".format(
-                acl_name, port_num))
-            self.logger.debug("DOT1X_DYN_ACL: ACL contents: '{0}'".format(str(acl.__dict__)))
+            self.logger.info(f"DOT1X_DYN_ACL: Adding ACL '{acl_name}' for port '{port_num}'")
+            self.logger.debug(f"DOT1X_DYN_ACL: ACL contents: '{str(acl.__dict__)}'")
             flowmods.extend(acl_manager.add_port_acl(acl, port_num, mac_str))
         elif dot1x_port.dot1x_acl:
             auth_acl, _ = self._get_acls(valve.dp)
-            self.logger.info("DOT1X_PRE_ACL: Adding ACL '{0}' for port '{1}'".format(
-                acl_name, port_num))
-            self.logger.debug("DOT1X_PRE_ACL: ACL contents: '{0}'".format(str(auth_acl.__dict__)))
+            self.logger.info(f"DOT1X_PRE_ACL: Adding ACL '{acl_name}' for port '{port_num}'")
+            self.logger.debug(f"DOT1X_PRE_ACL: ACL contents: '{str(auth_acl.__dict__)}'")
             flowmods.extend(acl_manager.add_port_acl(auth_acl, port_num, mac_str))
         else:
             flowmods.extend(acl_manager.add_authed_mac(port_num, mac_str))

--- a/faucet/faucet_pipeline.py
+++ b/faucet/faucet_pipeline.py
@@ -49,10 +49,10 @@ class ValveTableConfig:  # pylint: disable=too-many-instance-attributes
 
     def __str__(self):
         field_strs = ' '.join([
-            '%s: %s' % (key, val)
+            f'{key}: {val}'
             for key, val in sorted(self.__dict__.items())
             if val])
-        return 'table config %s' % field_strs
+        return f'table config {field_strs}'
 
     def __repr__(self):
         return self.__str__()
@@ -73,9 +73,9 @@ _NEXT_VIP = ('vip',) + _NEXT_ETH
 
 def _fib_table(ipv, table_id):
     return ValveTableConfig(
-        'ipv%u_fib' % ipv,
+        f'ipv{ipv}_fib',
         table_id,
-        match_types=(('eth_type', False), ('ipv%u_dst' % ipv, True), ('vlan_vid', False)),
+        match_types=(('eth_type', False), (f'ipv{ipv}_dst', True), ('vlan_vid', False)),
         set_fields=('eth_dst', 'eth_src', 'vlan_vid'),
         dec_ttl=True,
         vlan_port_scale=3.1,

--- a/faucet/gauge_influx.py
+++ b/faucet/gauge_influx.py
@@ -47,13 +47,13 @@ class InfluxShipper:
                     if client.write_points(points=points, time_precision='s'):
                         return True
                     self.logger.warning(
-                        '%s failed to update InfluxDB' % self.ship_error_prefix)
+                        f'{self.ship_error_prefix} failed to update InfluxDB')
                 else:
                     self.logger.warning(
-                        '%s error connecting to InfluxDB' % self.ship_error_prefix)
+                        f'{self.ship_error_prefix} error connecting to InfluxDB')
             except (requests.exceptions.ConnectionError, requests.exceptions.ReadTimeout,
                     InfluxDBClientError, InfluxDBServerError) as err:
-                self.logger.warning('%s %s' % (self.ship_error_prefix, err))
+                self.logger.warning(f'{self.ship_error_prefix} {err}')
         return False
 
     @staticmethod

--- a/faucet/stack.py
+++ b/faucet/stack.py
@@ -188,11 +188,11 @@ is technically a fixed allocation for this DP Stack instance."""
         if not timeout_healthy:
             # Too long since DP last running, if DP not running then
             #   number of UP stack or LACP ports should be 0
-            reason += 'last running %us ago (timeout %us)' % (now - last_live_time, health_timeout)
+            reason += f'last running {now - last_live_time}s ago (timeout {health_timeout}s)'
             self.dyn_healthy_info = (False, 0.0, 0.0)
             self.dyn_healthy = False
             return self.dyn_healthy, reason
-        reason += 'running %us ago' % (now - last_live_time)
+        reason += f'running {now - last_live_time}s ago'
         if reason:
             reason += ', '
         stack_ports_healthy, stack_percentage = self.stack_port_healthy()
@@ -258,8 +258,7 @@ is technically a fixed allocation for this DP Stack instance."""
 
         for dp in stack_priority_dps:
             test_config_condition(not isinstance(dp.stack.priority, int), (
-                'stack priority must be type %s not %s' % (
-                    int, type(dp.stack.priority))))
+                f'stack priority must be type {int} not {type(dp.stack.priority)}'))
             test_config_condition(dp.stack.priority <= 0, (
                 'stack priority must be > 0'))
 
@@ -285,13 +284,13 @@ is technically a fixed allocation for this DP Stack instance."""
                 edge_name = Stack.modify_topology(graph, dp, port)
                 edge_count[edge_name] += 1
         for edge_name, count in edge_count.items():
-            test_config_condition(count != 2, '%s defined only in one direction' % edge_name)
+            test_config_condition(count != 2, f'{edge_name} defined only in one direction')
         if graph.size() and self.name in graph:
             self.graph = graph
             for dp in graph.nodes():
                 path_to_root_len = len(self.shortest_path(self.root_name, src_dp=dp))
                 test_config_condition(
-                    path_to_root_len == 0, '%s not connected to stack' % dp)
+                    path_to_root_len == 0, f'{dp} not connected to stack')
             root_len = self.longest_path_to_root_len()
             if root_len is not None and root_len > 2:
                 self.root_flood_reflection = True
@@ -314,9 +313,7 @@ is technically a fixed allocation for this DP Stack instance."""
         def make_edge_name(edge_a, edge_z):
             edge_a_dp, edge_a_port = edge_a
             edge_z_dp, edge_z_port = edge_z
-            return '%s:%s-%s:%s' % (
-                edge_a_dp.name, edge_a_port.name,
-                edge_z_dp.name, edge_z_port.name)
+            return f'{edge_a_dp.name}:{edge_a_port.name}-{edge_z_dp.name}:{edge_z_port.name}'
 
         def make_edge_attr(edge_a, edge_z):
             edge_a_dp, edge_a_port = edge_a

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -1541,7 +1541,7 @@ class Valve:
             # Same scenario as groups.
             return
         self._inc_var('of_errors')
-        self.logger.error(f'OFError type: {error_type} code: {error_code} {error_text}')
+        self.logger.error(f'OFError type: {error_type} code: {error_code} {error_txt}')
 
     def prepare_send_flows(self, flow_msgs):
         """Prepare to send flows to datapath.

--- a/faucet/valve_lldp.py
+++ b/faucet/valve_lldp.py
@@ -91,14 +91,9 @@ class ValveLLDPManager(ValveManagerBase):
                 or remote_dp_name != remote_dp.name
                 or remote_port_id != remote_port.number):
             self.logger.error(
-                'Stack %s cabling incorrect, expected %s:%s:%u, actual %s:%s:%u' % (
-                    port,
-                    valve_util.dpid_log(remote_dp.dp_id),
-                    remote_dp.name,
-                    remote_port.number,
-                    valve_util.dpid_log(remote_dp_id),
-                    remote_dp_name,
-                    remote_port_id))
+                f'Stack {port} cabling incorrect, expected ' \
+                f'{valve_util.dpid_log(remote_dp.dp_id)}:{remote_dp.name}:{remote_port.number}, ' \
+                f'actual {valve_util.dpid_log(remote_dp_id)}:{remote_dp_name}:{remote_port_id}')
             stack_correct = False
             self._inc_var('stack_cabling_errors')
         port.dyn_stack_probe_info = {
@@ -138,9 +133,8 @@ class ValveLLDPManager(ValveManagerBase):
                 self.notify({'STACK_STATE': {
                     'port': port.number,
                     'state': after_state}})
-                self.logger.info('Stack %s state %s (previous state %s): %s' % (
-                    port, port.stack_state_name(after_state),
-                    port.stack_state_name(before_state), reason))
+                self.logger.info(f'Stack {port} state {port.stack_state_name(after_state)} ' \
+                    f'(previous state {port.stack_state_name(before_state)}): {reason}')
                 stack_changes += 1
                 port_up = False
                 if port.is_stack_up():
@@ -150,8 +144,7 @@ class ValveLLDPManager(ValveManagerBase):
                 for stack_valve in stacked_valves:
                     stack_valve.stack_manager.update_stack_topo(port_up, valve.dp, port)
         if stack_changes or valve.stale_root:
-            self.logger.info('%u stack ports changed state, stale root %s' %
-                             (stack_changes, valve.stale_root))
+            self.logger.info(f'{stack_changes} stack ports changed state, stale root {valve.stale_root}')
             valve.stale_root = False
             notify_dps = {}
             for stack_valve in stacked_valves:

--- a/faucet/valve_packet.py
+++ b/faucet/valve_packet.py
@@ -760,7 +760,7 @@ class PacketMeta:
     def log(self):
         vlan_msg = ''
         if self.vlan:
-            vlan_msg = 'VLAN %u' % self.vlan.vid
+            vlan_msg = f'VLAN {self.vlan.vid}'
         return '%s (L2 type 0x%4.4x, L2 dst %s, L3 src %s, L3 dst %s) %s %s' % (
             self.eth_src, self.eth_type, self.eth_dst, self.l3_src, self.l3_dst,
             self.port, vlan_msg)

--- a/faucet/valve_table.py
+++ b/faucet/valve_table.py
@@ -50,8 +50,7 @@ class ValveTable:  # pylint: disable=too-many-arguments,too-many-instance-attrib
     def goto(self, next_table):
         """Add goto next table instruction."""
         assert next_table.name in self.table_config.next_tables, (
-            '%s not configured as next table in %s' % (
-                next_table.name, self.name))
+            f'{next_table.name} not configured as next table in {self.name}')
         return valve_of.goto_table(next_table)
 
     def goto_this(self):
@@ -60,8 +59,7 @@ class ValveTable:  # pylint: disable=too-many-arguments,too-many-instance-attrib
     def goto_miss(self, next_table):
         """Add miss goto table instruction."""
         assert next_table.name == self.table_config.miss_goto, (
-            '%s not configured as miss table in %s' % (
-                next_table.name, self.name))
+            f'{next_table.name} not configured as miss table in {self.name}')
         return valve_of.goto_table(next_table)
 
     @staticmethod
@@ -110,25 +108,25 @@ class ValveTable:  # pylint: disable=too-many-arguments,too-many-instance-attrib
             if self.table_id != valve_of.ofp.OFPTT_ALL:
                 for match_type, match_field in match_fields:
                     assert match_type in self.match_types, (
-                        '%s match in table %s' % (match_type, self.name))
+                        f'{match_type} match in table {self.name}')
         else:
             # TODO: ACL builder should not use ALL table.
             if self.table_id == valve_of.ofp.OFPTT_ALL:
                 return
             assert not (flowmod.priority == 0 and match_fields), (
-                'default flow cannot have matches on table %s: %s' % (self.name, flowmod))
+                f'default flow cannot have matches on table {self.name}: {flowmod}')
             for match_type, match_field in match_fields:
                 assert match_type in self.match_types, (
-                    '%s match in table %s' % (match_type, self.name))
+                    f'{match_type} match in table {self.name}')
                 config_mask = self.match_types[match_type]
                 flow_mask = isinstance(match_field, tuple)
                 assert config_mask or (not config_mask and not flow_mask), (
-                    '%s configured mask %s but flow mask %s in table %s (%s)' % (
-                        match_type, config_mask, flow_mask, self.name, flowmod))
+                    f'{match_type} configured mask {config_mask} but flow mask ' \
+                    f'{flow_mask} in table {self.name} ({flowmod})')
                 if self.exact_match and match_fields:
                     assert len(self.match_types) == len(match_fields), (
-                        'exact match table %s matches %s do not match flow matches %s (%s)' % (
-                            self.name, self.match_types, match_fields, flowmod))
+                        f'exact match table {self.name} matches {self.match_types} ' \
+                        f'do not match flow matches {match_fields} ({flowmod})')
 
     def _trim_actions(self, actions):
         new_actions = []
@@ -143,9 +141,7 @@ class ValveTable:  # pylint: disable=too-many-arguments,too-many-instance-attrib
         set_fields = {action.key for action in new_actions if valve_of.is_set_field(action)}
         if self.table_id != valve_of.ofp.OFPTT_ALL and set_fields:
             assert set_fields.issubset(self.set_fields), (
-                'unexpected set fields %s configured %s in %s' % (set_fields,
-                                                                  self.set_fields,
-                                                                  self.name))
+                f'unexpected set fields {set_fields} configured {self.set_fields} in {self.name}')
         return new_actions
 
     @functools.lru_cache()

--- a/faucet/watcher.py
+++ b/faucet/watcher.py
@@ -80,18 +80,18 @@ class GaugePortStateLogger(GaugePortStatePoller):
         rcv_time_str = self._rcv_time(rcv_time)
         reason = msg.reason
         port_no = msg.desc.port_no
-        log_msg = 'port %s unknown state %s' % (port_no, reason)
+        log_msg = f'port {port_no} unknown state {reason}'
         if reason == ofp.OFPPR_ADD:
-            log_msg = 'port %s added' % port_no
+            log_msg = f'port {port_no} added'
         elif reason == ofp.OFPPR_DELETE:
-            log_msg = 'port %s deleted' % port_no
+            log_msg = f'port {port_no} deleted'
         elif reason == ofp.OFPPR_MODIFY:
             link_down = (msg.desc.state & ofp.OFPPS_LINK_DOWN)
             if link_down:
-                log_msg = 'port %s down' % port_no
+                log_msg = f'port {port_no} down'
             else:
-                log_msg = 'port %s up' % port_no
-        log_msg = '%s %s' % (dpid_log(self.dp.dp_id), log_msg)
+                log_msg = f'port {port_no} up'
+        log_msg = f'{dpid_log(self.dp.dp_id)} {log_msg}'
         self.logger.info(log_msg)
         if self.conf.file:
             with open(self.conf.file, 'a', encoding='utf-8') as logfile:
@@ -152,15 +152,14 @@ class GaugeFlowTableLogger(GaugeFlowTablePoller):
         # Double Hyphen to avoid confusion with ISO8601 times
         filename = os.path.join(
             path,
-            "{}--flowtable--{}.json".format(self.dp.name, rcv_time_str)
+            f"{self.dp.name}--flowtable--{rcv_time_str}.json"
         )
         if os.path.isfile(filename):
             # If this filename already exists, add an increment to the filename
             # (for dealing with parts of a multipart message arriving at the same time)
             inc = 1
             while os.path.isfile(filename):
-                filename = os.path.join(path, "{}--flowtable--{}--{}.json".format(
-                    self.dp.name, rcv_time_str, inc))
+                filename = os.path.join(path, f"{self.dp.name}--flowtable--{rcv_time_str}--{inc}.json")
                 inc += 1
 
         if self.conf.compress:

--- a/faucet/watcher_conf.py
+++ b/faucet/watcher_conf.py
@@ -182,10 +182,10 @@ For Prometheus:
         test_config_condition(
             self.file is not None and not
             (os.path.dirname(self.file) and os.access(os.path.dirname(self.file), os.W_OK)),
-            '%s is not writable' % self.file)
+            f'{self.file} is not writable')
         test_config_condition(
             self.path is not None and not os.access(self.path, os.W_OK),
-            '%s is not writable' % self.file)
+            f'{self.file} is not writable')
 
     def add_dp(self, dp):
         """Add a datapath to this watcher."""
@@ -201,4 +201,4 @@ For Prometheus:
         valid_types = {'flow_table', 'port_stats', 'port_state', 'meter_stats'}
         test_config_condition(
             self.type not in valid_types,
-            'type %s not one of %s' % (self.type, valid_types))
+            f'type {self.type} not one of {valid_types}')

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,9 +12,10 @@ classifier =
     Topic :: System :: Networking
     Natural Language :: English
     Programming Language :: Python
-    Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
     Operating System :: Unix
 keywords =
     openflow

--- a/setup.py
+++ b/setup.py
@@ -43,19 +43,19 @@ def install_configs():
 
     def setup_ryu_conf():
         if not os.path.exists(dst_ryu_conf_dir):
-            print("Creating %s" % dst_ryu_conf_dir)
+            print(f"Creating {dst_ryu_conf_dir}")
             os.makedirs(dst_ryu_conf_dir)
         if not os.path.isfile(dst_ryu_conf):
             if os.path.exists(old_ryu_conf) and os.path.isfile(old_ryu_conf):
-                print("Migrating %s to %s" % (old_ryu_conf, dst_ryu_conf))
+                print(f"Migrating {old_ryu_conf} to {dst_ryu_conf}")
                 shutil.copy(old_ryu_conf, dst_ryu_conf)
             else:
-                print("Copying %s to %s" % (src_ryu_conf, dst_ryu_conf))
+                print(f"Copying {src_ryu_conf} to {dst_ryu_conf}")
                 shutil.copy(src_ryu_conf, dst_ryu_conf)
 
     def setup_faucet_conf():
         if not os.path.exists(dst_faucet_conf_dir):
-            print("Creating %s" % dst_faucet_conf_dir)
+            print(f"Creating {dst_faucet_conf_dir}")
             os.makedirs(dst_faucet_conf_dir)
         for file_name in os.listdir(src_faucet_conf_dir):
             src_file = os.path.join(src_faucet_conf_dir, file_name)
@@ -64,15 +64,15 @@ def install_configs():
             if os.path.isfile(dst_file):
                 continue
             if os.path.isfile(alt_src):
-                print("Migrating %s to %s" % (alt_src, dst_file))
+                print(f"Migrating {alt_src} to {dst_file}")
                 shutil.copy(alt_src, dst_file)
             elif os.path.isfile(src_file):
-                print("Copying %s to %s" % (src_file, dst_file))
+                print(f"Copying {src_file} to {dst_file}")
                 shutil.copy(src_file, dst_file)
 
     def setup_faucet_log():
         if not os.path.exists(faucet_log_dir):
-            print("Creating %s" % faucet_log_dir)
+            print(f"Creating {faucet_log_dir}")
             os.makedirs(faucet_log_dir)
 
     try:
@@ -81,8 +81,7 @@ def install_configs():
         setup_faucet_log()
     except OSError as exception:
         if exception.errno == errno.EACCES:
-            print("Permission denied creating %s, skipping copying configs"
-                  % exception.filename)
+            print(f"Permission denied creating {exception.filename}, skipping copying configs")
         else:
             raise
 

--- a/setup.py
+++ b/setup.py
@@ -15,15 +15,15 @@ from setuptools import setup
 if sys.version_info < (3,):
     print("""You are trying to install faucet on python {py}
 
-Faucet is not compatible with python 2, please upgrade to python 3.5 or newer."""
+Faucet is not compatible with python 2, please upgrade to python 3.6 or newer."""
           .format(py='.'.join([str(v) for v in sys.version_info[:3]])), file=sys.stderr)
     sys.exit(1)
-elif sys.version_info < (3, 5):
+elif sys.version_info < (3, 6):
     print("""You are trying to install faucet on python {py}
 
 Faucet 1.9.0 and above are no longer compatible with older versions of python 3.
 
-Please upgrade to python 3.5 or newer."""
+Please upgrade to python 3.6 or newer."""
           .format(py='.'.join([str(v) for v in sys.version_info[:3]])))
     sys.exit(1)
 
@@ -90,7 +90,7 @@ def install_configs():
 setup(
     name='faucet',
     setup_requires=['pbr>=1.9', 'setuptools>=17.1'],
-    python_requires='>=3.5',
+    python_requires='>=3.6',
     pbr=True
 )
 

--- a/tests/generative/fuzzer/config/generate_dict.py
+++ b/tests/generative/fuzzer/config/generate_dict.py
@@ -31,12 +31,12 @@ class ConfigDictGenerator:
             bogus_values = []
             for value in config_file.readlines():
                 # Remove quotes and \n from bogus value to get the true bogus value
-                bogus_values.append(r'%s' % value[1:2])
+                bogus_values.append(fr'{value[1:2]}')
             # Make sure to add head values into the dictionary
             for value in V2_TOP_CONFS:
                 for bogus in bogus_values:
-                    to_write = r'%s%s' % (value, bogus)
-                    rev_to_write = r'%s%s' % (bogus, value)
+                    to_write = fr'{value}{bogus}'
+                    rev_to_write = fr'{bogus}{value}'
                     if (to_write in bogus_values
                             or rev_to_write in bogus_values
                             or value in bogus_values):
@@ -47,8 +47,8 @@ class ConfigDictGenerator:
             for conf_obj in [ACL, Meter, Port, Router, DP, VLAN]:
                 for value in conf_obj.defaults:
                     for bogus in bogus_values:
-                        to_write = r'%s%s' % (value, bogus)
-                        rev_to_write = r'%s%s' % (bogus, value)
+                        to_write = fr'{value}{bogus}'
+                        rev_to_write = fr'{bogus}{value}'
                         if (to_write in bogus_values
                                 or rev_to_write in bogus_values
                                 or value in bogus_values):

--- a/tests/generative/fuzzer/config/generate_dict.py
+++ b/tests/generative/fuzzer/config/generate_dict.py
@@ -42,7 +42,7 @@ class ConfigDictGenerator:
                             or value in bogus_values):
                         continue
                     config_file.write(f'\n"{to_write}"')
-                    config_file.write(f'\n"{rev_to_write"')
+                    config_file.write(f'\n"{rev_to_write}"')
             # Find CONF objects config file options
             for conf_obj in [ACL, Meter, Port, Router, DP, VLAN]:
                 for value in conf_obj.defaults:

--- a/tests/generative/fuzzer/config/generate_dict.py
+++ b/tests/generative/fuzzer/config/generate_dict.py
@@ -41,8 +41,8 @@ class ConfigDictGenerator:
                             or rev_to_write in bogus_values
                             or value in bogus_values):
                         continue
-                    config_file.write('\n"%s"' % to_write)
-                    config_file.write('\n"%s"' % rev_to_write)
+                    config_file.write(f'\n"{to_write}"')
+                    config_file.write(f'\n"{rev_to_write"')
             # Find CONF objects config file options
             for conf_obj in [ACL, Meter, Port, Router, DP, VLAN]:
                 for value in conf_obj.defaults:
@@ -53,8 +53,8 @@ class ConfigDictGenerator:
                                 or rev_to_write in bogus_values
                                 or value in bogus_values):
                             continue
-                        config_file.write('\n"%s"' % to_write)
-                        config_file.write('\n"%s"' % rev_to_write)
+                        config_file.write(f'\n"{to_write}"')
+                        config_file.write(f'\n"{rev_to_write}"')
 
     def create_examples(self, file_base, file_name):
         """Generate some initial starting configs by generating them via the config_generator"""
@@ -107,7 +107,7 @@ class ConfigDictGenerator:
             for stack in (True, False):
                 configs.append(create_config((graph), stack=stack))
         for config in configs:
-            ex_fn = os.path.join(file_base, '%s_%s' % (file_name, ex_curr))
+            ex_fn = os.path.join(file_base, f'{file_name}_{ex_curr}')
             with open(ex_fn, 'w+', encoding='utf-8') as ex_file:
                 ex_file.write(config)
             ex_curr += 1

--- a/tests/integration/mininet_tests.py
+++ b/tests/integration/mininet_tests.py
@@ -260,7 +260,7 @@ filter_id_user_deny  Cleartext-Password := "deny_pass"
     def _priv_mac(host_id):
         two_byte_port_num = '%04x' % host_id
         two_byte_port_num_formatted = ':'.join((two_byte_port_num[:2], two_byte_port_num[2:]))
-        return '00:00:00:00:%s' % two_byte_port_num_formatted
+        return f'00:00:00:00:{two_byte_port_num_formatted}'
 
     def pre_start_net(self):
         self.eapol1_host, self.eapol2_host, self.ping_host, self.nfv_host = self.hosts_name_ordered()
@@ -313,7 +313,7 @@ filter_id_user_deny  Cleartext-Password := "deny_pass"
 
     def tearDown(self, ignore_oferrors=False):
         for pid in self.nfv_pids:
-            self.nfv_host.cmd('kill %u' % pid)
+            self.nfv_host.cmd(f'kill {pid}')
         super().tearDown(ignore_oferrors=ignore_oferrors)
 
     def post_test_checks(self):
@@ -358,8 +358,7 @@ filter_id_user_deny  Cleartext-Password := "deny_pass"
 
             for expected_event in dot1x_expected_events:
                 self.assertTrue(expected_event in events_that_happened,
-                                msg='expected event: {} not in events_that_happened {}'.format(
-                                    expected_event, events_that_happened))
+                                msg=f'expected event: {expected_event} not in events_that_happened {events_that_happened}')
 
     @staticmethod
     def _eapol_filter(fields):
@@ -369,7 +368,7 @@ filter_id_user_deny  Cleartext-Password := "deny_pass"
         eap_code = '0x04'
         if expect_success:
             eap_code = '0x03'
-        return self._eapol_filter(('ether[14:4] == 0x01000004', 'ether[18] == %s' % eap_code))
+        return self._eapol_filter(('ether[14:4] == 0x01000004', f'ether[18] == {eap_code}'))
 
     def _logoff_eapol_filter(self):
         return self._eapol_filter(('ether[14:4] == 0x01020000',))
@@ -449,9 +448,9 @@ filter_id_user_deny  Cleartext-Password := "deny_pass"
 
     def wait_8021x_flows(self, port_no):
         port_actions = [
-            'SET_FIELD: {eth_dst:%s}' % self._priv_mac(port_no), 'OUTPUT:%u' % self.nfv_portno]
+            'SET_FIELD: {eth_dst:%s}' % self._priv_mac(port_no), f'OUTPUT:{self.nfv_portno}']
         from_nfv_actions = [
-            'SET_FIELD: {eth_src:01:80:c2:00:00:03}', 'OUTPUT:%d' % port_no]
+            'SET_FIELD: {eth_src:01:80:c2:00:00:03}', f'OUTPUT:{port_no}']
         from_nfv_match = {
             'in_port': self.nfv_portno, 'dl_src': self._priv_mac(port_no), 'dl_type': 0x888e}
         self.wait_until_matching_flow(None, table_id=0, actions=port_actions)
@@ -477,7 +476,7 @@ filter_id_user_deny  Cleartext-Password := "deny_pass"
         wpa_ctrl_path = self.get_wpa_ctrl_path(host)
         if os.path.exists(wpa_ctrl_path):
             self.terminate_wpasupplicant(host)
-            for pid in host.cmd('lsof -t %s' % wpa_ctrl_path).splitlines():
+            for pid in host.cmd(f'lsof -t {wpa_ctrl_path}').splitlines():
                 try:
                     os.kill(int(pid), 15)
                 except (ValueError, ProcessLookupError):
@@ -496,7 +495,7 @@ filter_id_user_deny  Cleartext-Password := "deny_pass"
                 {'eth_src': host.MAC(), 'in_port': port_num}, table_id=0)
             self.one_ipv4_ping(
                 host, self.ping_host.IP(), require_host_learned=False)
-            host.cmd('wpa_cli -p %s logoff' % wpa_ctrl_path)
+            host.cmd(f'wpa_cli -p {wpa_ctrl_path} logoff')
             self.wait_until_no_matching_flow(
                 {'eth_src': host.MAC(), 'in_port': port_num}, table_id=0)
             self.one_ipv4_ping(
@@ -508,16 +507,16 @@ filter_id_user_deny  Cleartext-Password := "deny_pass"
 
     def terminate_wpasupplicant(self, host):
         wpa_ctrl_path = self.get_wpa_ctrl_path(host)
-        host.cmd('wpa_cli -p %s terminate' % wpa_ctrl_path)
+        host.cmd(f'wpa_cli -p {wpa_ctrl_path} terminate')
 
     def get_wpa_ctrl_path(self, host):
         wpa_ctrl_path = os.path.join(
-            self.tmpdir, '%s/%s-wpasupplicant' % (self.tmpdir, host.name))
+            self.tmpdir, f'{self.tmpdir}/{host.name}-wpasupplicant')
         return wpa_ctrl_path
 
     @staticmethod
     def get_wpa_status(host, wpa_ctrl_path):
-        status = host.cmdPrint('wpa_cli -p %s status' % wpa_ctrl_path)
+        status = host.cmdPrint(f'wpa_cli -p {wpa_ctrl_path} status')
         for line in status.splitlines():
             if line.startswith('EAP state'):
                 return line.split('=')[1].strip()
@@ -529,14 +528,14 @@ filter_id_user_deny  Cleartext-Password := "deny_pass"
             if eap_state == 'SUCCESS':
                 return
             time.sleep(1)
-        self.fail('did not get EAP success: %s' % eap_state)
+        self.fail(f'did not get EAP success: {eap_state}')
 
     def wait_for_radius(self, radius_log_path):
         self.wait_until_matching_lines_from_file(
             r'.*Ready to process requests', radius_log_path)
 
     def start_freeradius(self):
-        radius_log_path = '%s/radius.log' % self.tmpdir
+        radius_log_path = f'{self.tmpdir}/radius.log'
 
         listen_match = r'(listen {[^}]*(limit {[^}]*})[^}]*})|(listen {[^}]*})'
         listen_config = """listen {
@@ -552,10 +551,10 @@ listen {
 
         if os.path.isfile('/etc/freeradius/users'):
             # Assume we are dealing with freeradius 2 configuration
-            shutil.copytree('/etc/freeradius/', '%s/freeradius' % self.tmpdir)
-            users_path = '%s/freeradius/users' % self.tmpdir
+            shutil.copytree('/etc/freeradius/', f'{self.tmpdir}/freeradius')
+            users_path = f'{self.tmpdir}/freeradius/users'
 
-            with open('%s/freeradius/radiusd.conf' % self.tmpdir, 'r+', encoding='utf-8') as default_site:
+            with open(f'{self.tmpdir}/freeradius/radiusd.conf', 'r+', encoding='utf-8') as default_site:
                 default_config = default_site.read()
                 default_config = re.sub(listen_match, '', default_config)
                 default_site.seek(0)
@@ -567,11 +566,11 @@ listen {
             freerad_version = os.popen(
                 r'freeradius -v | egrep -o -m 1 "Version ([0-9]\.[0.9])"').read().rstrip()
             freerad_major_version = freerad_version.split(' ')[1]
-            shutil.copytree('/etc/freeradius/%s/' % freerad_major_version,
-                            '%s/freeradius' % self.tmpdir)
-            users_path = '%s/freeradius/mods-config/files/authorize' % self.tmpdir
+            shutil.copytree(f'/etc/freeradius/{freerad_major_version}/',
+                            f'{self.tmpdir}/freeradius')
+            users_path = f'{self.tmpdir}/freeradius/mods-config/files/authorize'
 
-            with open('%s/freeradius/sites-enabled/default' % self.tmpdir, 'r+', encoding='utf-8') as default_site:
+            with open(f'{self.tmpdir}/freeradius/sites-enabled/default', 'r+', encoding='utf-8') as default_site:
                 default_config = default_site.read()
                 default_config = re.sub(
                     listen_match, '', default_config)
@@ -584,13 +583,13 @@ listen {
         with open(users_path, 'w', encoding='utf-8') as users_file:
             users_file.write(self.freeradius_user_conf.format(self.SESSION_TIMEOUT))
 
-        with open('%s/freeradius/clients.conf' % self.tmpdir, 'w', encoding='utf-8') as clients:
+        with open(f'{self.tmpdir}/freeradius/clients.conf', 'w', encoding='utf-8') as clients:
             clients.write("""client localhost {
     ipaddr = 127.0.0.1
     secret = SECRET
 }""")
 
-        with open('%s/freeradius/sites-enabled/inner-tunnel' % self.tmpdir, 'r+', encoding='utf-8') as innertunnel_site:
+        with open(f'{self.tmpdir}/freeradius/sites-enabled/inner-tunnel', 'r+', encoding='utf-8') as innertunnel_site:
             tunnel_config = innertunnel_site.read()
             listen_config = """listen {
        ipaddr = 127.0.0.1
@@ -602,8 +601,8 @@ listen {
             innertunnel_site.write(tunnel_config)
             innertunnel_site.truncate()
 
-        os.system('chmod o+rx %s' % self.root_tmpdir)
-        os.system('chown -R root:freerad %s/freeradius/' % self.tmpdir)
+        os.system(f'chmod o+rx {self.root_tmpdir}')
+        os.system(f'chown -R root:freerad {self.tmpdir}/freeradius/')
 
         self.nfv_host.cmd(
             mininet_test_util.timeout_cmd(
@@ -769,16 +768,16 @@ class Faucet8021XIdentityOnPortUpTest(Faucet8021XBase):
         username_bytes = ''.join(('%2x' % ord(c) for c in username))
         tcpdump_filter = ' or '.join((
             self._success_eapol_filter(True),
-            self._eapol_filter(('ether[23:4] == 0x%s' % username_bytes,))))
+            self._eapol_filter((f'ether[23:4] == 0x{username_bytes}',))))
         tcpdump_txt = self.tcpdump_helper(
             self.eapol1_host, tcpdump_filter, [
                 lambda: port_up(port_no1)],
             timeout=30, vflags='-vvv', packets=2)
         for req_str in (
-                'Identity: %s' % username,  # supplicant replies with username
+                f'Identity: {username}',  # supplicant replies with username
                 'Success',  # supplicant success
         ):
-            self.assertTrue(req_str in tcpdump_txt, msg='%s not in %s' % (req_str, tcpdump_txt))
+            self.assertTrue(req_str in tcpdump_txt, msg=f'{req_str} not in {tcpdump_txt}')
 
         self.one_ipv4_ping(
             self.eapol1_host, self.ping_host.IP(),
@@ -1195,15 +1194,15 @@ class Faucet8021XVLANTest(Faucet8021XSuccessTest):
         self.wait_until_matching_flow(
             {'vlan_vid': radius_vid1},
             table_id=self._FLOOD_TABLE,
-            actions=['POP_VLAN', 'OUTPUT:%s' % port_no1, 'OUTPUT:%s' % port_no3])
+            actions=[f'POP_VLAN', f'OUTPUT:{port_no1}', f'OUTPUT:{port_no3}'])
         self.wait_until_matching_flow(
             {'vlan_vid': vid},
             table_id=self._FLOOD_TABLE,
-            actions=['POP_VLAN', 'OUTPUT:%s' % port_no2])
+            actions=['POP_VLAN', f'OUTPUT:{port_no2}'])
         self.wait_until_no_matching_flow(
             {'vlan_vid': radius_vid2},
             table_id=self._FLOOD_TABLE,
-            actions=['POP_VLAN', 'OUTPUT:%s' % port_no1, 'OUTPUT:%s' % port_no2])
+            actions=['POP_VLAN', f'OUTPUT:{port_no1}', f'OUTPUT:{port_no2}'])
 
         self.one_ipv4_ping(
             self.eapol1_host, self.ping_host.IP(),
@@ -1228,11 +1227,11 @@ class Faucet8021XVLANTest(Faucet8021XSuccessTest):
         self.wait_until_no_matching_flow(
             {'vlan_vid': radius_vid1},
             table_id=self._FLOOD_TABLE,
-            actions=['POP_VLAN', 'OUTPUT:%s' % port_no1, 'OUTPUT:%s' % port_no3])
+            actions=['POP_VLAN', f'OUTPUT:{port_no1}', f'OUTPUT:{port_no2}'])
         self.wait_until_matching_flow(
             {'vlan_vid': vid},
             table_id=self._FLOOD_TABLE,
-            actions=['POP_VLAN', 'OUTPUT:%s' % port_no1, 'OUTPUT:%s' % port_no2])
+            actions=['POP_VLAN', f'OUTPUT:{port_no1}', f'OUTPUT:{port_no2}'])
 
         # check two 1x hosts play nicely. (same dyn vlan)
         self.assertTrue(self.try_8021x(
@@ -1301,7 +1300,7 @@ class Faucet8021XVLANTest(Faucet8021XSuccessTest):
         self.wait_until_matching_flow(
             {'vlan_vid': vid},
             table_id=self._FLOOD_TABLE,
-            actions=['POP_VLAN', 'OUTPUT:%s' % port_no2])
+            actions=['POP_VLAN', f'OUTPUT:{port_no2}'])
         self.wait_until_no_matching_flow(
             {'in_port': port_no2},
             table_id=self._VLAN_TABLE,
@@ -1309,14 +1308,14 @@ class Faucet8021XVLANTest(Faucet8021XSuccessTest):
         self.wait_until_no_matching_flow(
             {'vlan_vid': radius_vid2},
             table_id=self._FLOOD_TABLE,
-            actions=['POP_VLAN', 'OUTPUT:%s' % port_no1, 'OUTPUT:%s' % port_no2])
+            actions=['POP_VLAN', f'OUTPUT:{port_no1}', f'OUTPUT:{port_no2}'])
         self.wait_until_no_matching_flow(
             {'eth_src': self.eapol2_host.MAC()},
             table_id=self._ETH_SRC_TABLE)
         self.wait_until_no_matching_flow(
             {'eth_dst': self.eapol2_host.MAC(), 'vlan_vid': radius_vid1},
             table_id=self._ETH_DST_TABLE,
-            actions=['POP_VLAN', 'OUTPUT:%s' % port_no2])
+            actions=['POP_VLAN', f'OUTPUT:{port_no2}'])
 
         self.post_test_checks()
 
@@ -1374,7 +1373,7 @@ class FaucetUntaggedControllerNfvTest(FaucetUntaggedTest):
         super().test_untagged()
 
         # Confirm controller can see switch interface with traffic.
-        ifconfig_output = self.net.controllers[0].cmd('ifconfig %s' % last_host_switch_intf)
+        ifconfig_output = self.net.controllers[0].cmd(f'ifconfig {last_host_switch_intf}')
         self.assertTrue(
             re.search('(R|T)X packets[: ][1-9]', ifconfig_output),
             msg=ifconfig_output)
@@ -1487,7 +1486,7 @@ class FaucetUntaggedLLDPTest(FaucetUntaggedTest):
         timeout = 5 * 3
         tcpdump_txt = self.tcpdump_helper(
             first_host, tcpdump_filter, [
-                lambda: first_host.cmd('sleep %u' % timeout)],
+                lambda: first_host.cmd(f'sleep {timeout}')],
             timeout=timeout, vflags='-vv', packets=1)
         oui_prefix = ''.join(self.FAUCET_MAC.split(':')[:3])
         faucet_lldp_dp_id_attr = '%2.2x' % 1
@@ -1538,7 +1537,7 @@ class FaucetLLDPIntervalTest(FaucetUntaggedTest):
         timeout = interval * 3
         tcpdump_txt = self.tcpdump_helper(
             first_host, tcpdump_filter, [
-                lambda: first_host.cmd('sleep %u' % timeout)],
+                lambda: first_host.cmd(f'sleep {timeout}')],
             # output epoch secs
             timeout=timeout, vflags='-tt', packets=2)
         timestamps = re.findall(r'(\d+)\.\d+ [0-9a-f:]+ \> [0-9a-f:]+', tcpdump_txt)
@@ -1567,7 +1566,7 @@ class FaucetUntaggedLLDPDefaultFallbackTest(FaucetUntaggedTest):
         timeout = 5 * 3
         tcpdump_txt = self.tcpdump_helper(
             first_host, tcpdump_filter, [
-                lambda: first_host.cmd('sleep %u' % timeout)],
+                lambda: first_host.cmd(f'sleep {timeout}')],
             timeout=timeout, vflags='-vv', packets=1)
         for lldp_required in (
                 r'%s > 01:80:c2:00:00:0e, ethertype LLDP' % self.FAUCET_MAC,
@@ -1576,7 +1575,7 @@ class FaucetUntaggedLLDPDefaultFallbackTest(FaucetUntaggedTest):
                 r'Port Description TLV \(4\), length [1-9]: b%u' % self.port_map['port_1']):
             self.assertTrue(
                 re.search(lldp_required, tcpdump_txt),
-                msg='%s: %s' % (lldp_required, tcpdump_txt))
+                msg=f'{lldp_required}: {tcpdump_txt}')
 
 
 class FaucetUntaggedMeterParseTest(FaucetUntaggedTest):
@@ -1804,12 +1803,11 @@ class FaucetUntaggedHairpinTest(FaucetUntaggedTest):
         netns = self.hostns(first_host)
         setup_cmds = []
         setup_cmds.extend(
-            ['ip link set %s netns %s' % (macvlan2_intf, netns)])
+            [f'ip link set {macvlan2_intf} netns {netns}'])
         for exec_cmd in (
-                ('ip address add %s/24 brd + dev %s' % (
-                    macvlan2_ipv4, macvlan2_intf),
-                 'ip link set %s up' % macvlan2_intf)):
-            setup_cmds.append('ip netns exec %s %s' % (netns, exec_cmd))
+                (f'ip address add {macvlan2_ipv4}/24 brd + dev {macvlan2_intf}',
+                 f'ip link set {macvlan2_intf} up')):
+            setup_cmds.append(f'ip netns exec {netns} {exec_cmd}')
         self.quiet_commands(first_host, setup_cmds)
         self.one_ipv4_ping(first_host, macvlan2_ipv4, intf=macvlan1_ipv4)
         self.one_ipv4_ping(first_host, second_host.IP())
@@ -1885,7 +1883,7 @@ class FaucetSanityTest(FaucetUntaggedTest):
         try:
             scapy.all.send(scapy.all.fuzz(scapy.all.Ether()))  # pylint: disable=no-member
         except Exception as e:  # pylint: disable=broad-except
-            error('%s:' % self._test_name(), e)
+            error(f'{self._test_name()}:', e)
             exception = True
         self.assertFalse(exception, 'Scapy threw an exception in send(fuzz())')
 
@@ -1901,41 +1899,36 @@ class FaucetSanityTest(FaucetUntaggedTest):
             port_state = port_desc['state']
             port_config = port_desc['config']
             port_speed_mbps = (port_desc['curr_speed'] * 1e3) / 1e6
-            error('DP %u is %s, at %u mbps\n' % (dp_port, port_name, port_speed_mbps))
+            error(f'DP {dp_port} is {port_name}, at {port_speed_mbps} mbps\n')
             if port_speed_mbps < min_mbps:
-                error('port speed %u below minimum %u mbps\n' % (
-                    port_speed_mbps, min_mbps))
+                error(f'port speed {port_speed_mbps} below minimum {min_mbps} mbps\n')
             elif port_config != 0:
-                error('port config %u must be 0 (all clear)' % port_config)
+                error(f'port config {port_config} must be 0 (all clear)')
             elif port_state not in (0, 4):
-                error('state %u must be 0 (all flags clear or live)\n' % (
-                    port_state))
+                error(f'state {port_state} must be 0 (all flags clear or live)\n')
             else:
                 return
             time.sleep(1)
-        self.fail('DP port %u not healthy (%s)' % (dp_port, port_desc))
+        self.fail(f'DP port {dp_port} not healthy ({port_desc})')
 
     def test_portmap(self):
         prom_desc = self.scrape_prometheus(var='of_dp_desc_stats')
         self.assertIsNotNone(prom_desc, msg='Cannot scrape of_dp_desc_stats')
-        error('DP: %s\n' % prom_desc[0])
-        error('port_map: %s\n' % self.port_map)
+        error(f'DP: {prom_desc[0]}\n')
+        error(f'port_map: {self.port_map}\n')
         for i, host in enumerate(self.hosts_name_ordered(), start=1):
-            in_port = 'port_%u' % i
+            in_port = f'port_{i}'
             dp_port = self.port_map[in_port]
             if dp_port in self.switch_map:
-                error('verifying cabling for %s: host %s -> dp %u\n' % (
-                    in_port, self.switch_map[dp_port], dp_port))
+                error(f'verifying cabling for {in_port}: host {self.switch_map[dp_port]} -> dp {dp_port}\n')
             else:
-                error('verifying host %s -> dp %s\n' % (
-                    in_port, dp_port))
+                error(f'verifying host {in_port} -> dp {dp_port}\n')
             self.verify_dp_port_healthy(dp_port)
             self.require_host_learned(host, in_port=dp_port)
         learned = self.prom_macs_learned()
         self.assertEqual(
             len(self.hosts_name_ordered()), len(learned),
-            msg='test requires exactly %u hosts learned (got %s)' % (
-                len(self.hosts_name_ordered()), learned))
+            msg=f'test requires exactly {len(self.hosts_name_ordered())} hosts learned (got {learned})')
 
     def test_listening(self):
         msg_template = (
@@ -1966,7 +1959,7 @@ class FaucetSanityTest(FaucetUntaggedTest):
             self.tcpdump_rx_packets(tcpdump_txt, 0)
             self.assertTrue(
                 self.tcpdump_rx_packets(tcpdump_txt, 0),
-                msg='got unexpected packet from test switch: %s' % tcpdump_txt)
+                msg=f'got unexpected packet from test switch: {tcpdump_txt}')
 
 
 class FaucetUntaggedPrometheusGaugeTest(FaucetUntaggedTest):
@@ -2160,7 +2153,7 @@ class FaucetUntaggedInfluxTest(FaucetUntaggedTest):
             self.server_thread.start()
             return None
         except socket.error as err:
-            return 'cannot start Influx test server: %s' % err
+            return f'cannot start Influx test server: {err}'
 
     def test_untagged(self):
         self.ping_all_when_learned()
@@ -2734,8 +2727,8 @@ vlans:
         first_host, second_host = self.hosts_name_ordered()[:2]
         self.ping_all_when_learned()
         for i in range(10, 10 + (self.MAX_HOSTS * 2)):
-            mac_intf = 'mac%u' % i
-            mac_ipv4 = '10.0.0.%u' % i
+            mac_intf = f'mac{i}'
+            mac_ipv4 = f'10.0.0.{i}'
             self.add_macvlan(second_host, mac_intf, ipa=mac_ipv4)
             ping_cmd = mininet_test_util.timeout_cmd(
                 'fping %s -c1 -t1 -I%s %s > /dev/null 2> /dev/null' % (
@@ -2794,15 +2787,15 @@ vlans:
             self.TIMEOUT / 2)
         for _ in range(3):
             fping_out = first_host.cmd(fping_cmd)
-            self.assertTrue(fping_out, msg='fping did not complete: %s' % fping_cmd)
+            self.assertTrue(fping_out, msg=f'fping did not complete: {fping_cmd}')
             macs_learned = self.hosts_learned(hosts)
             if len(macs_learned) == len(hosts):
                 return
             time.sleep(1)
         first_host_diag = first_host.cmd('ifconfig -a ; arp -an')
         second_host_diag = second_host.cmd('ifconfig -a ; arp -an')
-        self.fail('%s cannot be learned (%s != %s)\nfirst host %s\nsecond host %s\n' % (
-            mac_ips, macs_learned, fping_out, first_host_diag, second_host_diag))
+        self.fail(f'{mac_ips} cannot be learned ({macs_learned} != {fping_out})\n' \
+            f'first host {first_host_diag}\nsecond host {second_host_diag}\n')
 
     def test_untagged(self):
         first_host, second_host = self.hosts_name_ordered()[:2]
@@ -2815,9 +2808,9 @@ vlans:
                 mac_ips = []
                 learned_mac_ports = {}
                 for i in range(base, base + count):
-                    mac_intf = 'mac%u' % i
+                    mac_intf = f'mac{i}'
                     mac_intfs.append(mac_intf)
-                    mac_ipv4 = '10.0.0.%u' % i
+                    mac_ipv4 = f'10.0.0.{i}'
                     self.add_macvlan(second_host, mac_intf, ipa=mac_ipv4)
                     macvlan_mac = self.get_mac_of_intf(mac_intf, second_host)
                     learned_mac_ports[macvlan_mac] = self.port_map['port_2']
@@ -2826,7 +2819,7 @@ vlans:
 
             def down_macvlans(macvlans):
                 for macvlan in macvlans:
-                    second_host.cmd('ip link set dev %s down' % macvlan)
+                    second_host.cmd(f'ip link set dev {macvlan} down')
 
             def learn_then_down_hosts(base, count):
                 mac_intfs, mac_ips, learned_mac_ports = add_macvlans(base, count)
@@ -2851,7 +2844,7 @@ vlans:
                 break
             time.sleep(1)
 
-        self.assertFalse(learned_macs, msg='MACs did not expire: %s' % learned_macs)
+        self.assertFalse(learned_macs, msg=f'MACs did not expire: {learned_macs}')
 
         self.assertTrue(before_expiry_learned_macs)
         for mac in before_expiry_learned_macs:
@@ -2916,7 +2909,7 @@ vlans:
 
     def test_untagged(self):
         test_net = ipaddress.IPv4Network(
-            '%s/%s' % (self.TEST_IPV4_NET, self.TEST_IPV4_PREFIX))
+            f'{self.TEST_IPV4_NET}/{self.TEST_IPV4_PREFIX}')
         learn_ip = ipaddress.IPv4Address(self.LEARN_IPV4)
         self.verify_learning(test_net, learn_ip, 64, self.MAX_HOSTS)
 
@@ -2962,7 +2955,7 @@ vlans:
 
     def test_untagged(self):
         test_net = ipaddress.IPv4Network(
-            '%s/%s' % (self.TEST_IPV4_NET, self.TEST_IPV4_PREFIX))
+            f'{self.TEST_IPV4_NET}/{self.TEST_IPV4_PREFIX}')
         learn_ip = ipaddress.IPv4Address(self.LEARN_IPV4)
         self.verify_learning(test_net, learn_ip, 64, self.MAX_HOSTS)
 
@@ -2983,7 +2976,7 @@ class FaucetUntaggedHUPTest(FaucetUntaggedTest):
             time.sleep(1)
         self.assertEqual(
             counts, expected,
-            'Controller configure counts %s != expected counts %s' % (counts, expected))
+            f'Controller configure counts {counts} != expected counts {expected}')
 
     def test_untagged(self):
         """Test that FAUCET receives HUP signal and keeps switching."""
@@ -3057,7 +3050,7 @@ acls:
         super().setUp()
         self.acl_config_file = os.path.join(self.tmpdir, 'acl.txt')
         self.CONFIG = '\n'.join(
-            (self.CONFIG, 'include:\n     - %s' % self.acl_config_file))
+            (self.CONFIG, f'include:\n     - {self.acl_config_file}'))
         with open(self.acl_config_file, 'w', encoding='utf-8') as acf:
             acf.write(self.START_ACL_CONFIG)
         self.topo = self.topo_class(
@@ -3080,18 +3073,18 @@ acls:
                     'ip_proto': 6,
                     'tcp_src': port,
                     'tcp_dst': port,
-                    'ipv%u_src' % host_ip.version: ip_match,
-                    'ipv%u_dst' % host_ip.version: ip_match,
+                    f'ipv{host_ip.version}_src': ip_match,
+                    f'ipv{host_ip.version}_dst': ip_match,
                     'actions': {'allow': 1},
                 }
                 rules_yaml.append({'rule': rule_yaml})
             yaml_acl_conf = {'acls': {1: {'exact_match': True, 'rules': rules_yaml}}}
-            tuple_txt = '%u IPv%u tuples\n' % (len(rules_yaml), host_ip.version)
-            error('pushing %s' % tuple_txt)
+            tuple_txt = f'{len(rules_yaml)} IPv{host_ip.version} tuples\n'
+            error(f'pushing {tuple_txt}')
             self.reload_conf(
                 yaml_acl_conf, self.acl_config_file,  # pytype: disable=attribute-error
                 restart=True, cold_start=False)
-            error('pushed %s' % tuple_txt)
+            error(f'pushed {tuple_txt}')
             self.wait_until_matching_flow(
                 {'tp_src': port, 'ip_proto': 6, 'dl_type': eth_type}, table_id=0)
             rules *= 2
@@ -3243,11 +3236,11 @@ acls:
         super().setUp()
         self.ACL_COOKIE = random.randint(1, 2**16 - 1)
         self.ACL = self.ACL.replace('COOKIE', str(self.ACL_COOKIE))
-        self.acl_config_file = '%s/acl.yaml' % self.tmpdir
+        self.acl_config_file = f'{self.tmpdir}/acl.yaml'
         with open(self.acl_config_file, 'w', encoding='utf-8') as config_file:
             config_file.write(self.ACL)
         self.CONFIG = '\n'.join(
-            (self.CONFIG, 'include:\n     - %s' % self.acl_config_file))
+            (self.CONFIG, f'include:\n     - {self.acl_config_file}'))
         self.topo = self.topo_class(
             self.OVS_TYPE, self.ports_sock, self._test_name(), [self.dpid],
             n_tagged=self.N_TAGGED, n_untagged=self.N_UNTAGGED,
@@ -3335,7 +3328,7 @@ class FaucetConfigReloadTest(FaucetConfigReloadTestBase):
             restart=False, cold_start=False)
         self.wait_until_matching_flow(
             {'vlan_vid': 200}, table_id=self._ETH_SRC_TABLE,
-            actions=['OUTPUT:CONTROLLER', 'GOTO_TABLE:%u' % self._ETH_DST_TABLE])
+            actions=['OUTPUT:CONTROLLER', f'GOTO_TABLE:{self._ETH_DST_TABLE}'])
         self.change_port_config(
             self.port_map['port_2'], 'native_vlan', 200,
             restart=True, cold_start=False)
@@ -3362,7 +3355,7 @@ class FaucetConfigReloadTest(FaucetConfigReloadTestBase):
             table_id=self._PORT_ACL_TABLE, cookie=self.ACL_COOKIE)
         self.wait_until_matching_flow(
             {'vlan_vid': 100}, table_id=self._ETH_SRC_TABLE,
-            actions=['OUTPUT:CONTROLLER', 'GOTO_TABLE:%u' % self._ETH_DST_TABLE])
+            actions=['OUTPUT:CONTROLLER', f'GOTO_TABLE:{self._ETH_DST_TABLE}'])
         self.verify_tp_dst_blocked(5001, first_host, second_host)
         self.verify_tp_dst_notblocked(5002, first_host, second_host)
         self.reload_conf(
@@ -3479,7 +3472,7 @@ class FaucetConfigReloadMACFlushTest(FaucetConfigReloadTestBase):
             restart=False, cold_start=False)
         self.wait_until_matching_flow(
             {'vlan_vid': 200}, table_id=self._ETH_SRC_TABLE,
-            actions=['OUTPUT:CONTROLLER', 'GOTO_TABLE:%u' % self._ETH_DST_TABLE])
+            actions=['OUTPUT:CONTROLLER', f'GOTO_TABLE:{self._ETH_DST_TABLE}'])
         self.change_port_config(
             self.port_map['port_2'], 'native_vlan', 200,
             restart=True, cold_start=False)
@@ -3824,7 +3817,7 @@ routers:
             if not self.get_matching_flow(match, table_id=table):
                 return
             time.sleep(1)
-        self.fail('host route %s still present' % match)
+        self.fail(f'host route {match} still present')
 
 
 class FaucetUntaggedRestBcastIPv4RouteTest(FaucetUntaggedIPv4RouteTest):
@@ -4013,8 +4006,8 @@ class FaucetCoprocessorTest(FaucetUntaggedTest):
         coprocessor_host, first_host, second_host, _ = self.hosts_name_ordered()
         self.one_ipv4_ping(first_host, second_host.IP())
         tcpdump_filter = ' and '.join((
-            'ether dst %s' % first_host.MAC(),
-            'ether src %s' % coprocessor_host.MAC(),
+            f'ether dst {first_host.MAC()}',
+            f'ether src {coprocessor_host.MAC()}',
             'icmp'))
         cmds = [
             lambda: coprocessor_host.cmd(
@@ -4065,7 +4058,7 @@ vlans:
     def total_port_bans(self):
         total_bans = 0
         for i in range(self.LINKS_PER_HOST * self.N_UNTAGGED):
-            port_labels = self.port_labels(self.port_map['port_%u' % (i + 1)])
+            port_labels = self.port_labels(self.port_map[f'port_{i + 1}'])
             total_bans += self.scrape_prometheus_var(
                 'port_learn_bans', port_labels, dpid=True, default=0)
         return total_bans
@@ -4091,13 +4084,13 @@ vlans:
             'brctl setfd br-loop1 0',
             'ip link set br-loop1 up',
             'brctl addif br-loop1 veth-loop1',
-            'brctl addif br-loop1 %s-eth0' % second_host.name,
+            f'brctl addif br-loop1 {second_host.name}-eth0',
             # Connect other leg of veth pair.
             'brctl addbr br-loop2',
             'brctl setfd br-loop2 0',
             'ip link set br-loop2 up',
             'brctl addif br-loop2 veth-loop2',
-            'brctl addif br-loop2 %s-eth1' % second_host.name))
+            f'brctl addif br-loop2 {second_host.name}-eth1'))
 
         # Flood some traffic into the loop
         for _ in range(3):
@@ -4245,14 +4238,14 @@ details partner lacp pdu:
     port priority: 2
     port number: %d
     port state: 62
-""".strip() % tuple(get_lacp_port_id(self.port_map['port_%u' % i]) for i in lag_ports)
+""".strip() % tuple(get_lacp_port_id(self.port_map[f'port_{i}']) for i in lag_ports)
 
         lacp_timeout = 5
 
         def prom_lacp_up_ports():
             lacp_up_ports = 0
             for lacp_port in lag_ports:
-                port_labels = self.port_labels(self.port_map['port_%u' % lacp_port])
+                port_labels = self.port_labels(self.port_map[f'port_{lacp_port}'])
                 lacp_state = self.scrape_prometheus_var('port_lacp_state', port_labels, default=0)
                 lacp_up_ports += 1 if lacp_state == 3 else 0
             return lacp_up_ports
@@ -4275,12 +4268,11 @@ details partner lacp pdu:
                 time.sleep(1)
             self.assertTrue(
                 re.search(synced_state_txt, result),
-                msg='LACP did not synchronize: %s\n\nexpected:\n\n%s' % (
-                    result, synced_state_txt))
+                msg=f'LACP did not synchronize: {result}\n\nexpected:\n\n{synced_state_txt}')
 
         # Start with ports down.
         for port in lag_ports:
-            self.set_port_down(self.port_map['port_%u' % port])
+            self.set_port_down(self.port_map[f'port_{port}'])
         require_lag_up_ports(0)
         orig_ip = first_host.IP()
         switch = self.first_switch()
@@ -4288,45 +4280,45 @@ details partner lacp pdu:
         # Deconfigure bond members
         for bond_member in bond_members:
             self.quiet_commands(first_host, (
-                'ip link set %s down' % bond_member,
-                'ip address flush dev %s' % bond_member))
+                f'ip link set {bond_member} down',
+                f'ip address flush dev {bond_member}'))
         # Configure bond interface
         self.quiet_commands(first_host, (
-            ('ip link add %s address 0e:00:00:00:00:99 '
-             'type bond mode 802.3ad lacp_rate fast miimon 100') % bond,
-            'ip add add %s/24 dev %s' % (orig_ip, bond),
-            'ip link set %s up' % bond))
+            f'ip link add {bond} address 0e:00:00:00:00:99 ' \
+            f'type bond mode 802.3ad lacp_rate fast miimon 100',
+            f'ip add add {orig_ip}/24 dev {bond}',
+            f'ip link set {bond} up'))
         # Add bond members
         for bond_member in bond_members:
             self.quiet_commands(first_host, (
-                'ip link set dev %s master %s' % (bond_member, bond),))
+                f'ip link set dev {bond_member} master {bond}',))
 
         for _flaps in range(2):
             # All ports down.
             for port in lag_ports:
-                self.set_port_down(self.port_map['port_%u' % port])
+                self.set_port_down(self.port_map[f'port_{port}'])
             require_lag_up_ports(0)
             # Pick a random port to come up.
             up_port = random.choice(lag_ports)
-            self.set_port_up(self.port_map['port_%u' % up_port])
+            self.set_port_up(self.port_map[f'port_{up_port}'])
             require_lag_up_ports(1)
             # We have connectivity with only one port.
             self.one_ipv4_ping(
                 first_host, self.FAUCET_VIPV4.ip, require_host_learned=False, intf=bond, retries=5)
             for port in lag_ports:
-                self.set_port_up(self.port_map['port_%u' % port])
+                self.set_port_up(self.port_map[f'port_{port}'])
             # We have connectivity with two ports.
             require_lag_up_ports(2)
             require_linux_bond_up()
             self.one_ipv4_ping(
                 first_host, self.FAUCET_VIPV4.ip, require_host_learned=False, intf=bond, retries=5)
             # We have connectivity if that random port goes down.
-            self.set_port_down(self.port_map['port_%u' % up_port])
+            self.set_port_down(self.port_map[f'port_{up_port}'])
             require_lag_up_ports(1)
             self.one_ipv4_ping(
                 first_host, self.FAUCET_VIPV4.ip, require_host_learned=False, intf=bond, retries=5)
             for port in lag_ports:
-                self.set_port_up(self.port_map['port_%u' % port])
+                self.set_port_up(self.port_map[f'port_{port}'])
 
 
 class FaucetUntaggedIPv4LACPMismatchTest(FaucetUntaggedIPv4LACPTest):
@@ -4338,15 +4330,15 @@ class FaucetUntaggedIPv4LACPMismatchTest(FaucetUntaggedIPv4LACPTest):
         switch = self.first_switch()
         bond_members = [pair[0].name for pair in first_host.connectionsTo(switch)]
         for i, bond_member in enumerate(bond_members):
-            bond = 'bond%u' % i
+            bond = f'bond{i}'
             self.quiet_commands(first_host, (
-                'ip link set %s down' % bond_member,
-                'ip address flush dev %s' % bond_member,
+                f'ip link set {bond_member} down',
+                f'ip address flush dev {bond_member}',
                 ('ip link add %s address 0e:00:00:00:00:%2.2x '
                  'type bond mode 802.3ad lacp_rate fast miimon 100') % (bond, i * 2 + i),
-                'ip add add %s/24 dev %s' % (orig_ip, bond),
-                'ip link set %s up' % bond,
-                'ip link set dev %s master %s' % (bond_member, bond)))
+                f'ip add add {orig_ip}/24 dev {bond}',
+                f'ip link set {bond} up',
+                f'ip link set dev {bond_member} master {bond}'))
         self.wait_until_matching_lines_from_faucet_log_files(r'.+actor system mismatch.+')
 
 
@@ -4379,8 +4371,7 @@ vlans:
                 fuzz_template % ('fuzz(%s(pdst=\'%s\'))' % ('ARP', self.FAUCET_VIPV4.ip), packets)):
             fuzz_out = first_host.cmd(mininet_test_util.timeout_cmd(fuzz_cmd, 180))
             self.assertTrue(
-                re.search('Sent %u packets' % packets, fuzz_out), msg='%s: %s' % (
-                    fuzz_cmd, fuzz_out))
+                re.search(f'Sent {packets} packets', fuzz_out), msg=f'{fuzz_cmd}: {fuzz_out}')
         self.one_ipv4_controller_ping(first_host)
 
     def test_flap_ping_controller(self):
@@ -4435,12 +4426,12 @@ vlans:
         for vip in ('fe80::1:254', 'fc00::1:254', 'fc00::2:254'):
             self.assertEqual(
                 self.FAUCET_MAC.upper(),
-                first_host.cmd('ndisc6 -q %s %s' % (vip, first_host.defaultIntf())).strip())
+                first_host.cmd(f'ndisc6 -q {vip} {first_host.defaultIntf()}').strip())
 
     def test_rdisc6(self):
         first_host = self.hosts_name_ordered()[0]
         rdisc6_results = sorted(list(set(first_host.cmd(
-            'rdisc6 -q %s' % first_host.defaultIntf()).splitlines())))
+            f'rdisc6 -q {first_host.defaultIntf()}').splitlines())))
         self.assertEqual(
             ['fc00::1:0/112', 'fc00::2:0/112'],
             rdisc6_results)
@@ -4449,7 +4440,7 @@ vlans:
         first_host = self.hosts_name_ordered()[0]
         tcpdump_filter = ' and '.join((
             'ether dst 33:33:00:00:00:01',
-            'ether src %s' % self.FAUCET_MAC,
+            f'ether src {self.FAUCET_MAC}',
             'icmp6',
             'ip6[40] == 134',
             'ip6 host fe80::1:254'))
@@ -4463,20 +4454,20 @@ vlans:
                 r'source link-address option \(1\), length 8 \(1\): %s' % self.FAUCET_MAC):
             self.assertTrue(
                 re.search(ra_required, tcpdump_txt),
-                msg='%s: %s' % (ra_required, tcpdump_txt))
+                msg=f'{ra_required}: {tcpdump_txt}')
 
     def test_rs_reply(self):
         first_host = self.hosts_name_ordered()[0]
         tcpdump_filter = ' and '.join((
-            'ether src %s' % self.FAUCET_MAC,
-            'ether dst %s' % first_host.MAC(),
+            f'ether src {self.FAUCET_MAC}',
+            f'ether dst {first_host.MAC()}',
             'icmp6',
             'ip6[40] == 134',
             'ip6 host fe80::1:254'))
         tcpdump_txt = self.tcpdump_helper(
             first_host, tcpdump_filter, [
                 lambda: first_host.cmd(
-                    'rdisc6 -1 %s' % first_host.defaultIntf())],
+                    f'rdisc6 -1 {first_host.defaultIntf()}')],
             timeout=30, vflags='-vv', packets=1)
         for ra_required in (
                 r'fe80::1:254 > fe80::.+ICMP6, router advertisement',
@@ -4485,7 +4476,7 @@ vlans:
                 r'source link-address option \(1\), length 8 \(1\): %s' % self.FAUCET_MAC):
             self.assertTrue(
                 re.search(ra_required, tcpdump_txt),
-                msg='%s: %s (%s)' % (ra_required, tcpdump_txt, tcpdump_filter))
+                msg=f'{ra_required}: {tcpdump_txt} ({tcpdump_filter})')
 
 
 class FaucetUntaggedIPv6ControlPlaneFuzzTest(FaucetUntaggedTest):
@@ -4521,7 +4512,7 @@ vlans:
         abort = False
 
         def note(*args):
-            error('%s:' % self._test_name(), *args + tuple('\n'))
+            error(f'{self._test_name()}:', *args + tuple('\n'))
 
         # Some of these tests have been slowing down and timing out,
         # So this code is intended to allow some debugging and analysis
@@ -4541,7 +4532,7 @@ vlans:
                         abort = True
                         break
                 popen.wait()
-                if 'Sent %u packets' % packets in out:
+                if f'Sent {packets} packets' in out:
                     count += packets
                     elapsed = time.time() - start
                     note('sent', packets, fuzz_class, 'packets in %.2fs' % elapsed)
@@ -5101,19 +5092,19 @@ acls:
             second_host, tcpdump_filter, [
                 lambda: first_host.cmd(' '.join((self.FPINGS_ARGS_ONE, second_host.IP())))])
         self.assertTrue(re.search(
-            '%s: ICMP echo request' % second_host.IP(), tcpdump_txt))
+            f'{second_host.IP()}: ICMP echo request', tcpdump_txt))
         tcpdump_txt = self.tcpdump_helper(
             third_host, tcpdump_filter, [
                 lambda: first_host.cmd(
-                    'arp -s %s %s' % (third_host.IP(), '01:02:03:04:05:06')),
+                    f'arp -s {third_host.IP()} 01:02:03:04:05:06'),
                 lambda: first_host.cmd(' '.join((self.FPINGS_ARGS_ONE, third_host.IP())))])
         self.assertTrue(re.search(
-            '%s: ICMP echo request' % third_host.IP(), tcpdump_txt))
+            f'{third_host.IP()}: ICMP echo request', tcpdump_txt))
         tcpdump_txt = self.tcpdump_helper(
             fourth_host, tcpdump_filter, [
                 lambda: first_host.cmd(' '.join((self.FPINGS_ARGS_ONE, fourth_host.IP())))])
         self.assertFalse(re.search(
-            '%s: ICMP echo request' % fourth_host.IP(), tcpdump_txt))
+            f'{fourth_host.IP()}: ICMP echo request', tcpdump_txt))
 
 
 class FaucetMultiOrderedOutputTest(FaucetUntaggedTest):
@@ -5150,19 +5141,19 @@ acls:
             second_host, tcpdump_filter, [
                 lambda: first_host.cmd(' '.join((self.FPINGS_ARGS_ONE, second_host.IP())))])
         self.assertTrue(re.search(
-            '%s: ICMP echo request' % second_host.IP(), tcpdump_txt))
+            f'{second_host.IP()}: ICMP echo request', tcpdump_txt))
         tcpdump_txt = self.tcpdump_helper(
             third_host, tcpdump_filter, [
                 lambda: first_host.cmd(
-                    'arp -s %s %s' % (third_host.IP(), '01:02:03:04:05:06')),
+                    f'arp -s {third_host.IP()} 01:02:03:04:05:06'),
                 lambda: first_host.cmd(' '.join((self.FPINGS_ARGS_ONE, third_host.IP())))])
         self.assertTrue(re.search(
-            '%s: ICMP echo request' % third_host.IP(), tcpdump_txt))
+            f'{third_host.IP()}: ICMP echo request', tcpdump_txt))
         tcpdump_txt = self.tcpdump_helper(
             fourth_host, tcpdump_filter, [
                 lambda: first_host.cmd(' '.join((self.FPINGS_ARGS_ONE, fourth_host.IP())))])
         self.assertFalse(re.search(
-            '%s: ICMP echo request' % fourth_host.IP(), tcpdump_txt))
+            f'{fourth_host.IP()}: ICMP echo request', tcpdump_txt))
 
 
 class FaucetUntaggedOutputTest(FaucetUntaggedTest):
@@ -5204,10 +5195,10 @@ acls:
         tcpdump_txt = self.tcpdump_helper(
             second_host, tcpdump_filter, [
                 lambda: first_host.cmd(
-                    'arp -s %s %s' % (second_host.IP(), '01:02:03:04:05:06')),
+                    f'arp -s {second_host.IP()} 01:02:03:04:05:06'),
                 lambda: first_host.cmd(' '.join((self.FPINGS_ARGS_ONE, second_host.IP())))])
         self.assertTrue(re.search(
-            '%s: ICMP echo request' % second_host.IP(), tcpdump_txt))
+            f'{second_host.IP()}: ICMP echo request', tcpdump_txt))
         self.assertTrue(re.search(
             'vlan 123', tcpdump_txt))
 
@@ -5251,10 +5242,10 @@ acls:
         tcpdump_txt = self.tcpdump_helper(
             second_host, tcpdump_filter, [
                 lambda: first_host.cmd(
-                    'arp -s %s %s' % (second_host.IP(), '01:02:03:04:05:06')),
+                    f'arp -s {second_host.IP()} 01:02:03:04:05:06'),
                 lambda: first_host.cmd(' '.join((self.FPINGS_ARGS_ONE, second_host.IP())))])
         self.assertTrue(re.search(
-            '%s: ICMP echo request' % second_host.IP(), tcpdump_txt))
+            f'{second_host.IP()}: ICMP echo request', tcpdump_txt))
         self.assertTrue(re.search(
             'vlan 123', tcpdump_txt))
 
@@ -5298,10 +5289,10 @@ acls:
         tcpdump_txt = self.tcpdump_helper(
             second_host, tcpdump_filter, [
                 lambda: first_host.cmd(
-                    'arp -s %s %s' % (second_host.IP(), '01:02:03:04:05:06')),
+                    f'arp -s {second_host.IP()} 01:02:03:04:05:06'),
                 lambda: first_host.cmd(' '.join((self.FPINGS_ARGS_ONE, second_host.IP())))])
         self.assertTrue(re.search(
-            '%s: ICMP echo request' % second_host.IP(), tcpdump_txt))
+            f'{second_host.IP()}: ICMP echo request', tcpdump_txt))
         self.assertTrue(re.search(
             'vlan 456.+vlan 123', tcpdump_txt))
 
@@ -5345,10 +5336,10 @@ acls:
         tcpdump_txt = self.tcpdump_helper(
             second_host, tcpdump_filter, [
                 lambda: first_host.cmd(
-                    'arp -s %s %s' % (second_host.IP(), '01:02:03:04:05:06')),
+                    f'arp -s {second_host.IP()} 01:02:03:04:05:06'),
                 lambda: first_host.cmd(' '.join((self.FPINGS_ARGS_ONE, second_host.IP())))])
         self.assertTrue(re.search(
-            '%s: ICMP echo request' % second_host.IP(), tcpdump_txt))
+            f'{second_host.IP()}: ICMP echo request', tcpdump_txt))
         self.assertTrue(re.search(
             'vlan 456.+vlan 123', tcpdump_txt))
 
@@ -5392,11 +5383,11 @@ acls:
         tcpdump_txt = self.tcpdump_helper(
             second_host, tcpdump_filter, [
                 lambda: first_host.cmd(
-                    'arp -s %s %s' % (second_host.IP(), '01:02:03:04:05:06')),
+                    f'arp -s {second_host.IP()} 01:02:03:04:05:06'),
                 lambda: first_host.cmd(' '.join((self.FPINGS_ARGS_ONE, second_host.IP())))],
             packets=1)
         self.assertTrue(re.search(
-            '%s: ICMP echo request' % second_host.IP(), tcpdump_txt), msg=tcpdump_txt)
+            f'{second_host.IP()}: ICMP echo request', tcpdump_txt), msg=tcpdump_txt)
         self.assertTrue(re.search(
             'vlan 456.+ethertype 802.1Q-QinQ, vlan 123', tcpdump_txt), msg=tcpdump_txt)
 
@@ -5440,11 +5431,11 @@ acls:
         tcpdump_txt = self.tcpdump_helper(
             second_host, tcpdump_filter, [
                 lambda: first_host.cmd(
-                    'arp -s %s %s' % (second_host.IP(), '01:02:03:04:05:06')),
+                    f'arp -s {second_host.IP()} 01:02:03:04:05:06'),
                 lambda: first_host.cmd(' '.join((self.FPINGS_ARGS_ONE, second_host.IP())))],
             packets=1)
         self.assertTrue(re.search(
-            '%s: ICMP echo request' % second_host.IP(), tcpdump_txt), msg=tcpdump_txt)
+            f'{second_host.IP()}: ICMP echo request', tcpdump_txt), msg=tcpdump_txt)
         self.assertTrue(re.search(
             'vlan 456.+ethertype 802.1Q-QinQ, vlan 123', tcpdump_txt), msg=tcpdump_txt)
 
@@ -5642,7 +5633,7 @@ vlans:
             self.wait_until_matching_flow(
                 {'vlan_vid': 100, 'in_port': port},
                 table_id=self._VLAN_TABLE,
-                actions=['GOTO_TABLE:%u' % self._ETH_SRC_TABLE])
+                actions=[f'GOTO_TABLE:{self._ETH_SRC_TABLE}'])
         self.change_port_config(
             self.port_map['port_3'], 'mirror', None,
             restart=True, cold_start=False)
@@ -5650,7 +5641,7 @@ vlans:
             self.wait_until_matching_flow(
                 {'vlan_vid': 100, 'in_port': port},
                 table_id=self._VLAN_TABLE,
-                actions=['GOTO_TABLE:%u' % self._ETH_SRC_TABLE])
+                actions=[f'GOTO_TABLE:{self._ETH_SRC_TABLE}'])
 
 
 class FaucetTaggedVLANPCPTest(FaucetTaggedTest):
@@ -5690,16 +5681,16 @@ acls:
         first_host, second_host = self.hosts_name_ordered()[:2]
         self.quiet_commands(
             first_host,
-            ['ip link set %s type vlan egress %u:1' % (
-                first_host.defaultIntf(), i) for i in range(0, 8)])
+            [f'ip link set {first_host.defaultIntf()} type vlan egress {i}:1'
+                for i in range(0, 8)])
         self.one_ipv4_ping(first_host, second_host.IP())
         self.wait_nonzero_packet_count_flow(
             {'vlan_vid': 100, 'vlan_pcp': 1}, table_id=self._PORT_ACL_TABLE)
-        tcpdump_filter = 'ether dst %s' % second_host.MAC()
+        tcpdump_filter = f'ether dst {second_host.MAC()}'
         tcpdump_txt = self.tcpdump_helper(
             second_host, tcpdump_filter, [
                 lambda: first_host.cmd(
-                    'ping -c3 %s' % second_host.IP())], root_intf=True, packets=1)
+                    f'ping -c3 {second_host.IP()}')], root_intf=True, packets=1)
         self.assertTrue(re.search('vlan 100, p 2,', tcpdump_txt))
 
 
@@ -5740,16 +5731,16 @@ acls:
         first_host, second_host = self.hosts_name_ordered()[:2]
         self.quiet_commands(
             first_host,
-            ['ip link set %s type vlan egress %u:1' % (
-                first_host.defaultIntf(), i) for i in range(0, 8)])
+            [f'ip link set {first_host.defaultIntf()} type vlan egress {i}:1'
+                for i in range(0, 8)])
         self.one_ipv4_ping(first_host, second_host.IP())
         self.wait_nonzero_packet_count_flow(
             {'vlan_vid': 100, 'vlan_pcp': 1}, table_id=self._PORT_ACL_TABLE)
-        tcpdump_filter = 'ether dst %s' % second_host.MAC()
+        tcpdump_filter = f'ether dst {second_host.MAC()}'
         tcpdump_txt = self.tcpdump_helper(
             second_host, tcpdump_filter, [
                 lambda: first_host.cmd(
-                    'ping -c3 %s' % second_host.IP())], root_intf=True, packets=1)
+                    f'ping -c3 {second_host.IP()}')], root_intf=True, packets=1)
         self.assertTrue(re.search('vlan 100, p 2,', tcpdump_txt))
 
 
@@ -5772,7 +5763,7 @@ class FaucetTaggedGlobalIPv4RouteTest(FaucetTaggedTest):
 
     @staticmethod
     def netbase(vid, host):
-        return ipaddress.ip_interface('192.168.%u.%u' % (vid, host))
+        return ipaddress.ip_interface(f'192.168.{vid}.{host}')
 
     def fping(self, macvlan_int, ipg):
         return 'fping %s -c1 -t1 -I%s %s > /dev/null 2> /dev/null' % (
@@ -5785,7 +5776,7 @@ class FaucetTaggedGlobalIPv4RouteTest(FaucetTaggedTest):
         return self.one_ipv4_ping(host, ipa, intf=macvlan_int)
 
     def run_ip(self, args):
-        return 'ip -%u %s' % (self.IPV, args)
+        return f'ip -{self.IPV} {args}'
 
     CONFIG_GLOBAL = """
 routers:
@@ -5833,31 +5824,30 @@ vlans:
         for i, host in enumerate(hosts, start=1):
             setup_commands = []
             for vid in self.NEW_VIDS:
-                vlan_int = '%s.%u' % (host.intf_root_name, vid)
-                macvlan_int = 'macvlan%u' % vid
+                vlan_int = f'{host.intf_root_name}.{vid}'
+                macvlan_int = f'macvlan{vid}'
                 ipa = self.netbase(vid, i)
                 ipg = self.netbase(vid, 254)
                 ipd = self.netbase(vid, 253)
                 required_ipds.add(str(ipd.ip))
                 ipd_to_macvlan[str(ipd.ip)] = (macvlan_int, host)
                 setup_commands.extend([
-                    self.run_ip('link add link %s name %s type vlan id %u' % (
-                        host.intf_root_name, vlan_int, vid)),
-                    self.run_ip('link set dev %s up' % vlan_int),
-                    self.run_ip('link add %s link %s type macvlan mode vepa' % (macvlan_int, vlan_int)),
-                    self.run_ip('link set dev %s up' % macvlan_int),
-                    self.run_ip('address add %s/%u dev %s' % (ipa.ip, self.NETPREFIX, macvlan_int)),
-                    self.run_ip('route add default via %s table %u' % (ipg.ip, vid)),
-                    self.run_ip('rule add from %s table %u priority 100' % (ipa, vid)),
+                    self.run_ip(f'link add link {host.intf_root_name} name {vlan_int} type vlan id {vid}'),
+                    self.run_ip(f'link set dev {vlan_int} up'),
+                    self.run_ip(f'link add {macvlan_int} link {vlan_int} type macvlan mode vepa'),
+                    self.run_ip(f'link set dev {macvlan_int} up'),
+                    self.run_ip(f'address add {ipa.ip}/{self.NETPREFIX} dev {macvlan_int}'),
+                    self.run_ip(f'route add default via {ipg.ip} table {vid}'),
+                    self.run_ip(f'rule add from {ipa} table {vid} priority 100'),
                     # stimulate learning attempts for down host.
-                    self.run_ip('neigh add %s lladdr %s dev %s' % (ipd.ip, self.FAUCET_MAC, macvlan_int))])
+                    self.run_ip(f'neigh add {ipd.ip} lladdr {self.FAUCET_MAC} dev {macvlan_int}')])
                 # next host routes via FAUCET for other host in same connected subnet
                 # to cause routing to be exercised.
                 for j, _ in enumerate(hosts, start=1):
                     if j != i:
                         other_ip = self.netbase(vid, j)
                         setup_commands.append(
-                            self.run_ip('route add %s via %s table %u' % (other_ip, ipg.ip, vid)))
+                            self.run_ip(f'route add {other_ip} via {ipg.ip} table {vid}'))
                 for ipa in (ipg.ip, ipd.ip):
                     setup_commands.append(self.fping(macvlan_int, ipa))
 
@@ -5884,7 +5874,7 @@ vlans:
                 macvlan_int, host = ipd_to_macvlan[ipd]
                 host.cmd(self.fping(macvlan_int, ipd))
             time.sleep(1)
-        self.assertFalse(required_ipds, msg='no drop rules for %s' % required_ipds)
+        self.assertFalse(required_ipds, msg=f'no drop rules for {required_ipds}')
 
     def verify_routing_performance(self, first_host, second_host):
         for first_host_ip, second_host_ip in (
@@ -5899,29 +5889,29 @@ vlans:
 
     def verify_l3_mesh(self, first_host, second_host):
         for vid in self.NEW_VIDS:
-            macvlan_int = 'macvlan%u' % vid
+            macvlan_int = f'macvlan{vid}'
             first_host_ip = self.netbase(vid, 1)
             second_host_ip = self.netbase(vid, 2)
             self.macvlan_ping(first_host, second_host_ip.ip, macvlan_int)
             self.macvlan_ping(second_host, first_host_ip.ip, macvlan_int)
 
     def verify_l3_hairpin(self, first_host):
-        macvlan1_int = 'macvlan%u' % self.NEW_VIDS[0]
-        macvlan2_int = 'macvlan%u' % self.NEW_VIDS[1]
+        macvlan1_int = f'macvlan{self.NEW_VIDS[0]}'
+        macvlan2_int = f'macvlan{self.NEW_VIDS[1]}'
         macvlan2_ip = self.netbase(self.NEW_VIDS[1], 1)
         macvlan1_gw = self.netbase(self.NEW_VIDS[0], 254)
         macvlan2_gw = self.netbase(self.NEW_VIDS[1], 254)
         netns = self.hostns(first_host)
         setup_cmds = []
         setup_cmds.extend(
-            [self.run_ip('link set %s netns %s' % (macvlan2_int, netns))])
+            [self.run_ip(f'link set {macvlan2_int} netns {netns}')])
         for exec_cmd in (
-                (self.run_ip('address add %s/%u dev %s' % (macvlan2_ip.ip, self.NETPREFIX, macvlan2_int)),
-                 self.run_ip('link set %s up' % macvlan2_int),
-                 self.run_ip('route add default via %s' % macvlan2_gw.ip))):
-            setup_cmds.append('ip netns exec %s %s' % (netns, exec_cmd))
+                (self.run_ip(f'address add {macvlan2_ip.ip}/{self.NETPREFIX} dev {macvlan2_int}'),
+                 self.run_ip(f'link set {macvlan2_int} up'),
+                 self.run_ip(f'route add default via {macvlan2_gw.ip}'))):
+            setup_cmds.append(f'ip netns exec {netns} {exec_cmd}')
         setup_cmds.append(
-            self.run_ip('route add %s via %s' % (macvlan2_ip, macvlan1_gw.ip)))
+            self.run_ip(f'route add {macvlan2_ip} via {macvlan1_gw.ip}'))
         self.quiet_commands(first_host, setup_cmds)
         self.macvlan_ping(first_host, macvlan2_ip.ip, macvlan1_int)
 
@@ -5954,7 +5944,7 @@ class FaucetTaggedGlobalIPv6RouteTest(FaucetTaggedGlobalIPv4RouteTest):
     NEW_VIDS = VIDS[1:]
 
     def netbase(self, vid, host):
-        return ipaddress.ip_interface('fc00::%u:%u' % (vid, host))
+        return ipaddress.ip_interface(f'fc00::{vid}:{host}')
 
     def fib_table(self):
         return self._IPV6_FIB_TABLE
@@ -5967,7 +5957,7 @@ class FaucetTaggedGlobalIPv6RouteTest(FaucetTaggedGlobalIPv4RouteTest):
         return self.one_ipv6_ping(host, ipa, intf=macvlan_int)
 
     def run_ip(self, args):
-        return 'ip -%u %s' % (self.IPV, args)
+        return f'ip -{self.IPV} {args}'
 
     CONFIG_GLOBAL = """
 routers:
@@ -6038,21 +6028,20 @@ vlans:
         for host in self.hosts_name_ordered():
             setup_commands = []
             for vid in self.NEW_VIDS:
-                vlan_int = '%s.%u' % (host.intf_root_name, vid)
+                vlan_int = f'{host.intf_root_name}.{vid}'
                 setup_commands.extend([
-                    'ip link add link %s name %s type vlan id %u' % (
-                        host.intf_root_name, vlan_int, vid),
-                    'ip link set dev %s up' % vlan_int])
+                    f'ip link add link {host.intf_root_name} name {vlan_int} type vlan id {vid}',
+                    f'ip link set dev {vlan_int} up'])
             self.quiet_commands(host, setup_commands)
         for host in self.hosts_name_ordered():
             rdisc6_commands = []
             for vid in self.NEW_VIDS:
-                vlan_int = '%s.%u' % (host.intf_root_name, vid)
+                vlan_int = f'{host.intf_root_name}.{vid}'
                 rdisc6_commands.append(
                     'rdisc6 -r2 -w1 -q %s 2> /dev/null' % vlan_int)
             self.quiet_commands(host, rdisc6_commands)
         for vlan in self.NEW_VIDS:
-            vlan_int = '%s.%u' % (host.intf_root_name, vid)
+            vlan_int = f'{host.intf_root_name}.{vid}'
             for _ in range(3):
                 for host in self.hosts_name_ordered():
                     self.quiet_commands(
@@ -6065,7 +6054,7 @@ vlans:
                 time.sleep(1)
             self.assertGreater(
                 vlan_hosts_learned, 1,
-                msg='not all VLAN %u hosts learned (%u)' % (vlan, vlan_hosts_learned))
+                msg=f'not all VLAN {vlan} hosts learned ({vlan_hosts_learned})')
 
 
 class FaucetTaggedBroadcastTest(FaucetTaggedTest):
@@ -6131,7 +6120,7 @@ vlans:
     def test_tagged(self):
         self.ping_all_when_learned()
         native_ips = [
-            ipaddress.ip_interface('10.99.99.%u/24' % (i + 1)) for i in range(len(self.hosts_name_ordered()))]
+            ipaddress.ip_interface(f'10.99.99.{i + 1}/24') for i in range(len(self.hosts_name_ordered()))]
         for native_ip, host in zip(native_ips, self.hosts_name_ordered()):
             self.host_ipv4_alias(host, native_ip, intf=host.intf_root_name)
         for own_native_ip, host in zip(native_ips, self.hosts_name_ordered()):
@@ -6180,11 +6169,11 @@ acls:
             tcpdump_txt = self.tcpdump_helper(
                 tcpdump_host, tcpdump_filter, [
                     lambda: first_host.cmd(
-                        'arp -s %s %s' % (second_host.IP(), '01:02:03:04:05:06')),
+                        f'arp -s {second_host.IP()} 01:02:03:04:05:06'),
                     lambda: first_host.cmd(' '.join((self.FPINGS_ARGS_ONE, second_host.IP())))],
                 root_intf=True)
             self.assertTrue(re.search(
-                '%s: ICMP echo request' % second_host.IP(), tcpdump_txt))
+                f'{second_host.IP()}: ICMP echo request', tcpdump_txt))
             self.assertTrue(re.search(
                 tcpdump_filter, tcpdump_txt))
 
@@ -6234,11 +6223,11 @@ acls:
             tcpdump_txt = self.tcpdump_helper(
                 tcpdump_host, tcpdump_filter, [
                     lambda: first_host.cmd(
-                        'arp -s %s %s' % (second_host.IP(), '01:02:03:04:05:06')),
+                        f'arp -s {second_host.IP()} 01:02:03:04:05:06'),
                     lambda: first_host.cmd(' '.join((self.FPINGS_ARGS_ONE, second_host.IP())))],
                 root_intf=True)
             self.assertTrue(re.search(
-                '%s: ICMP echo request' % second_host.IP(), tcpdump_txt))
+                f'{second_host.IP()}: ICMP echo request', tcpdump_txt))
             self.assertTrue(re.search(
                 tcpdump_filter, tcpdump_txt))
 
@@ -6288,11 +6277,11 @@ acls:
         tcpdump_txt = self.tcpdump_helper(
             second_host, tcpdump_filter, [
                 lambda: first_host.cmd(
-                    'arp -s %s %s' % (second_host.IP(), '01:02:03:04:05:06')),
+                    f'arp -s {second_host.IP()} 01:02:03:04:05:06'),
                 lambda: first_host.cmd(' '.join((self.FPINGS_ARGS_ONE, second_host.IP())))],
             root_intf=True)
         self.assertTrue(re.search(
-            '%s: ICMP echo request' % second_host.IP(), tcpdump_txt))
+            f'{second_host.IP()}: ICMP echo request', tcpdump_txt))
         self.assertTrue(re.search(
             'vlan 101', tcpdump_txt))
 
@@ -6337,11 +6326,11 @@ acls:
         tcpdump_txt = self.tcpdump_helper(
             second_host, tcpdump_filter, [
                 lambda: first_host.cmd(
-                    'arp -s %s %s' % (second_host.IP(), '01:02:03:04:05:06')),
+                    f'arp -s {second_host.IP()} 01:02:03:04:05:06'),
                 lambda: first_host.cmd(' '.join((self.FPINGS_ARGS_ONE, second_host.IP())))],
             root_intf=True)
         self.assertTrue(re.search(
-            '%s: ICMP echo request' % second_host.IP(), tcpdump_txt))
+            f'{second_host.IP()}: ICMP echo request', tcpdump_txt))
         self.assertTrue(re.search(
             'vlan 101', tcpdump_txt))
 
@@ -6385,12 +6374,12 @@ acls:
         tcpdump_txt = self.tcpdump_helper(
             second_host, tcpdump_filter, [
                 lambda: first_host.cmd(
-                    'arp -s %s %s' % (second_host.IP(), '01:02:03:04:05:06')),
+                    f'arp -s {second_host.IP()} 01:02:03:04:05:06'),
                 lambda: first_host.cmd(
                     ' '.join((self.FPINGS_ARGS_ONE, second_host.IP())))],
             packets=10, root_intf=True)
         self.assertTrue(re.search(
-            '%s: ICMP echo request' % second_host.IP(), tcpdump_txt))
+            f'{second_host.IP()}: ICMP echo request', tcpdump_txt))
 
 
 class FaucetTaggedPopVlansOrderedOutputTest(FaucetTaggedTest):
@@ -6432,12 +6421,12 @@ acls:
         tcpdump_txt = self.tcpdump_helper(
             second_host, tcpdump_filter, [
                 lambda: first_host.cmd(
-                    'arp -s %s %s' % (second_host.IP(), '01:02:03:04:05:06')),
+                    f'arp -s {second_host.IP()} 01:02:03:04:05:06'),
                 lambda: first_host.cmd(
                     ' '.join((self.FPINGS_ARGS_ONE, second_host.IP())))],
             packets=10, root_intf=True)
         self.assertTrue(re.search(
-            '%s: ICMP echo request' % second_host.IP(), tcpdump_txt))
+            f'{second_host.IP()}: ICMP echo request', tcpdump_txt))
 
 
 class FaucetTaggedIPv4ControlPlaneTest(FaucetTaggedTest):
@@ -6962,10 +6951,10 @@ routers:
         self.add_host_route(second_host, first_host_ip, second_faucet_vip.ip)
         self.one_ipv4_ping(first_host, second_host_ip.ip)
         self.one_ipv4_ping(second_host, first_host_ip.ip)
-        second_host.cmd('ifconfig %s down' % second_host.defaultIntf().name)
+        second_host.cmd(f'ifconfig {second_host.defaultIntf().name} down')
         expired_re = r'.+expiring dead route %s.+' % second_host_ip.ip
         self.wait_until_matching_lines_from_faucet_log_files(expired_re)
-        second_host.cmd('ifconfig %s up' % second_host.defaultIntf().name)
+        second_host.cmd(f'ifconfig {second_host.defaultIntf().name} up')
         self.add_host_route(second_host, first_host_ip, second_faucet_vip.ip)
         self.one_ipv4_ping(second_host, first_host_ip.ip)
         self.one_ipv4_ping(first_host, second_host_ip.ip)
@@ -7680,31 +7669,30 @@ acls:
     def test_untagged(self):
         first_host, second_host = self.hosts_name_ordered()[0:2]
         # we expect to see the rewritten mac address.
-        tcpdump_filter = ('icmp and ether dst %s' % self.REWRITE_MAC)
+        tcpdump_filter = (f'icmp and ether dst {self.REWRITE_MAC}')
         tcpdump_txt = self.tcpdump_helper(
             second_host, tcpdump_filter, [
                 lambda: first_host.cmd(
-                    'arp -s %s %s' % (second_host.IP(), self.OVERRIDE_MAC)),
+                    f'arp -s {second_host.IP()} {self.OVERRIDE_MAC}'),
                 lambda: first_host.cmd(' '.join((self.FPINGS_ARGS_ONE, second_host.IP())))],
             timeout=5, packets=1)
         self.assertTrue(re.search(
-            '%s: ICMP echo request' % second_host.IP(), tcpdump_txt))
+            f'{second_host.IP()}: ICMP echo request', tcpdump_txt))
 
     def verify_dest_rewrite(self, source_host, overridden_host, rewrite_host, tcpdump_host):
         overridden_host.setMAC(self.OVERRIDE_MAC)
         rewrite_host.setMAC(self.REWRITE_MAC)
-        rewrite_host.cmd('arp -s %s %s' % (overridden_host.IP(), overridden_host.MAC()))
+        rewrite_host.cmd(f'arp -s {overridden_host.IP()} {overridden_host.MAC()}')
         rewrite_host.cmd(' '.join((self.FPINGS_ARGS_ONE, overridden_host.IP())))
         self.wait_until_matching_flow(
             {'dl_dst': self.REWRITE_MAC},
             table_id=self._ETH_DST_TABLE,
-            actions=['OUTPUT:%u' % self.port_map['port_3']])
-        tcpdump_filter = ('icmp and ether src %s and ether dst %s' % (
-            source_host.MAC(), rewrite_host.MAC()))
+            actions=[f'OUTPUT:{self.port_map["port_3"]}'])
+        tcpdump_filter = f'icmp and ether src {source_host.MAC()} and ether dst {rewrite_host.MAC()}'
         tcpdump_txt = self.tcpdump_helper(
             tcpdump_host, tcpdump_filter, [
                 lambda: source_host.cmd(
-                    'arp -s %s %s' % (rewrite_host.IP(), overridden_host.MAC())),
+                    f'arp -s {rewrite_host.IP()} {overridden_host.MAC()}'),
                 # this will fail if no reply
                 lambda: self.one_ipv4_ping(
                     source_host, rewrite_host.IP(), require_host_learned=False)],
@@ -7712,7 +7700,7 @@ acls:
         # ping from h1 to h2.mac should appear in third host, and not second host, as
         # the acl should rewrite the dst mac.
         self.assertFalse(re.search(
-            '%s: ICMP echo request' % rewrite_host.IP(), tcpdump_txt))
+            f'{rewrite_host.IP()}: ICMP echo request', tcpdump_txt))
 
     def test_switching(self):
         """Tests that a acl can rewrite the destination mac address,
@@ -7770,31 +7758,30 @@ acls:
     def test_untagged(self):
         first_host, second_host = self.hosts_name_ordered()[0:2]
         # we expect to see the rewritten mac address.
-        tcpdump_filter = ('icmp and ether dst %s' % self.REWRITE_MAC)
+        tcpdump_filter = (f'icmp and ether dst {self.REWRITE_MAC}')
         tcpdump_txt = self.tcpdump_helper(
             second_host, tcpdump_filter, [
                 lambda: first_host.cmd(
-                    'arp -s %s %s' % (second_host.IP(), self.OVERRIDE_MAC)),
+                    f'arp -s {second_host.IP()} {self.OVERRIDE_MAC}'),
                 lambda: first_host.cmd(' '.join((self.FPINGS_ARGS_ONE, second_host.IP())))],
             timeout=5, packets=1)
         self.assertTrue(re.search(
-            '%s: ICMP echo request' % second_host.IP(), tcpdump_txt))
+            f'{second_host.IP()}: ICMP echo request', tcpdump_txt))
 
     def verify_dest_rewrite(self, source_host, overridden_host, rewrite_host, tcpdump_host):
         overridden_host.setMAC(self.OVERRIDE_MAC)
         rewrite_host.setMAC(self.REWRITE_MAC)
-        rewrite_host.cmd('arp -s %s %s' % (overridden_host.IP(), overridden_host.MAC()))
+        rewrite_host.cmd(f'arp -s {overridden_host.IP()} {overridden_host.MAC()}')
         rewrite_host.cmd(' '.join((self.FPINGS_ARGS_ONE, overridden_host.IP())))
         self.wait_until_matching_flow(
             {'dl_dst': self.REWRITE_MAC},
             table_id=self._ETH_DST_TABLE,
-            actions=['OUTPUT:%u' % self.port_map['port_3']])
-        tcpdump_filter = ('icmp and ether src %s and ether dst %s' % (
-            source_host.MAC(), rewrite_host.MAC()))
+            actions=[f'OUTPUT:{self.port_map["port_3"]}'])
+        tcpdump_filter = f'icmp and ether src {source_host.MAC()} and ether dst {rewrite_host.MAC()}'
         tcpdump_txt = self.tcpdump_helper(
             tcpdump_host, tcpdump_filter, [
                 lambda: source_host.cmd(
-                    'arp -s %s %s' % (rewrite_host.IP(), overridden_host.MAC())),
+                    f'arp -s {rewrite_host.IP()} {overridden_host.MAC()}'),
                 # this will fail if no reply
                 lambda: self.one_ipv4_ping(
                     source_host, rewrite_host.IP(), require_host_learned=False)],
@@ -7802,7 +7789,7 @@ acls:
         # ping from h1 to h2.mac should appear in third host, and not second host, as
         # the acl should rewrite the dst mac.
         self.assertFalse(re.search(
-            '%s: ICMP echo request' % rewrite_host.IP(), tcpdump_txt))
+            f'{rewrite_host.IP()}: ICMP echo request', tcpdump_txt))
 
     def test_switching(self):
         """Tests that a acl can rewrite the destination mac address,
@@ -7880,7 +7867,7 @@ acls:
             dest_host.IP(), self.UDP_DST_PORT, self.UDP_SRC_PORT,
             dst=self.OUTPUT_MAC)
 
-        tcpdump_filter = "ether dst %s" % self.OUTPUT_MAC
+        tcpdump_filter = f"ether dst {self.OUTPUT_MAC}"
         tcpdump_txt = self.tcpdump_helper(
             dest_host, tcpdump_filter, [lambda: source_host.cmd(scapy_pkt)],
             root_intf=True, packets=1)
@@ -7892,7 +7879,7 @@ acls:
                                          self.IPV4_DST_VAL, self.UDP_DST_PORT),
                       tcpdump_txt))
         # check the packet's converted dscp value
-        self.assertTrue(re.search("tos %s" % hex(self.NW_TOS_VAL), tcpdump_txt))
+        self.assertTrue(re.search(f"tos {hex(self.NW_TOS_VAL)}", tcpdump_txt))
 
     def test_set_fields_icmp(self):
         # Send a basic ICMP packet through the faucet pipeline and verify that
@@ -7905,7 +7892,7 @@ acls:
             self.SRC_MAC, source_host.defaultIntf(), source_host.IP(),
             dest_host.IP(), dst=self.OUTPUT_MAC)
 
-        tcpdump_filter = "ether dst %s" % self.OUTPUT_MAC
+        tcpdump_filter = f"ether dst {self.OUTPUT_MAC}"
         tcpdump_txt = self.tcpdump_helper(
             dest_host, tcpdump_filter, [lambda: source_host.cmd(scapy_pkt)],
             root_intf=True, packets=1)
@@ -7984,7 +7971,7 @@ acls:
             dest_host.IP(), self.UDP_DST_PORT, self.UDP_SRC_PORT,
             dst=self.OUTPUT_MAC)
 
-        tcpdump_filter = "ether dst %s" % self.OUTPUT_MAC
+        tcpdump_filter = f"ether dst {self.OUTPUT_MAC}"
         tcpdump_txt = self.tcpdump_helper(
             dest_host, tcpdump_filter, [lambda: source_host.cmd(scapy_pkt)],
             root_intf=True, packets=1)
@@ -7996,7 +7983,7 @@ acls:
                                          self.IPV4_DST_VAL, self.UDP_DST_PORT),
                       tcpdump_txt))
         # check the packet's converted dscp value
-        self.assertTrue(re.search("tos %s" % hex(self.NW_TOS_VAL), tcpdump_txt))
+        self.assertTrue(re.search(f"tos {hex(self.NW_TOS_VAL)}", tcpdump_txt))
 
     def test_set_fields_icmp(self):
         # Send a basic ICMP packet through the faucet pipeline and verify that
@@ -8009,7 +7996,7 @@ acls:
             self.SRC_MAC, source_host.defaultIntf(), source_host.IP(),
             dest_host.IP(), dst=self.OUTPUT_MAC)
 
-        tcpdump_filter = "ether dst %s" % self.OUTPUT_MAC
+        tcpdump_filter = f"ether dst {self.OUTPUT_MAC}"
         tcpdump_txt = self.tcpdump_helper(
             dest_host, tcpdump_filter, [lambda: source_host.cmd(scapy_pkt)],
             root_intf=True, packets=1)
@@ -8082,7 +8069,7 @@ acls:
         scapy_pkt = self.scapy_dscp(self.SRC_MAC, self.DST_MAC, 184,
                                     source_host.defaultIntf())
 
-        tcpdump_filter = "ether dst %s" % self.REWRITE_MAC
+        tcpdump_filter = f"ether dst {self.REWRITE_MAC}"
         tcpdump_txt = self.tcpdump_helper(
             dest_host, tcpdump_filter, [lambda: source_host.cmd(scapy_pkt)],
             root_intf=True, packets=1)
@@ -8152,7 +8139,7 @@ acls:
         scapy_pkt = self.scapy_dscp(self.SRC_MAC, self.DST_MAC, 184,
                                     source_host.defaultIntf())
 
-        tcpdump_filter = "ether dst %s" % self.REWRITE_MAC
+        tcpdump_filter = f"ether dst {self.REWRITE_MAC}"
         tcpdump_txt = self.tcpdump_helper(
             dest_host, tcpdump_filter, [lambda: source_host.cmd(scapy_pkt)],
             root_intf=True, packets=1)
@@ -8178,16 +8165,16 @@ vlans:
         for _ in range(timeout):
             if not self.host_learned(host, in_port=in_port, timeout=1):
                 return
-        self.fail('host %s still learned' % host)
+        self.fail(f'host {host} still learned')
 
     def wait_for_flowremoved_msg(self, src_mac=None, dst_mac=None, timeout=30):
         pattern = "OFPFlowRemoved"
         mac = None
         if src_mac:
-            pattern = "OFPFlowRemoved(.*)'eth_src': '%s'" % src_mac
+            pattern = f"OFPFlowRemoved(.*)'eth_src': '{src_mac}'"
             mac = src_mac
         if dst_mac:
-            pattern = "OFPFlowRemoved(.*)'eth_dst': '%s'" % dst_mac
+            pattern = f"OFPFlowRemoved(.*)'eth_dst': '{dst_mac}'"
             mac = dst_mac
         for _ in range(timeout):
             for _, debug_log_name in self._get_ofchannel_logs():
@@ -8196,7 +8183,7 @@ vlans:
                 if re.search(pattern, debug):
                     return
             time.sleep(1)
-        self.fail('Not received OFPFlowRemoved for host %s' % mac)
+        self.fail(f'Not received OFPFlowRemoved for host {mac}')
 
     def wait_for_host_log_msg(self, host_mac, msg):
         host_log_re = r'.*%s %s.*' % (msg, host_mac)
@@ -8223,7 +8210,7 @@ class FaucetWithUseIdleTimeoutRuleExpiredTest(FaucetWithUseIdleTimeoutTest):
         self.ping_all_when_learned()
         first_host, second_host, third_host, fourth_host = self.hosts_name_ordered()
         self.host_ipv4_alias(first_host, ipaddress.ip_interface('10.99.99.1/24'))
-        first_host.cmd('arp -s %s %s' % (second_host.IP(), second_host.MAC()))
+        first_host.cmd(f'arp -s {second_host.IP()} {second_host.MAC()}')
         first_host.cmd('timeout 120s ping -I 10.99.99.1 %s &' % second_host.IP())
         for host in (second_host, third_host, fourth_host):
             self.host_drop_all_ips(host)
@@ -8346,7 +8333,7 @@ class FaucetBadFlowModTest(FaucetUntaggedTest):
         options = random.sample(self.bad_options,
                                 random.randint(2, len(self.bad_options)))
         for option in options:
-            param = getattr(self, 'bad_%s' % option)()
+            param = getattr(self, f'bad_{option}')()
             flow_mod.update(param)
         return flow_mod
 
@@ -8361,7 +8348,7 @@ class FaucetBadFlowModTest(FaucetUntaggedTest):
         oferrors = super().tearDown(ignore_oferrors)
         oferrors = re.findall(r'type: (\w+)', oferrors)
         counter = collections.Counter(oferrors)
-        error('Ignored OF error count: %s\n' % dict(counter))
+        error(f'Ignored OF error count: {dict(counter)}\n')
         # TODO: ensure at least one error is always generated.
 
     # pylint: disable=arguments-differ
@@ -8401,7 +8388,7 @@ class FaucetUntaggedMorePortsBase(FaucetUntaggedTest):
         if self.config and self.config.get('hw_switch', False):
             self.N_UNTAGGED = min(len(self.config['dp_ports']),
                                   self.N_UNTAGGED)
-        error('(%d ports) ' % self.N_UNTAGGED)
+        error(f'({self.N_UNTAGGED} ports) ')
         super().setUp()
 
 

--- a/tests/unit/faucet/test_fctl.py
+++ b/tests/unit/faucet/test_fctl.py
@@ -61,7 +61,7 @@ class FctlTestCaseBase(unittest.TestCase):  # pytype: disable=module-attr
     def fctl_args(self, extra_args=None):
         """generate argument list for fctl"""
         result = copy.copy(self.FCTL_BASE_ARGS)
-        result += ['--endpoints=file:%s' % self.prom_input_file_name]
+        result += [f'--endpoints=file:{self.prom_input_file_name}']
         if extra_args is not None:
             result += extra_args
         return result
@@ -96,8 +96,7 @@ class FctlTestCase(FctlTestCaseBase):
         fctl_cli = ' '.join(
             ['python3', self.FCTL] + self.fctl_args(extra_args))
         retcode, output = subprocess.getstatusoutput(fctl_cli)  # pytype: disable=module-attr
-        self.assertEqual(0, retcode, msg='%s returned %d' % (
-            fctl_cli, retcode))
+        self.assertEqual(0, retcode, msg=f'{fctl_cli} returned {retcode}')
         output = output.strip()
         self.assertEqual(output, expected_output)
 
@@ -145,7 +144,7 @@ class FctlClassTestCase(FctlTestCaseBase):
             self.assertEqual(
                 None,
                 fctl.scrape_prometheus(
-                    ['file://%s' % bad_input_file_name], err_output_file=err_output_file))
+                    [f'file://{bad_input_file_name}'], err_output_file=err_output_file))
 
     def write_prom_input_file(self, input_data):
         with open(self.prom_input_file_name, 'w', encoding='utf-8') as prom_input_file:

--- a/tests/unit/faucet/test_valve.py
+++ b/tests/unit/faucet/test_valve.py
@@ -47,15 +47,15 @@ class ValveTestCase(ValveTestBases.ValveTestBig):  # pylint: disable=too-few-pub
 class ValveFuzzTestCase(ValveTestBases.ValveTestNetwork):
     """Test unknown ports/VLANs."""
 
-    CONFIG = """
+    CONFIG = f"""
 dps:
     s1:
-%s
+{DP1_CONFIG}
         interfaces:
             p1:
                 number: 1
                 native_vlan: 0x100
-""" % DP1_CONFIG
+"""
 
     def setUp(self):
         """Setup basic port and vlan config"""
@@ -153,10 +153,10 @@ acls:
 class ValveRestBcastTestCase(ValveTestBases.ValveTestNetwork):
     """Test restricted broadcast."""
 
-    CONFIG = """
+    CONFIG = f"""
 dps:
     s1:
-%s
+{DP1_CONFIG}
         interfaces:
             p1:
                 number: 1
@@ -169,7 +169,7 @@ dps:
                 number: 3
                 native_vlan: 0x100
                 restricted_bcast_arpnd: true
-""" % DP1_CONFIG
+"""
 
     def setUp(self):
         """Setup basic port and vlan config with restricted broadcast enabled"""
@@ -271,10 +271,10 @@ class ValveOFErrorTestCase(ValveTestBases.ValveTestNetwork):
 class ValveGroupTestCase(ValveTestBases.ValveTestNetwork):
     """Tests for datapath with group support."""
 
-    CONFIG = """
+    CONFIG = f"""
 dps:
     s1:
-%s
+{GROUP_DP1_CONFIG}
         interfaces:
             p1:
                 number: 1
@@ -294,7 +294,7 @@ vlans:
         vid: 0x100
     v200:
         vid: 0x200
-""" % GROUP_DP1_CONFIG
+"""
 
     def setUp(self):
         """Setup basic port and vlan config"""
@@ -335,10 +335,10 @@ vlans:
 class ValveIdleLearnTestCase(ValveTestBases.ValveTestNetwork):
     """Smoke test for idle-flow based learning. This feature is not currently reliable."""
 
-    CONFIG = """
+    CONFIG = f"""
 dps:
     s1:
-%s
+{IDLE_DP1_CONFIG}
         interfaces:
             p1:
                 number: 1
@@ -362,7 +362,7 @@ vlans:
         vid: 0x100
     v200:
         vid: 0x200
-""" % IDLE_DP1_CONFIG
+"""
 
     def setUp(self):
         """Setup basic port and vlan config with mirroring"""
@@ -411,10 +411,10 @@ vlans:
 class ValveLACPTestCase(ValveTestBases.ValveTestNetwork):
     """Test LACP."""
 
-    CONFIG = """
+    CONFIG = f"""
 dps:
     s1:
-%s
+{DP1_CONFIG}
         lacp_timeout: 5
         interfaces:
             p1:
@@ -441,7 +441,7 @@ vlans:
         vid: 0x200
     v300:
         vid: 0x300
-""" % DP1_CONFIG
+"""
 
     def setUp(self):
         """Setup lacp config and activate ports"""
@@ -553,10 +553,10 @@ vlans:
 class ValveTFMSizeOverride(ValveTestBases.ValveTestNetwork):
     """Test TFM size override."""
 
-    CONFIG = """
+    CONFIG = f"""
 dps:
     s1:
-%s
+{DP1_CONFIG}
         table_sizes:
             eth_src: 999
         interfaces:
@@ -566,7 +566,7 @@ dps:
 vlans:
     v100:
         vid: 0x100
-""" % DP1_CONFIG
+"""
 
     def setUp(self):
         """Setup basic port and vlan config with overriden TFM sizing"""
@@ -586,10 +586,10 @@ class ValveTFMSize(ValveTestBases.ValveTestNetwork):
 
     NUM_PORTS = 128
 
-    CONFIG = """
+    CONFIG = f"""
 dps:
     s1:
-%s
+{DP1_CONFIG}
         lacp_timeout: 5
         interfaces:
             p1:
@@ -620,7 +620,7 @@ vlans:
         vid: 0x200
     v300:
         vid: 0x300
-""" % DP1_CONFIG
+"""
 
     def setUp(self):
         """Setup basic port and vlan config"""
@@ -638,10 +638,10 @@ vlans:
 class ValveActiveLACPTestCase(ValveTestBases.ValveTestNetwork):
     """Test LACP."""
 
-    CONFIG = """
+    CONFIG = f"""
 dps:
     s1:
-%s
+{DP1_CONFIG}
         lacp_timeout: 5
         interfaces:
             p1:
@@ -669,7 +669,7 @@ vlans:
         vid: 0x200
     v300:
         vid: 0x300
-""" % DP1_CONFIG
+"""
 
     def setUp(self):
         """Setup basic lacp config and activate ports"""
@@ -805,7 +805,7 @@ class ValveMirrorTestCase(ValveTestBases.ValveTestBig):
     """Test ACL and interface mirroring."""
     # TODO: check mirror packets are present/correct
 
-    CONFIG = """
+    CONFIG = f"""
 acls:
     mirror_ospf:
         - rule:
@@ -823,7 +823,7 @@ acls:
                 allow: 1
 dps:
     s1:
-%s
+{DP1_CONFIG}
         interfaces:
             p1:
                 number: 1
@@ -879,7 +879,7 @@ routers:
             server_addresses: ['127.0.0.1']
             neighbor_addresses: ['127.0.0.1']
             vlan: v100
-""" % DP1_CONFIG
+"""
 
     def setUp(self):
         """Setup complex config with routing, bgp, mirroring and ACLs"""
@@ -894,10 +894,10 @@ routers:
 class ValvePortDescTestCase(ValveTestBases.ValveTestNetwork):
     """Test OFPMP_PORT_DESC reply handling."""
 
-    CONFIG = """
+    CONFIG = f"""
 dps:
     s1:
-%s
+{DP1_CONFIG}
         interfaces:
             p1:
                 number: 1
@@ -910,7 +910,7 @@ vlans:
         vid: 0x100
     v200:
         vid: 0x200
-""" % DP1_CONFIG
+"""
 
     def setUp(self):
         """Setup simple configuration with no ports up"""

--- a/tests/unit/faucet/test_valve_config.py
+++ b/tests/unit/faucet/test_valve_config.py
@@ -38,16 +38,16 @@ from clib.valve_test_lib import BASE_DP1_CONFIG, CONFIG, DP1_CONFIG, FAUCET_MAC,
 class ValveIncludeTestCase(ValveTestBases.ValveTestNetwork):
     """Test include optional files."""
 
-    CONFIG = """
+    CONFIG = f"""
 include-optional: ['/does/not/exist/']
 dps:
     s1:
-%s
+{DP1_CONFIG}
         interfaces:
             p1:
                 number: 1
                 native_vlan: 0x100
-""" % DP1_CONFIG
+"""
 
     def setUp(self):
         """Setup config with non-existent optional include file"""
@@ -61,20 +61,20 @@ dps:
 class ValveBadConfTestCase(ValveTestBases.ValveTestNetwork):
     """Test recovery from a bad config file."""
 
-    CONFIG = """
+    CONFIG = f"""
 dps:
     s1:
-%s
+{DP1_CONFIG}
         interfaces:
             p1:
                 number: 1
                 native_vlan: 0x100
-""" % DP1_CONFIG
+"""
 
-    MORE_CONFIG = """
+    MORE_CONFIG = f"""
 dps:
     s1:
-%s
+{DP1_CONFIG}
         interfaces:
             p1:
                 number: 1
@@ -82,7 +82,7 @@ dps:
             p2:
                 number: 2
                 native_vlan: 0x100
-""" % DP1_CONFIG
+"""
 
     BAD_CONFIG = """
 dps: {}
@@ -107,16 +107,16 @@ dps: {}
             self.assertEqual(
                 load_error,
                 self.get_prom('faucet_config_load_error', bare=True),
-                msg='%u: %s' % (load_error, config))
+                msg=f'{load_error}: {config}')
 
 
 class ValveChangePortTestCase(ValveTestBases.ValveTestNetwork):
     """Test changes to config on ports."""
 
-    CONFIG = """
+    CONFIG = f"""
 dps:
     s1:
-%s
+{DP1_CONFIG}
         interfaces:
             p1:
                 number: 1
@@ -125,12 +125,12 @@ dps:
                 number: 2
                 native_vlan: 0x200
                 permanent_learn: True
-""" % DP1_CONFIG
+"""
 
-    LESS_CONFIG = """
+    LESS_CONFIG = f"""
 dps:
     s1:
-%s
+{DP1_CONFIG}
         interfaces:
             p1:
                 number: 1
@@ -139,7 +139,7 @@ dps:
                 number: 2
                 native_vlan: 0x200
                 permanent_learn: False
-""" % DP1_CONFIG
+"""
 
     def setUp(self):
         """Setup basic port and vlan config"""
@@ -163,10 +163,10 @@ dps:
 class ValveDeletePortTestCase(ValveTestBases.ValveTestNetwork):
     """Test deletion of a port."""
 
-    CONFIG = """
+    CONFIG = f"""
 dps:
     s1:
-%s
+{DP1_CONFIG}
         interfaces:
             p1:
                 number: 1
@@ -177,12 +177,12 @@ dps:
             p3:
                 number: 3
                 tagged_vlans: [0x100]
-""" % DP1_CONFIG
+"""
 
-    LESS_CONFIG = """
+    LESS_CONFIG = f"""
 dps:
     s1:
-%s
+{DP1_CONFIG}
         interfaces:
             p1:
                 number: 1
@@ -190,7 +190,7 @@ dps:
             p2:
                 number: 2
                 tagged_vlans: [0x100]
-""" % DP1_CONFIG
+"""
 
     def setUp(self):
         """Setup basic port and vlan config"""
@@ -204,10 +204,10 @@ dps:
 class ValveAddPortMirrorNoDelVLANTestCase(ValveTestBases.ValveTestNetwork):
     """Test addition of port mirroring does not cause a del VLAN."""
 
-    CONFIG = """
+    CONFIG = f"""
 dps:
     s1:
-%s
+{DP1_CONFIG}
         interfaces:
             p1:
                 number: 1
@@ -218,12 +218,12 @@ dps:
             p3:
                 number: 3
                 output_only: true
-""" % DP1_CONFIG
+"""
 
-    MORE_CONFIG = """
+    MORE_CONFIG = f"""
 dps:
     s1:
-%s
+{DP1_CONFIG}
         interfaces:
             p1:
                 number: 1
@@ -235,7 +235,7 @@ dps:
                 number: 3
                 output_only: true
                 mirror: [1]
-""" % DP1_CONFIG
+"""
 
     def setUp(self):
         """Setup basic port and vlan config"""
@@ -249,10 +249,10 @@ dps:
 class ValveAddPortTestCase(ValveTestBases.ValveTestNetwork):
     """Test addition of a port."""
 
-    CONFIG = """
+    CONFIG = f"""
 dps:
     s1:
-%s
+{DP1_CONFIG}
         interfaces:
             p1:
                 number: 1
@@ -260,12 +260,12 @@ dps:
             p2:
                 number: 2
                 tagged_vlans: [0x100]
-""" % DP1_CONFIG
+"""
 
-    MORE_CONFIG = """
+    MORE_CONFIG = f"""
 dps:
     s1:
-%s
+{DP1_CONFIG}
         interfaces:
             p1:
                 number: 1
@@ -276,7 +276,7 @@ dps:
             p3:
                 number: 3
                 tagged_vlans: [0x100]
-""" % DP1_CONFIG
+"""
 
     @staticmethod
     def _inport_flows(in_port, ofmsgs):
@@ -393,10 +393,10 @@ dps:
 class ValveWarmStartVLANTestCase(ValveTestBases.ValveTestNetwork):
     """Test change of port VLAN only is a warm start."""
 
-    CONFIG = """
+    CONFIG = f"""
 dps:
     s1:
-%s
+{DP1_CONFIG}
         interfaces:
             p1:
                 number: 9
@@ -410,12 +410,12 @@ dps:
             p4:
                 number: 14
                 native_vlan: 0x200
-""" % DP1_CONFIG
+"""
 
-    WARM_CONFIG = """
+    WARM_CONFIG = f"""
 dps:
     s1:
-%s
+{DP1_CONFIG}
         interfaces:
             p1:
                 number: 9
@@ -429,7 +429,7 @@ dps:
             p4:
                 number: 14
                 native_vlan: 0x300
-""" % DP1_CONFIG
+"""
 
     def setUp(self):
         """Setup basic port and vlan config"""
@@ -461,10 +461,10 @@ dps:
 class ValveDeleteVLANTestCase(ValveTestBases.ValveTestNetwork):
     """Test deleting VLAN."""
 
-    CONFIG = """
+    CONFIG = f"""
 dps:
     s1:
-%s
+{DP1_CONFIG}
         interfaces:
             p1:
                 number: 1
@@ -472,12 +472,12 @@ dps:
             p2:
                 number: 2
                 native_vlan: 0x200
-""" % DP1_CONFIG
+"""
 
-    LESS_CONFIG = """
+    LESS_CONFIG = f"""
 dps:
     s1:
-%s
+{DP1_CONFIG}
         interfaces:
             p1:
                 number: 1
@@ -485,7 +485,7 @@ dps:
             p2:
                 number: 2
                 native_vlan: 0x200
-""" % DP1_CONFIG
+"""
 
     def setUp(self):
         """Setup basic port and vlan config"""
@@ -499,10 +499,10 @@ dps:
 class ValveChangeDPTestCase(ValveTestBases.ValveTestNetwork):
     """Test changing DP."""
 
-    CONFIG = """
+    CONFIG = f"""
 dps:
     s1:
-%s
+{DP1_CONFIG}
         priority_offset: 4321
         interfaces:
             p1:
@@ -511,12 +511,12 @@ dps:
             p2:
                 number: 2
                 native_vlan: 0x100
-""" % DP1_CONFIG
+"""
 
-    NEW_CONFIG = """
+    NEW_CONFIG = f"""
 dps:
     s1:
-%s
+{DP1_CONFIG}
         priority_offset: 1234
         interfaces:
             p1:
@@ -525,7 +525,7 @@ dps:
             p2:
                 number: 2
                 native_vlan: 0x100
-""" % DP1_CONFIG
+"""
 
     def setUp(self):
         """Setup basic port and vlan config with priority offset"""
@@ -539,10 +539,10 @@ dps:
 class ValveAddVLANTestCase(ValveTestBases.ValveTestNetwork):
     """Test adding VLAN."""
 
-    CONFIG = """
+    CONFIG = f"""
 dps:
     s1:
-%s
+{DP1_CONFIG}
         interfaces:
             p1:
                 number: 1
@@ -550,12 +550,12 @@ dps:
             p2:
                 number: 2
                 tagged_vlans: [0x100]
-""" % DP1_CONFIG
+"""
 
-    MORE_CONFIG = """
+    MORE_CONFIG = f"""
 dps:
     s1:
-%s
+{DP1_CONFIG}
         interfaces:
             p1:
                 number: 1
@@ -563,7 +563,7 @@ dps:
             p2:
                 number: 2
                 tagged_vlans: [0x100, 0x300]
-""" % DP1_CONFIG
+"""
 
     def setUp(self):
         """Setup basic port and vlan config"""
@@ -577,7 +577,7 @@ dps:
 class ValveChangeACLTestCase(ValveTestBases.ValveTestNetwork):
     """Test changes to ACL on a port."""
 
-    CONFIG = """
+    CONFIG = f"""
 acls:
     acl_same_a:
         - rule:
@@ -593,7 +593,7 @@ acls:
                 allow: 0
 dps:
     s1:
-%s
+{DP1_CONFIG}
         interfaces:
             p1:
                 number: 1
@@ -602,9 +602,9 @@ dps:
             p2:
                 number: 2
                 native_vlan: 0x200
-""" % DP1_CONFIG
+"""
 
-    SAME_CONTENT_CONFIG = """
+    SAME_CONTENT_CONFIG = f"""
 acls:
     acl_same_a:
         - rule:
@@ -620,7 +620,7 @@ acls:
                 allow: 0
 dps:
     s1:
-%s
+{DP1_CONFIG}
         interfaces:
             p1:
                 number: 1
@@ -629,9 +629,9 @@ dps:
             p2:
                 number: 2
                 native_vlan: 0x200
-""" % DP1_CONFIG
+"""
 
-    DIFF_CONTENT_CONFIG = """
+    DIFF_CONTENT_CONFIG = f"""
 acls:
     acl_same_a:
         - rule:
@@ -647,7 +647,7 @@ acls:
                 allow: 0
 dps:
     s1:
-%s
+{DP1_CONFIG}
         interfaces:
             p1:
                 number: 1
@@ -656,7 +656,7 @@ dps:
             p2:
                 number: 2
                 native_vlan: 0x200
-""" % DP1_CONFIG
+"""
 
     def setUp(self):
         """Setup basic ACL config"""
@@ -690,10 +690,10 @@ dps:
 class ValveChangeMirrorTestCase(ValveTestBases.ValveTestNetwork):
     """Test changes mirroring port."""
 
-    CONFIG = """
+    CONFIG = f"""
 dps:
     s1:
-%s
+{DP1_CONFIG}
         interfaces:
             p1:
                 number: 1
@@ -704,12 +704,12 @@ dps:
             p3:
                 number: 3
                 native_vlan: 0x200
-""" % DP1_CONFIG
+"""
 
-    MIRROR_CONFIG = """
+    MIRROR_CONFIG = f"""
 dps:
     s1:
-%s
+{DP1_CONFIG}
         interfaces:
             p1:
                 number: 1
@@ -720,7 +720,7 @@ dps:
             p3:
                 number: 3
                 native_vlan: 0x200
-""" % DP1_CONFIG
+"""
 
     def setUp(self):
         """Setup basic port and vlan config"""
@@ -763,10 +763,10 @@ class ValveACLTestCase(ValveTestBases.ValveTestNetwork):
 
     def test_vlan_acl_deny(self):
         """Test VLAN ACL denies a packet."""
-        acl_config = """
+        acl_config = f"""
 dps:
     s1:
-%s
+{DP1_CONFIG}
         interfaces:
             p1:
                 number: 1
@@ -803,7 +803,7 @@ acls:
             dl_type: 0x800
             actions:
                 allow: 0
-""" % DP1_CONFIG
+"""
 
         drop_match = {
             'in_port': 2,
@@ -976,15 +976,15 @@ acls:
 class ValveReloadConfigProfile(ValveTestBases.ValveTestNetwork):
     """Test reload processing time."""
 
-    CONFIG = """
+    CONFIG = f"""
 dps:
     s1:
-%s
+{BASE_DP1_CONFIG}
         interfaces:
             p1:
                 number: 1
                 native_vlan: 0x100
-""" % BASE_DP1_CONFIG
+"""
     NUM_PORTS = 100
 
     baseline_total_tt = None
@@ -1028,16 +1028,16 @@ dps:
                 return
             time.sleep(i)
 
-        self.fail('%f: %s' % (total_tt_prop, pstats_text))
+        self.fail('{total_tt_prop}: {pstats_text}')
 
 
 class ValveTestVLANRef(ValveTestBases.ValveTestNetwork):
     """Test reference to same VLAN by name or VID."""
 
-    CONFIG = """
+    CONFIG = f"""
 dps:
     s1:
-%s
+{DP1_CONFIG}
         interfaces:
             p1:
                 number: 1
@@ -1048,7 +1048,7 @@ dps:
 vlans:
     threes:
         vid: 333
-""" % DP1_CONFIG
+"""
 
     def setUp(self):
         """Setup basic port and vlan config"""
@@ -1065,15 +1065,15 @@ vlans:
 class ValveTestConfigHash(ValveTestBases.ValveTestNetwork):
     """Verify faucet_config_hash_info update after config change"""
 
-    CONFIG = """
+    CONFIG = f"""
 dps:
     s1:
-%s
+{DP1_CONFIG}
         interfaces:
             p1:
                 number: 1
                 native_vlan: 0x100
-""" % DP1_CONFIG
+"""
 
     def setUp(self):
         """Setup basic port and vlan config"""

--- a/tests/unit/faucet/test_valve_dot1x.py
+++ b/tests/unit/faucet/test_valve_dot1x.py
@@ -27,10 +27,10 @@ from clib.valve_test_lib import DOT1X_CONFIG, DOT1X_ACL_CONFIG, ValveTestBases
 class ValveDot1xSmokeTestCase(ValveTestBases.ValveTestNetwork):
     """Smoke test to check dot1x can be initialized."""
 
-    CONFIG = """
+    CONFIG = f"""
 dps:
     s1:
-%s
+{DOT1X_CONFIG}
         interfaces:
             p1:
                 number: 1
@@ -46,7 +46,7 @@ vlans:
         vid: 0x200
         dot1x_assigned: True
 
-""" % DOT1X_CONFIG
+"""
 
     def setUp(self):
         """Setup basic 802.1x config"""
@@ -84,11 +84,11 @@ acls:
                 allow: 0
 """
 
-    CONFIG = """
-{}
+    CONFIG = f"""
+{ACL_CONFIG}
 dps:
     s1:
-{}
+{DOT1X_ACL_CONFIG}
         interfaces:
             p1:
                 number: 1
@@ -104,16 +104,16 @@ vlans:
     student:
         vid: 0x200
         dot1x_assigned: True
-""".format(ACL_CONFIG, DOT1X_ACL_CONFIG)
+"""
 
 
 class ValveDot1xMABSmokeTestCase(ValveDot1xSmokeTestCase):
     """Smoke test to check dot1x can be initialized with dot1x MAB."""
 
-    CONFIG = """
+    CONFIG = f"""
 dps:
     s1:
-{}
+{DOT1X_CONFIG}
         interfaces:
             p1:
                 number: 1
@@ -126,12 +126,12 @@ dps:
 vlans:
     v100:
         vid: 0x100
-""".format(DOT1X_CONFIG)
+"""
 
 
 class ValveDot1xDynACLSmokeTestCase(ValveDot1xSmokeTestCase):
     """Smoke test to check dot1x can be initialized with dynamic dot1x ACLs."""
-    CONFIG = """
+    CONFIG = f"""
 acls:
     accept_acl:
         dot1x_assigned: True
@@ -147,7 +147,7 @@ acls:
                 allow: True
 dps:
     s1:
-%s
+{DOT1X_CONFIG}
         interfaces:
             p1:
                 number: 1
@@ -161,7 +161,7 @@ dps:
 vlans:
     v100:
         vid: 0x100
-""" % DOT1X_CONFIG
+"""
 
     def setUp(self):
         self.setup_valves(self.CONFIG)


### PR DESCRIPTION
This PR moves most string interpolation to use the new f-strings that Python now prefers over older methods such as `%` and `.format`. Pylint now enforces this by default, so this PR addresses at least enough to keep the pylint minimum at 9.50+ for the code base when re-enabling `consider-using-f-string`. Since f-strings are not supported in Python3.5 this PR also removes the support for that to demonstrate that the rest of the tests pass.  This will need to wait to be merged until Faucet is ready to remove support for Python3.5.