### PR TITLE
Improve debug output from test suite when a test fails because of an unhealthy controller

### DIFF
--- a/clib/mininet_test_base.py
+++ b/clib/mininet_test_base.py
@@ -691,7 +691,7 @@ class FaucetTestBase(unittest.TestCase):
         return gauge_controller
 
     def _start_faucet(self, controller_intf, controller_ipv6):
-        self.assertIsNone(self.net, 'Cannot invoke _start_faucet() multilpe times')
+        self.assertIsNone(self.net, 'Cannot invoke _start_faucet() multiple times')
         self.assertTrue(self.NUM_FAUCET_CONTROLLERS > 0, 'Define at least 1 Faucet controller')
         self.assertTrue(self.NUM_GAUGE_CONTROLLERS > 0, 'Define at least 1 Gauge controller')
 

--- a/clib/mininet_test_base.py
+++ b/clib/mininet_test_base.py
@@ -852,11 +852,18 @@ class FaucetTestBase(unittest.TestCase):
 
     def _dump_controller_logs(self):
         dump_txt = ''
-        test_logs = glob.glob(os.path.join(self.tmpdir, '*.log'))
+        test_logs = sorted(glob.glob(os.path.join(self.tmpdir, '*.log')))
         for controller in self.net.controllers:
+            header_txt = controller.name + ' log files'
+            dump_txt += '\n'.join((
+                '',
+                '#' * len(header_txt),
+                header_txt,
+                '#' * len(header_txt),
+                ''))
             for test_log_name in test_logs:
                 basename = os.path.basename(test_log_name)
-                if basename.startswith(controller.name):
+                if basename.startswith(controller.name_no_pid):
                     with open(test_log_name, encoding='utf-8') as test_log:
                         dump_txt += '\n'.join((
                             '',
@@ -864,7 +871,6 @@ class FaucetTestBase(unittest.TestCase):
                             '=' * len(basename),
                             '',
                             test_log.read()))
-                    break
         return dump_txt
 
     def _controllers_healthy(self):

--- a/clib/mininet_test_topo.py
+++ b/clib/mininet_test_topo.py
@@ -460,12 +460,13 @@ socket_timeout=15
 
     def __init__(self, name, tmpdir, controller_intf=None, controller_ipv6=False,
                  cargs='', **kwargs):
-        name = '%s-%u' % (name, os.getpid())
+        self.name_no_pid = name
+        name_with_pid = '%s-%u' % (name, os.getpid())
         self.tmpdir = tmpdir
         self.controller_intf = controller_intf
         self.controller_ipv6 = controller_ipv6
         super().__init__(
-            name, cargs=self._add_cargs(cargs, name), **kwargs)
+            name_with_pid, cargs=self._add_cargs(cargs, name_with_pid), **kwargs)
 
     def _add_cargs(self, cargs, name):
         ofp_listen_host_arg = ''
@@ -633,7 +634,7 @@ socket_timeout=15
         super().stop()
         if os.path.exists(self.logname()):
             tmpdir_logname = os.path.join(
-                self.tmpdir, os.path.basename(self.logname()))
+                self.tmpdir, self.name + '-stdout-stderr.log')
             if os.path.exists(tmpdir_logname):
                 os.remove(tmpdir_logname)
             shutil.move(self.logname(), tmpdir_logname)


### PR DESCRIPTION
Currently when the test suite encounters an unhealthy controller it will output the stdout/stderr from mininet to the screen.

If the controller failed due to an exception, this wouldn't be output as the exception would be in the faucet log not on stderr. The test log dir would need to be inspected to find the reason for the controller crash.

This PR modifies this behaviour to instead output all the log files for a controller instance if it is unhealthy to help with debugging the problem.