### PR TITLE
Allow non-root users to read test suite output directory.

### DIFF
--- a/clib/clib_mininet_test_main.py
+++ b/clib/clib_mininet_test_main.py
@@ -657,6 +657,7 @@ def run_tests(modules, hw_config, requested_test_classes, regex_test_classes, du
         print('Testing hardware, forcing test serialization')
         serial = True
     root_tmpdir = tempfile.mkdtemp(prefix='faucet-tests-', dir='/var/tmp')
+    os.chmod(root_tmpdir, 0o755)
     print('Logging test results in %s' % root_tmpdir)
     start_free_ports = 10
     min_free_ports = 200

--- a/clib/mininet_test_base.py
+++ b/clib/mininet_test_base.py
@@ -353,6 +353,7 @@ class FaucetTestBase(unittest.TestCase):
                 dir=os.path.dirname(yaml_path),
                 delete=False) as conf_file_tmp:
             conf_file_tmp_name = conf_file_tmp.name
+            os.chmod(conf_file_tmp_name, 0o644)
             conf_file_tmp.write(new_conf_str)
         with open(conf_file_tmp_name, 'rb', encoding=None) as conf_file_tmp:
             conf_file_tmp_str = conf_file_tmp.read()


### PR DESCRIPTION
Since the docker test suite runs as root and `tempfile` creates all directories/files without group/other access, this leads to other non-root users being unable to inspect the test output directory (logs/config/pcaps/etc).

Open the permissions on these dirs/files when they are created to allow non-root users to access them.