### PR TITLE
Add support for using openvswitch conntrack in faucet ACLs

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -959,6 +959,10 @@ Actions is a dictionary of actions to apply upon match.
       - dictionary or list
       - None
       - Used to apply more specific output actions for an ACL
+    * - ct
+      - dictionary
+      - None
+      - Used to apply connection tracking to the specified flow.
 
 The output action contains a dictionary with the following elements:
 

--- a/faucet/valve_of.py
+++ b/faucet/valve_of.py
@@ -384,6 +384,10 @@ def is_set_field(action):
     return isinstance(action, parser.OFPActionSetField)
 
 
+def is_ct(action):
+    return isinstance(action, parser.NXActionCT)
+
+
 def apply_meter(meter_id):
     """Return instruction to apply a meter."""
     return parser.OFPInstructionMeter(meter_id, ofp.OFPIT_METER)
@@ -511,6 +515,39 @@ def pop_vlan():
         ryu.ofproto.ofproto_v1_3_parser.OFPActionPopVlan: Pop VLAN.
     """
     return parser.OFPActionPopVlan()
+
+
+def ct(**kwds):  # pylint: disable=invalid-name
+    """Return connection tracker action.
+
+    Args:
+        kwds (dict): exactly one connection tracker action.
+    Returns:
+        ryu.ofproto.nx_actions.NXActionCT: connection tracker action.
+    """
+    return parser.NXActionCT(**kwds)  # pylint: disable=no-member
+
+
+def ct_clear():
+    """Return clear connection tracker state action.
+
+    Args:
+        kwds (dict): exactly one clear connection tracker state action.
+    Returns:
+        ryu.ofproto.nx_actions.NXActionCTClear: clear connection tracker state action.
+    """
+    return parser.NXActionCTClear()  # pylint: disable=no-member
+
+
+def ct_nat(**kwds):
+    """Return network address translation connection tracker action.
+
+    Args:
+        kwds (dict): exactly one network address translation connection tracker action.
+    Returns:
+        ryu.ofproto.nx_actions.NXActionNAT: network address translation connection tracker action.
+    """
+    return parser.NXActionNAT(**kwds)  # pylint: disable=no-member
 
 
 @functools.lru_cache(maxsize=1024)

--- a/faucet/valve_of.py
+++ b/faucet/valve_of.py
@@ -662,8 +662,8 @@ def valve_match_vid(value):
     return to_match_vid(value, ofp.OFPVID_PRESENT)
 
 
-# See 7.2.3.7 Flow Match Fields (OF 1.3.5)
 MATCH_FIELDS = {
+    # See 7.2.3.7 Flow Match Fields (OF 1.3.5)
     'in_port': OFCtlUtil(ofp).ofp_port_from_user,
     'in_phy_port': str_to_int,
     'metadata': to_match_masked_int,
@@ -703,7 +703,13 @@ MATCH_FIELDS = {
     'mpls_bos': str_to_int,
     'pbb_isid': to_match_masked_int,
     'tunnel_id': to_match_masked_int,
-    'ipv6_exthdr': to_match_masked_int
+    'ipv6_exthdr': to_match_masked_int,
+
+    # Nicira extensions, see ovs-fields(7)
+    'ct_state': to_match_masked_int,
+    'ct_zone': str_to_int,
+    'ct_mark': to_match_masked_int,
+    'ct_label': to_match_masked_int
 }
 
 

--- a/faucet/valve_table.py
+++ b/faucet/valve_table.py
@@ -157,8 +157,12 @@ class ValveTable:  # pylint: disable=too-many-arguments,too-many-instance-attrib
             new_inst = []
             for instruction in inst:
                 if instruction.type == valve_of.ofp.OFPIT_APPLY_ACTIONS:
+                    recirc_present = any((
+                        True for action in instruction.actions
+                        if valve_of.is_ct(action) and hasattr(action, 'recirc_table')
+                    ))
                     # If no goto present, this is the last set of actions that can take place
-                    if not goto_present:
+                    if not goto_present and not recirc_present:
                         instruction.actions = self._trim_actions(instruction.actions)
                     # Always drop an apply actions instruction with no actions.
                     if not instruction.actions:

--- a/tests/integration/mininet_tests.py
+++ b/tests/integration/mininet_tests.py
@@ -8024,6 +8024,246 @@ acls:
         pass
 
 
+class FaucetConntrackMatchTest(FaucetUntaggedTest):
+    """Test that untracked TCP packets can be matched with conntrack and blocked"""
+
+    SOFTWARE_ONLY = True
+
+    CONFIG_GLOBAL = """
+vlans:
+    100:
+        description: "untagged"
+acls:
+    1:
+        - rule:
+            eth_type: 0x0800
+            ip_proto: 6
+            ct_state: 0/0x20
+            actions:
+                allow: 0
+        - rule:
+            actions:
+                allow: 1
+"""
+    CONFIG = """
+        interfaces:
+            %(port_1)d:
+                native_vlan: 100
+                acl_in: 1
+            %(port_2)d:
+                native_vlan: 100
+            %(port_3)d:
+                native_vlan: 100
+            %(port_4)d:
+                native_vlan: 100
+"""
+
+    def test_untracked_tcp_blocked(self):
+        self.wait_until_matching_flow(
+            {'ct_state': '0/0x20',
+             'eth_type': 0x0800,
+             'ip_proto': 6},
+            table_id=self._PORT_ACL_TABLE)
+
+        self.ping_all_when_learned()
+
+        first_host, second_host = self.hosts_name_ordered()[0:2]
+        tcpdump_filter = ('tcp and port 1024')
+        tcpdump_txt = self.tcpdump_helper(
+            second_host, tcpdump_filter, [
+                lambda: first_host.cmd(f"nc -w 1 {second_host.IP()} 1024")])
+        self.assertNotIn(f"{second_host.IP()}.1024: Flags [S]", tcpdump_txt)
+
+        self.wait_nonzero_packet_count_flow(
+            {'ct_state': '0/0x20',
+             'eth_type': 0x0800,
+             'ip_proto': 6},
+            table_id=self._PORT_ACL_TABLE)
+
+
+class FaucetConntrackCommitTest(FaucetUntaggedTest):
+    """Test that new TCP flows can be matched/tracked and commited to conntrack"""
+
+    SOFTWARE_ONLY = True
+
+    CONFIG_GLOBAL = """
+vlans:
+    100:
+        description: "untagged"
+acls:
+    1:
+        - rule:
+            eth_type: 0x0800
+            ip_proto: 6
+            ct_state: 0/0x20
+            actions:
+                ct:
+                    table: 0
+                    zone: 1
+        - rule:
+            eth_type: 0x0800
+            ip_proto: 6
+            ct_state: 0x21/0x21
+            actions:
+                ct:
+                    flags: 1
+                    table: 1
+                    zone: 1
+        - rule:
+            actions:
+                allow: 1
+"""
+    CONFIG = """
+        interfaces:
+            %(port_1)d:
+                native_vlan: 100
+                acl_in: 1
+            %(port_2)d:
+                native_vlan: 100
+            %(port_3)d:
+                native_vlan: 100
+            %(port_4)d:
+                native_vlan: 100
+"""
+
+    def test_commit_tracked_tcp(self):
+        self.ping_all_when_learned()
+
+        first_host, second_host = self.hosts_name_ordered()[0:2]
+        tcpdump_filter = ('tcp and port 1024')
+        tcpdump_txt = self.tcpdump_helper(
+            second_host, tcpdump_filter, [
+                lambda: first_host.cmd(f"nc -w 1 {second_host.IP()} 1024")])
+
+        self.wait_nonzero_packet_count_flow(
+            {'ct_state': '0/0x20',
+             'eth_type': 0x0800,
+             'ip_proto': 6},
+            actions=['NX_CT: {flags: 0, zone: [1..17], table: 0, alg: 0, actions: []}'],
+            table_id=self._PORT_ACL_TABLE)
+        self.wait_nonzero_packet_count_flow(
+            {'ct_state': '0x21/0x21',
+             'eth_type': 0x0800,
+             'ip_proto': 6},
+            actions=['NX_CT: {flags: 1, zone: [1..17], table: 1, alg: 0, actions: []}'],
+            table_id=self._PORT_ACL_TABLE)
+
+        self.assertIn(f"{second_host.IP()}.1024: Flags [S]", tcpdump_txt)
+
+
+class FaucetConntrackClearTest(FaucetUntaggedTest):
+    """Verify clear flag can be set in CT action"""
+
+    SOFTWARE_ONLY = True
+
+    CONFIG_GLOBAL = """
+vlans:
+    100:
+        description: "untagged"
+        acl_in: 2
+acls:
+    1:
+        - rule:
+            eth_type: 0x0800
+            ip_proto: 6
+            ct_state: 0/0x20
+            actions:
+                ct:
+                    table: 0
+                    zone: 1
+        - rule:
+            eth_type: 0x0800
+            ip_proto: 6
+            ct_state: 0x21/0x21
+            actions:
+                ct:
+                    flags: 1
+                    table: 1
+                    zone: 1
+        - rule:
+            actions:
+                allow: 1
+    2:
+        - rule:
+            eth_type: 0x0800
+            ip_proto: 6
+            ct_state: 0x20/0x20
+            actions:
+                ct:
+                    clear: true
+                allow: 1
+        - rule:
+            actions:
+                allow: 1
+"""
+    CONFIG = """
+        interfaces:
+            %(port_1)d:
+                native_vlan: 100
+                acl_in: 1
+            %(port_2)d:
+                native_vlan: 100
+            %(port_3)d:
+                native_vlan: 100
+            %(port_4)d:
+                native_vlan: 100
+"""
+
+
+class FaucetConntrackNATTest(FaucetUntaggedTest):
+    """Test that conntrack NAT action rewrites source IP address"""
+
+    SOFTWARE_ONLY = True
+
+    CONFIG_GLOBAL = """
+vlans:
+    100:
+        description: "untagged"
+acls:
+    1:
+        - rule:
+            eth_type: 0x0800
+            ip_proto: 6
+            actions:
+                ct:
+                    flags: 1
+                    table: 1
+                    zone: 1
+                    nat:
+                        flags: 1
+                        range_ipv4_min: 192.0.2.250
+                        range_ipv4_max: 192.0.2.250
+        - rule:
+            actions:
+                allow: 1
+"""
+    CONFIG = """
+        interfaces:
+            %(port_1)d:
+                native_vlan: 100
+                acl_in: 1
+            %(port_2)d:
+                native_vlan: 100
+            %(port_3)d:
+                native_vlan: 100
+            %(port_4)d:
+                native_vlan: 100
+"""
+
+    def test_nat_tcp(self):
+        self.ping_all_when_learned()
+
+        first_host, second_host = self.hosts_name_ordered()[0:2]
+        tcpdump_filter = ('tcp and port 1024')
+        tcpdump_txt = self.tcpdump_helper(
+            second_host, tcpdump_filter, [
+                lambda: first_host.cmd(f"nc -w 1 {second_host.IP()} 1024")])
+
+        tcpdump_regex = re.escape("192.0.2.250.") + r"\d+" + \
+            re.escape(f" > {second_host.IP()}.1024: Flags [S]")
+        self.assertRegex(tcpdump_txt, tcpdump_regex)
+
+
 class FaucetDscpMatchTest(FaucetUntaggedTest):
     # Match all packets with this IP_DSP and eth_type, based on the ryu API def
     # e.g {"ip_dscp": 3, "eth_type": 2048}


### PR DESCRIPTION
Adds support for nicira extension conntrack matches and actions in faucet ACLs.

Throwing draft PR up for feedback, I've still got to write the documentation for this change.