### PR TITLE
Use python 3.8 for building our docs on readthedocs.

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,7 +3,7 @@ version: 2
 build:
   image: latest
 python:
-  version: 3.6
+  version: 3.8
   install:
     - requirements: docs/requirements.txt
     - method: pip


### PR DESCRIPTION
Fixes failing builds after #4003