### PR TITLE
Upgrade to test-base v10.0.0.

### DIFF
--- a/.github/workflows/tests-integration.yml
+++ b/.github/workflows/tests-integration.yml
@@ -11,7 +11,7 @@ jobs:
     name: Sanity tests
     runs-on: ubuntu-latest
     container:
-      image: faucet/test-base:9.0.2
+      image: faucet/test-base:10.0.0
       options: --privileged --cap-add=ALL -v /lib/modules:/lib/modules -v /var/local/lib/docker:/var/lib/docker --sysctl net.ipv6.conf.all.disable_ipv6=0 --ulimit core=-1
     steps:
       - name: Checkout repo
@@ -76,7 +76,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: sanity-tests
     container:
-      image: faucet/test-base:9.0.2
+      image: faucet/test-base:10.0.0
       options: --privileged --cap-add=ALL -v /lib/modules:/lib/modules -v /var/local/lib/docker:/var/lib/docker --sysctl net.ipv6.conf.all.disable_ipv6=0 --ulimit core=-1
     strategy:
       matrix:

--- a/Dockerfile.fuzz-config
+++ b/Dockerfile.fuzz-config
@@ -1,6 +1,6 @@
 ## Image name: faucet/config-fuzzer
 
-FROM faucet/test-base:9.0.2
+FROM faucet/test-base:10.0.0
 
 ENV PIP3="pip3 --no-cache-dir install --upgrade"
 ENV PATH="/venv/bin:$PATH"

--- a/Dockerfile.fuzz-packet
+++ b/Dockerfile.fuzz-packet
@@ -1,6 +1,6 @@
 ## Image name: faucet/packet-fuzzer
 
-FROM faucet/test-base:9.0.2
+FROM faucet/test-base:10.0.0
 
 ENV PIP3="pip3 --no-cache-dir install --upgrade"
 ENV PATH="/venv/bin:$PATH"

--- a/Dockerfile.tests
+++ b/Dockerfile.tests
@@ -1,6 +1,6 @@
 ## Image name: faucet/tests
 
-FROM faucet/test-base:9.0.2
+FROM faucet/test-base:10.0.0
 
 COPY ./ /faucet-src/
 WORKDIR /faucet-src/

--- a/clib/clib_mininet_test_main.py
+++ b/clib/clib_mininet_test_main.py
@@ -70,7 +70,7 @@ EXTERNAL_DEPENDENCIES = (
     ('fuser', ['-V'], r'fuser \(PSmisc\)',
      r'fuser \(PSmisc\) (\d+\.\d+|UNKNOWN)\n', "22.0"),
     ('lsof', ['-v'], r'lsof version',
-     r'revision: (\d+\.\d+)\n', "4.86"),
+     r'revision: (\d+\.\d+(\.\d+)?)\n', "4.86"),
     ('mn', ['--version'], r'\d+\.\d+.\d+',
      r'(\d+\.\d+).\d+', "2.2"),
     ('exabgp', ['--version'], 'ExaBGP',

--- a/tests/integration/mininet_tests.py
+++ b/tests/integration/mininet_tests.py
@@ -6383,7 +6383,7 @@ acls:
 
     def test_tagged(self):
         first_host, second_host = self.hosts_name_ordered()[0:2]
-        tcpdump_filter = 'not vlan and icmp and ether dst 06:06:06:06:06:06'
+        tcpdump_filter = 'icmp and ether dst 06:06:06:06:06:06 and not vlan'
         tcpdump_txt = self.tcpdump_helper(
             second_host, tcpdump_filter, [
                 lambda: first_host.cmd(
@@ -6430,7 +6430,7 @@ acls:
 
     def test_tagged(self):
         first_host, second_host = self.hosts_name_ordered()[0:2]
-        tcpdump_filter = 'not vlan and icmp and ether dst 06:06:06:06:06:06'
+        tcpdump_filter = 'icmp and ether dst 06:06:06:06:06:06 and not vlan'
         tcpdump_txt = self.tcpdump_helper(
             second_host, tcpdump_filter, [
                 lambda: first_host.cmd(

--- a/tests/integration/mininet_tests.py
+++ b/tests/integration/mininet_tests.py
@@ -1811,7 +1811,7 @@ class FaucetUntaggedHairpinTest(FaucetUntaggedTest):
                  'ip link set %s up' % macvlan2_intf)):
             setup_cmds.append('ip netns exec %s %s' % (netns, exec_cmd))
         self.quiet_commands(first_host, setup_cmds)
-        self.one_ipv4_ping(first_host, macvlan2_ipv4, intf=macvlan1_ipv4)
+        self.one_ipv4_ping(first_host, macvlan2_ipv4, intf=macvlan1_intf)
         self.one_ipv4_ping(first_host, second_host.IP())
         # Verify OUTPUT:IN_PORT flood rules are exercised.
         self.wait_nonzero_packet_count_flow(

--- a/tests/integration/mininet_tests.py
+++ b/tests/integration/mininet_tests.py
@@ -5400,7 +5400,7 @@ acls:
         self.assertTrue(re.search(
             '%s: ICMP echo request' % second_host.IP(), tcpdump_txt), msg=tcpdump_txt)
         self.assertTrue(re.search(
-            'vlan 456.+ethertype 802.1Q-QinQ, vlan 123', tcpdump_txt), msg=tcpdump_txt)
+            r'vlan 456.+ethertype 802\.1Q-QinQ \(0x88a8\), vlan 123', tcpdump_txt), msg=tcpdump_txt)
 
 
 class FaucetUntaggedMultiConfVlansOrderedOutputTest(FaucetUntaggedTest):
@@ -5448,7 +5448,7 @@ acls:
         self.assertTrue(re.search(
             '%s: ICMP echo request' % second_host.IP(), tcpdump_txt), msg=tcpdump_txt)
         self.assertTrue(re.search(
-            'vlan 456.+ethertype 802.1Q-QinQ, vlan 123', tcpdump_txt), msg=tcpdump_txt)
+            r'vlan 456.+ethertype 802\.1Q-QinQ \(0x88a8\), vlan 123', tcpdump_txt), msg=tcpdump_txt)
 
 
 class FaucetUntaggedMirrorTest(FaucetUntaggedTest):


### PR DESCRIPTION
Upgrade to test-base v10.0.0 docker image which upgrades to Debian Bullseye and Open vSwitch 2.16.2.

This should fix our current failures running the test suite.

closes #4004 