### PR TITLE
Use physical core count, not logical to avoid process/load oversubscr…

### DIFF
--- a/clib/clib_mininet_test_main.py
+++ b/clib/clib_mininet_test_main.py
@@ -21,7 +21,6 @@ import glob
 import inspect
 import os
 import sys
-import multiprocessing
 import pdb
 import pstats
 import random
@@ -39,6 +38,7 @@ from packaging import version
 from concurrencytest import ConcurrentTestSuite, fork_for_tests
 from mininet.log import setLogLevel
 from mininet.clean import Cleanup
+import psutil
 
 from clib import mininet_test_util
 from clib.valve_test_lib import yaml_load, yaml_dump
@@ -374,7 +374,7 @@ def filter_test_hardware(test_obj, hw_config):
 
 
 def max_loadavg():
-    return int(multiprocessing.cpu_count() * 1.5)
+    return int(psutil.cpu_count(logical=False) * 1.5)
 
 
 def expand_tests(modules, requested_test_classes, regex_test_classes, excluded_test_classes,

--- a/clib/mininet_test_base.py
+++ b/clib/mininet_test_base.py
@@ -494,7 +494,7 @@ class FaucetTestBase(unittest.TestCase):
         for switch in self.net.switches:
             switch_names.append(switch.name)
             self.dump_switch_flows(switch)
-            switch.cmd('%s del-br %s' % (self.VSCTL, switch.name))
+            switch.cmd('%s --if-exists del-br %s' % (self.VSCTL, switch.name))
         self._stop_net()
         self.net = None
         if self.event_sock_dir and os.path.exists(self.event_sock_dir):

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -7,6 +7,7 @@ exabgp==4.2.17
 importlab>=0.3.1
 netifaces
 packaging
+psutil==5.8.0
 requests
 requirements-parser
 scapy==2.4.4


### PR DESCRIPTION
…iption.

Only delete a br that failed to be added (if a test fails due to a bridge not being added, e.g. due to overload).