### PR TITLE
Fix crash in gauge in no response to stats poll. Serialize/limit gene…

### DIFF
--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -29,6 +29,6 @@ jobs:
       - name: Build docker
         run: docker build --pull -t ${FAUCET_TEST_IMG} -f Dockerfile.tests . || exit 1
       - name: Run docker
-        run: sudo docker run ${SHARDARGS} -e FAUCET_TESTS="${{ matrix.MATRIX_SHARD }}" -t ${FAUCET_TEST_IMG} || exit 1
+        run: sudo docker run ${SHARDARGS} -e FAUCET_TESTS="${{ matrix.MATRIX_SHARD }}" -e FAUCET_GENERATIVE_LIMIT=200 -t ${FAUCET_TEST_IMG} || exit 1
       - name: Detect core dumps
         run: if [ ls -1 /var/tmp/core* > /dev/null 2>&1 ]; then exit 1; fi

--- a/clib/clib_mininet_test_main.py
+++ b/clib/clib_mininet_test_main.py
@@ -794,7 +794,7 @@ def parse_args():
         args.loglevel, args.profile)
 
 
-def test_main(modules):
+def test_main(modules, serial_override=None):
     """Test main."""
 
     print('testing module %s' % modules)
@@ -802,6 +802,10 @@ def test_main(modules):
     (requested_test_classes, regex_test_classes, clean, dumpfail, debug, keep_logs, nocheck,
      serial, repeat, excluded_test_classes, report_json_filename, port_order,
      start_port, loglevel, profile) = parse_args()
+
+    if serial_override is not None:
+        print('overriding serial to ', serial_override)
+        serial = serial_override
 
     setLogLevel(loglevel)
 

--- a/clib/mininet_test_base.py
+++ b/clib/mininet_test_base.py
@@ -1555,7 +1555,7 @@ dbs:
                 dpid=dpid, multiple=multiple, controller=controller, retries=retries)
             if result == result_wanted:
                 return True
-            if orgreater and result > result_wanted:
+            if orgreater and result is not None and result > result_wanted:
                 return True
             time.sleep(1)
         return False

--- a/faucet/gauge_pollers.py
+++ b/faucet/gauge_pollers.py
@@ -78,7 +78,7 @@ class GaugePoller:
         """Called when a polling cycle passes without receiving a response."""
 
         dpid_str = ''
-        if self.req and 'datapath' in self.req:
+        if self.req and hasattr(self.req, 'datapath'):
             dpid_str = 'DPID %s (%s)' % (self.req.datapath.id, hex(self.req.datapath.id))
 
         self.logger.info('%s no response to %s', dpid_str, self.req)

--- a/tests/generative/integration/fault_tolerance_main.py
+++ b/tests/generative/integration/fault_tolerance_main.py
@@ -10,6 +10,7 @@ It is strongly recommended to run these tests via Docker, to ensure you have
 all dependencies correctly installed. See ../docs/.
 """
 
+import os
 import networkx
 from networkx.generators.atlas import graph_atlas_g
 
@@ -38,10 +39,23 @@ if __name__ == '__main__':
         if networkx.is_connected(graph):
             GRAPHS.setdefault(graph.number_of_nodes(), [])
             GRAPHS[graph.number_of_nodes()].append(graph)
-    for i, test_class in enumerate(fault_tolerance_tests.TEST_CLASS_LIST):
-        for test_graph in GRAPHS[test_class.NUM_DPS]:
-            test_name = 'test_%s' % test_graph.name
-            test_func = test_generator(test_graph, test_class.STACK_ROOTS)
-            setattr(test_class, test_name, test_func)
+    TEST_LIMIT = int(os.getenv('FAUCET_GENERATIVE_LIMIT', '0'))
 
-    test_main([fault_tolerance_tests.__name__])
+    def create_tests():
+        """Create multi DP test variations."""
+        test_count = 0
+        for test_class in fault_tolerance_tests.TEST_CLASS_LIST:
+            for test_graph in GRAPHS[test_class.NUM_DPS]:
+                test_name = 'test_%s' % test_graph.name
+                test_func = test_generator(test_graph, test_class.STACK_ROOTS)
+                setattr(test_class, test_name, test_func)
+                test_count += 1
+                if TEST_LIMIT and test_count == TEST_LIMIT:
+                    print('Limiting number of tests to', test_count)
+                    return
+
+    # TODO: because we are creating tests dynamically re-using the same base class,
+    # we cannot run tests in parallel as tests with the same base class will
+    # overwrite each other's metadata (including switch names).
+    create_tests()
+    test_main([fault_tolerance_tests.__name__], serial_override=True)

--- a/tests/generative/integration/fault_tolerance_tests.py
+++ b/tests/generative/integration/fault_tolerance_tests.py
@@ -4,6 +4,7 @@ import random
 import unittest
 import networkx
 
+from mininet.log import error
 from clib.mininet_test_watcher import OptimizedTopologyWatcher
 from clib.mininet_test_base_topo import FaucetTopoTestBase
 from clib.mininet_test_topo import FAUCET
@@ -211,10 +212,10 @@ class FaucetFaultToleranceBaseTest(FaucetTopoTestBase):
         name = '%s:%s DOWN' % (self.topo.switches_by_id[index], self.dpids[index])
         self.topo_watcher.add_switch_fault(index, name)
         switch.stop()
-        switch.cmd(self.VSCTL, 'del-controller', switch.name, '|| true')
+        error(switch.cmd(self.VSCTL, 'del-controller', switch.name, '|| true'))
         self.assertTrue(
-            self.wait_for_prometheus_var(
-                'of_dp_disconnections_total', 1, dpid=dpid), 'DP %s not detected as DOWN' % dpid)
+            self.wait_for_prometheus_var('dp_status', 0, default=0, dpid=dpid, retries=10),
+            'DP %s not detected as DOWN' % dpid)
         self.net.switches.remove(switch)
 
     def random_switch_fault(self, *_args):

--- a/tests/unit/gauge/test_gauge.py
+++ b/tests/unit/gauge/test_gauge.py
@@ -656,16 +656,9 @@ class GaugeThreadPollerTest(unittest.TestCase):  # pytype: disable=module-attr
         GaugeThreadPoller class, which just throws an error"""
         self.send_called = True
 
-    @staticmethod
-    def fake_no_response():
-        """This should be called instead of the no_response method in the
-        GaugeThreadPoller class, which just throws an error"""
-        return
-
     def test_start(self):
         """ Checks if the poller is started """
         self.poller.send_req = self.fake_send_req
-        self.poller.no_response = self.fake_no_response
 
         self.poller.start(mock.Mock(), active=True)
         poller_thread = self.poller.thread
@@ -676,7 +669,6 @@ class GaugeThreadPollerTest(unittest.TestCase):  # pytype: disable=module-attr
     def test_stop(self):
         """ Check if a poller can be stopped """
         self.poller.send_req = self.fake_send_req
-        self.poller.no_response = self.fake_no_response
 
         self.poller.start(mock.Mock(), active=True)
         poller_thread = self.poller.thread


### PR DESCRIPTION
…rative tests as they are not parallel compatible.

The generative test suite is failing, because multiple versions of the same test base class are overwriting test metadata.
Make it serial for now with a configurable limit.