### PR TITLE
Upgrade to faucet/python3 v8.0.0 base image.

### DIFF
--- a/Dockerfile.faucet
+++ b/Dockerfile.faucet
@@ -1,6 +1,6 @@
 ## Image name: faucet/faucet
 
-FROM faucet/python3:7.0.0
+FROM faucet/python3:8.0.0
 
 COPY ./ /faucet-src/
 

--- a/adapters/vendors/faucetagent/Dockerfile
+++ b/adapters/vendors/faucetagent/Dockerfile
@@ -1,6 +1,6 @@
 ## Image name: faucet/adapter-faucetagent
 
-FROM faucet/python3:7.0.0
+FROM faucet/python3:8.0.0
 LABEL maintainer="Charlie Lewis <clewis@iqt.org>"
 
 ENV PYTHONUNBUFFERED=0

--- a/adapters/vendors/rabbitmq/Dockerfile
+++ b/adapters/vendors/rabbitmq/Dockerfile
@@ -1,6 +1,6 @@
 ## Image name: faucet/event-adapter-rabbitmq
 
-FROM faucet/python3:7.0.0
+FROM faucet/python3:8.0.0
 LABEL maintainer="Charlie Lewis <clewis@iqt.org>"
 
 ENV PYTHONUNBUFFERED=0


### PR DESCRIPTION
* Change base image from faucet/base to python:3.9-alpine3.15 to reduce size of faucet docker images.