### PR TITLE
Further reduce size of our docker image

### DIFF
--- a/docker/install-faucet.sh
+++ b/docker/install-faucet.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 APK="apk -q --no-cache"
 BUILDDEPS="gcc python3-dev musl-dev parallel yaml-dev g++"
 TESTDEPS="bitstring pytest wheel virtualenv pip"
-PIP3="pip3 -q --no-cache-dir install --upgrade"
+PIP3="pip3 -q install --upgrade"
 FROOT="/faucet-src"
 
 dir=$(dirname "$0")
@@ -32,6 +32,7 @@ for i in ${BUILDDEPS} ; do
 done
 
 # Clean up
+rm -r "${HOME}/.cache"
 rm -r "${FROOT}"
 rm -r /usr/local/lib/python3*/site-packages/os_ken/tests/
 

--- a/docker/install-faucet.sh
+++ b/docker/install-faucet.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-APK="apk -q"
+APK="apk -q --no-cache"
 BUILDDEPS="gcc python3-dev musl-dev parallel yaml-dev g++"
 TESTDEPS="bitstring pytest wheel virtualenv pip"
 PIP3="pip3 -q --no-cache-dir install --upgrade"

--- a/docker/install-faucet.sh
+++ b/docker/install-faucet.sh
@@ -2,10 +2,10 @@
 
 set -euo pipefail
 
-APK="apk -q --no-cache"
+APK="apk --no-cache"
 BUILDDEPS="gcc python3-dev musl-dev parallel yaml-dev g++"
 TESTDEPS="bitstring pytest wheel virtualenv pip"
-PIP3="pip3 -q install --upgrade"
+PIP3="pip3 install --upgrade"
 FROOT="/faucet-src"
 
 dir=$(dirname "$0")


### PR DESCRIPTION
Further reduce our docker image size by about 4MB.

* Add --no-cache flag to apk.
* Pip --no-cache-dir doesn't always work so manually clear the cache ourselves