### PR TITLE
Skip installing ncclient in docker image.

### DIFF
--- a/docker/install-faucet.sh
+++ b/docker/install-faucet.sh
@@ -11,6 +11,7 @@ FROOT="/faucet-src"
 dir=$(dirname "$0")
 
 ${APK} add -U ${BUILDDEPS}
+"${dir}/retrycmd.sh" "${PIP3} git+https://github.com/faucetsdn/python3-fakencclient"
 "${dir}/retrycmd.sh" "${PIP3} ${TESTDEPS}"
 "${dir}/retrycmd.sh" "${PIP3} -r ${FROOT}/requirements.txt"
 ${PIP3} ${FROOT}
@@ -35,6 +36,8 @@ done
 rm -r "${HOME}/.cache"
 rm -r "${FROOT}"
 rm -r /usr/local/lib/python3*/site-packages/os_ken/tests/
+rm -r /usr/local/lib/python3*/site-packages/os_ken/lib/of_config/
+rm /usr/local/lib/python3*/site-packages/os_ken/cmd/of_config_cli.py
 
 # Smoke test
 faucet -V || exit 1


### PR DESCRIPTION
os-ken now lists ncclient as a dependency (see #4145) which causes installation times and disk usage to increase beyond our acceptable limits.

Install our own fake ncclient in the docker build process which will prevent the real ncclient from being installed.