### PR TITLE
Use latest version of test-base in github action workflow.

### DIFF
--- a/.github/workflows/tests-integration.yml
+++ b/.github/workflows/tests-integration.yml
@@ -11,7 +11,7 @@ jobs:
     name: Sanity tests
     runs-on: ubuntu-latest
     container:
-      image: faucet/test-base:11.0.0
+      image: faucet/test-base:latest
       options: --privileged --cap-add=ALL -v /lib/modules:/lib/modules -v /var/local/lib/docker:/var/lib/docker --sysctl net.ipv6.conf.all.disable_ipv6=0 --ulimit core=-1
     steps:
       - name: Checkout repo
@@ -76,7 +76,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: sanity-tests
     container:
-      image: faucet/test-base:11.0.0
+      image: faucet/test-base:latest
       options: --privileged --cap-add=ALL -v /lib/modules:/lib/modules -v /var/local/lib/docker:/var/lib/docker --sysctl net.ipv6.conf.all.disable_ipv6=0 --ulimit core=-1
     strategy:
       matrix:


### PR DESCRIPTION
Dependabot doesn't currently have the ability to update container image versions inside a github action workflow.

So instead of keeping it up to date, always use the latest version of the test-base to run integration tests.