### PR TITLE
Partially re-enable renovatebot.

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,18 @@
+{
+  "enabledManagers": [
+    "docker-compose"
+  ],
+  "packageRules": [
+    {
+      "matchManagers": ["github-actions"],
+      "matchDatasources": ["github-tags"],
+      "enabled": false
+    }
+  ],
+  "separateMajorMinor": false,
+  "extends": [
+    "config:base",
+    ":preserveSemverRanges",
+    "docker:enableMajor"
+  ]
+}

--- a/.github/workflows/tests-integration.yml
+++ b/.github/workflows/tests-integration.yml
@@ -11,7 +11,7 @@ jobs:
     name: Sanity tests
     runs-on: ubuntu-latest
     container:
-      image: faucet/test-base:latest
+      image: faucet/test-base:12.0.0
       options: --privileged --cap-add=ALL -v /lib/modules:/lib/modules -v /var/local/lib/docker:/var/lib/docker --sysctl net.ipv6.conf.all.disable_ipv6=0 --ulimit core=-1
     steps:
       - name: Checkout repo
@@ -76,7 +76,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: sanity-tests
     container:
-      image: faucet/test-base:latest
+      image: faucet/test-base:12.0.0
       options: --privileged --cap-add=ALL -v /lib/modules:/lib/modules -v /var/local/lib/docker:/var/lib/docker --sysctl net.ipv6.conf.all.disable_ipv6=0 --ulimit core=-1
     strategy:
       matrix:


### PR DESCRIPTION
For docker-compose and github action docker tags only.