### PR TITLE
Fix unit tests by not installing tinyrpc v1.1.6.

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -12,4 +12,4 @@ requests
 requirements-parser
 scapy==2.4.4
 webob
-tinyrpc
+tinyrpc<1.1.6


### PR DESCRIPTION
tinyrpc v1.1.6 has started installing a global package named "tests":

https://github.com/mbr/tinyrpc/commit/07e17a05081f4a1afd365654f00f0a42a513bff9 

This is shadowing the faucet unit tests which are in the `tests` directory. Pin tinyrpc to an older version to make our tests run again.