### PR TITLE
Fix black tests not running when there have been no changed py files.

### DIFF
--- a/.github/workflows/tests-codecheck.yml
+++ b/.github/workflows/tests-codecheck.yml
@@ -62,7 +62,7 @@ jobs:
           if [[ "${{ env.FILES_CHANGED }}" == "all" || ! -z "${{ env.RQ_FILES_CHANGED }}" ]]; then
             echo "Running black on everything"
             black . --check
-          else
+          elif [ ! -z "${{ env.PY_FILES_CHANGED }}" ]; then
             echo "Running black on ${{ env.PY_FILES_CHANGED }}"
             black ${{ env.PY_FILES_CHANGED }} --check
           fi


### PR DESCRIPTION
Error:

```
Running black on 
Usage: black [OPTIONS] SRC ...

One of 'SRC' or 'code' is required.
Error: Process completed with exit code 1.
```