### PR TITLE
periodic tests failing under ubuntu-latest:

### DIFF
--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -13,7 +13,7 @@ env:
 jobs:
   generative-testing:
     name: Generative tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         MATRIX_SHARD: [--generative_unit, --generative_tolerance]


### PR DESCRIPTION
Exception: errFail: ('cgget -n -g cpu -g cpuacct -g cpuset /',) failed with return code 81: cgget: libcgroup initialization failed: Cgroup is not mounted