### PR TITLE
Install fakencclient for all python package installs.

### DIFF
--- a/docker/install-faucet.sh
+++ b/docker/install-faucet.sh
@@ -11,7 +11,6 @@ FROOT="/faucet-src"
 dir=$(dirname "$0")
 
 ${APK} add -U ${BUILDDEPS}
-"${dir}/retrycmd.sh" "${PIP3} git+https://github.com/faucetsdn/python3-fakencclient"
 "${dir}/retrycmd.sh" "${PIP3} ${TESTDEPS}"
 "${dir}/retrycmd.sh" "${PIP3} -r ${FROOT}/requirements.txt"
 ${PIP3} ${FROOT}

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ ruamel.yaml==0.17.26
 os_ken==2.6.0
 beka==0.4.2
 pytricia>=1.0.0
+https://github.com/faucetsdn/python3-fakencclient/archive/main.tar.gz

--- a/tests/unit/packaging/test_packaging.py
+++ b/tests/unit/packaging/test_packaging.py
@@ -57,6 +57,8 @@ class CheckDebianPackageTestCase(unittest.TestCase):  # pytype: disable=module-a
         self.faucet_pip_reqs = {}
         with open(requirements_file, "r", encoding="utf-8") as handle:
             for pip_req in requirements.parse(handle):
+                if pip_req.name is None:
+                    continue
                 self.faucet_pip_reqs[pip_req.name] = pip_req.specs
 
     def _pip_req_to_dpkg_name(self, pip_req):


### PR DESCRIPTION
ncclient as a dependency causes us some issues and since we don't make use of it skip installing it by installing our fakencclient package instead