### PR TITLE
Prevent override deps from becoming part of python package.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-eventlet @ https://github.com/faucetsdn/eventlet/archive/main.tar.gz#egg=eventlet
-ncclient @ https://github.com/faucetsdn/python3-fakencclient/archive/main.tar.gz#egg=ncclient
+https://github.com/faucetsdn/eventlet/archive/main.tar.gz#egg=eventlet
+https://github.com/faucetsdn/python3-fakencclient/archive/main.tar.gz#egg=ncclient
 chewie==0.0.25
 influxdb>=2.12.0
 networkx>=1.9

--- a/tests/unit/packaging/test_packaging.py
+++ b/tests/unit/packaging/test_packaging.py
@@ -57,7 +57,7 @@ class CheckDebianPackageTestCase(unittest.TestCase):  # pytype: disable=module-a
         self.faucet_pip_reqs = {}
         with open(requirements_file, "r", encoding="utf-8") as handle:
             for pip_req in requirements.parse(handle):
-                if pip_req.name is None or pip_req.local_file:
+                if pip_req.name is None or pip_req.local_file or pip_req.uri:
                     continue
                 self.faucet_pip_reqs[pip_req.name] = pip_req.specs
 


### PR DESCRIPTION
Removing the "package name @" will prevent these override dependencies ending up in our python packaging metadata which should make faucet installable via pip again without this error:

ERROR: Packages installed from PyPI cannot depend on packages which are not also hosted on PyPI.
faucet depends on eventlet@ https://github.com/faucetsdn/eventlet/archive/main.tar.gz 

However, will remove python 3.12 support when installing faucet via pypi, i.e: "pip install faucet".