### PR TITLE
Add Default Port Hint

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -23,6 +23,14 @@ The datapath ID may be specified as an integer or hex string (beginning with 0x)
 
 A port not explicitly defined in the YAML configuration file will be left down and will drop all packets.
 
+**Default Port and Configuration**
+
+Faucet uses port 6653 as the default listening port. You can customize this and other settings in the following configuration files:
+
+- `/etc/default/faucet`
+- `/etc/default/gauge`
+- `/etc/faucet/ryu.conf`
+
 Configuration options
 ~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Added documentation about the default listening port (6653) for Faucet and how it can be customized in configuration files such as /etc/default/faucet, /etc/default/gauge, and /etc/faucet/ryu.conf. 

This information helps users easily adapt Faucet's port settings to their specific network requirements.

Feel free to further adapt this is just a suggestion. But at least for me this information would have been quite useful.
I did not know that I also have to adapt /etc/default/gauge that's why I ran into some issues

PS: Nice tool thanks a lot for the good work