### PR TITLE
Add support for sending ICMP v4 and v6 time exceeded messages.

### DIFF
--- a/Dockerfile.fuzz-config
+++ b/Dockerfile.fuzz-config
@@ -1,6 +1,6 @@
 ## Image name: faucet/config-fuzzer
 
-FROM faucet/test-base:23.0.1
+FROM faucet/test-base:24.0.0
 
 ENV PIP3="pip3 --no-cache-dir install --upgrade"
 ENV PATH="/venv/bin:$PATH"

--- a/Dockerfile.fuzz-packet
+++ b/Dockerfile.fuzz-packet
@@ -1,6 +1,6 @@
 ## Image name: faucet/packet-fuzzer
 
-FROM faucet/test-base:23.0.1
+FROM faucet/test-base:24.0.0
 
 ENV PIP3="pip3 --no-cache-dir install --upgrade"
 ENV PATH="/venv/bin:$PATH"

--- a/Dockerfile.tests
+++ b/Dockerfile.tests
@@ -1,6 +1,6 @@
 ## Image name: faucet/tests
 
-FROM faucet/test-base:23.0.1
+FROM faucet/test-base:24.0.0
 
 COPY ./ /faucet-src/
 WORKDIR /faucet-src/

--- a/docker/runtests.sh
+++ b/docker/runtests.sh
@@ -19,8 +19,7 @@ if [ -z "${FAUCET_TESTS:-}" ]; then
   FAUCET_TESTS="$*"
 fi
 
-# TODO: FaucetDockerHostTest docker-in-docker currently broken
-PARAMS="-x FaucetDockerHostTest"
+PARAMS=""
 
 # Parse options, some are used by this script, some are
 # passed onto mininet_main.py & clib_mininet_main.py

--- a/faucet/valve_of.py
+++ b/faucet/valve_of.py
@@ -1329,7 +1329,7 @@ def faucet_async(
     """Return async message config for FAUCET/Gauge"""
     packet_in_mask = 0
     if packet_in:
-        packet_in_mask = 1 << ofp.OFPR_ACTION
+        packet_in_mask = 1 << ofp.OFPR_ACTION | 1 << ofp.OFPR_INVALID_TTL
     port_status_mask = 0
     if port_status:
         port_status_mask = (

--- a/faucet/valve_switch_standalone.py
+++ b/faucet/valve_switch_standalone.py
@@ -1378,7 +1378,8 @@ class ValveSwitchManager(ValveManagerBase):  # pylint: disable=too-many-public-m
     def learn_host_from_pkt(valve, now, pkt_meta, other_valves):
         """Learn host from packet."""
         ofmsgs = []
-        ofmsgs.extend(valve.learn_host(now, pkt_meta, other_valves))
+        if pkt_meta.reason == valve_of.ofp.OFPR_ACTION:
+            ofmsgs.extend(valve.learn_host(now, pkt_meta, other_valves))
         ofmsgs.extend(valve.router_rcv_packet(now, pkt_meta))
         return {valve: ofmsgs}
 


### PR DESCRIPTION
This patch allows faucet to reply to traceroute probes from hosts.

This changes faucet to request the openflow agent to send us packet ins of type `OFPR_INVALID_TTL` and adds to PacketMeta the reason a packet in was received (so we can disable learning from ` OFPR_INVALID_TTL` packets).

This patch slightly modifies the order of openflow actions in the FIB tables, to do `dec_ttl` before the `set_fields` that updates the src/dst mac addresses so that we can create the correct ICMP TTL expired response and send it to the right host.