### PR TITLE
Fix docker compose error: services.gauge.links must be a list

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -41,7 +41,6 @@ services:
         ports:
             - '6654:6653'
             - '9303'
-        links:
 
     faucet:
         restart: always


### PR DESCRIPTION
fixes #4549 