### PR TITLE
VLAN ACL change detection to be able to warm reload

### DIFF
--- a/faucet/dp.py
+++ b/faucet/dp.py
@@ -1504,19 +1504,15 @@ class DP(Conf):
             ignore_keys=frozenset(["acls_in"]),
         )
         logger.debug("""
-            _: {},
             deleted_vlans: {},
             added_vlans: {},
             changed_vlans: {},
             same_vlans: {},
-            _: {},
         """.format(
-            _,
             deleted_vlans,
             added_vlans,
             changed_vlans,
             same_vlans,
-            _,
         ))
         # changed_vlans = added_vlans.union(changed_vlans)
         # DOING: optimize for warm start.
@@ -1528,7 +1524,10 @@ class DP(Conf):
                 "VLAN %u" % vlan_id, old_vlan, new_vlan, changed_acls, logger
             ):
                 changed_acl_vlans.add(vlan_id)
-        logger.debug("deleted_vlans: {}, changed_vlans: {}".format(deleted_vlans, changed_vlans))
+        logger.debug(
+            "deleted_vlans: {}, changed_vlans: {}".format(
+            deleted_vlans, changed_vlans)
+        )
         return (deleted_vlans, changed_vlans, added_vlans, changed_acl_vlans)
 
     def _acl_ref_changes(self, conf_desc, old_conf, new_conf, changed_acls, logger):
@@ -1541,7 +1540,10 @@ class DP(Conf):
         old_acl_ids = old_conf.acls_in
         if old_acl_ids:
             old_acl_ids = [acl._id for acl in old_acl_ids]
-        logger.debug("conf_desc: {}, old_acl_ids: {}, new_acl_ids: {}, conf_acls_changed: {}".format(conf_desc, old_acl_ids, new_acl_ids, conf_acls_changed))
+        logger.debug(
+            "conf_desc: {}, old_acl_ids: {}, new_acl_ids: {}, conf_acls_changed: {}".format(
+            conf_desc, old_acl_ids, new_acl_ids, conf_acls_changed)
+        )
         if conf_acls_changed:
             changed = True
             logger.info(
@@ -1564,6 +1566,7 @@ class DP(Conf):
             logger (ValveLogger): logger instance.
             new_dp (DP): new dataplane configuration.
             changed_vlans (set): changed/added VLAN IDs.
+            added_vlans (set): added VLAN IDs.
             deleted_vlans (set): deleted VLAN IDs.
             changed_acls (set): changed/added ACL IDs.
         Returns:
@@ -1607,9 +1610,11 @@ class DP(Conf):
         ))
         # What is port change?
         # - Detect port added/deleted/changed by using _get_conf_changes
-        #   - If port added or deleted, their related opfmgs are processed later by Valve._apply_config_changes()
+        #   - If port added or deleted, their related opfmgs are processed later
+        #       by Valve._apply_config_changes()
         # - Port other config changed like vlan id or port ACL?
-        #   - Vlan membership added / changed / deleted? -> go through all vlan changes to find affected ports
+        #   - Vlan membership added / changed / deleted?
+        #       -> go through all vlan changes to find affected ports
         #   - Port ACL changed
 
         changed_acl_ports = set()
@@ -1650,7 +1655,6 @@ class DP(Conf):
                     if old_vlan.vid == vlan.vid:
                         changed_port_nums = {port.number for port in vlan.get_ports()}
                         old_port_nums = {port.number for port in old_vlan.get_ports()}
-                        # changed_port_nums = old_port_nums.symmetric_difference(changed_port_nums)
                         changed_port_nums -= old_port_nums
                     logger.debug("VLAN %s changed ports: %s" % (vlan.vid, changed_port_nums))
                     changed_ports.update(changed_port_nums)

--- a/faucet/dp.py
+++ b/faucet/dp.py
@@ -1676,6 +1676,41 @@ class DP(Conf):
 
         # Detect port ACL change
         if not all_ports_changed:
+            def get_vids(vlans):
+                if not vlans:
+                    return set()
+                try:
+                    return {vlan.vid for vlan in vlans}
+                except TypeError:
+                    return {vlans.vid}
+
+            def _add_changed_vlan_port(port, port_dp):
+                changed_vlans.update(get_vids(port.vlans()))
+                if port.stack:
+                    changed_vlans.update(get_vids(port_dp.vlans.values()))
+
+            def _add_changed_vlans(old_port, new_port):
+                if old_port.vlans() != new_port.vlans():
+                    old_vids = get_vids(old_port.vlans())
+                    new_vids = get_vids(new_port.vlans())
+                    changed_vlans.update(old_vids.symmetric_difference(new_vids))
+                # stacking dis/enabled on a port.
+                if bool(old_port.stack) != bool(new_port.stack):
+                    changed_vlans.update(get_vids(new_dp.vlans.values()))
+
+            for port_no in changed_ports:
+                if port_no not in self.ports:
+                    continue
+                old_port = self.ports[port_no]
+                new_port = new_dp.ports[port_no]
+                _add_changed_vlans(old_port, new_port)
+            for port_no in deleted_ports:
+                port = self.ports[port_no]
+                _add_changed_vlan_port(port, self)
+            for port_no in added_ports:
+                port = new_dp.ports[port_no]
+                _add_changed_vlan_port(port, new_dp)
+
             for port_no in same_ports:
                 old_port = self.ports[port_no]
                 new_port = new_dp.ports[port_no]

--- a/faucet/faucet.py
+++ b/faucet/faucet.py
@@ -218,16 +218,9 @@ class Faucet(OSKenAppBase):
             ryu_dp: Override datapath from DPSet.
         """
         if ryu_dp is None:
-            try:
-                ryu_dp = self.dpset.get(valve.dp.dp_id)
-                valve.logger.warning("value of self.dpset.get_all is {}".format(self.dpset.get_all()))
-            except Exception as e:
-                valve.logger.warning(
-                    "error: {} when getting DP".format(e),
-                )
+            ryu_dp = self.dpset.get(valve.dp.dp_id)
         if not ryu_dp:
             valve.logger.error("send_flow_msgs: DP not up")
-            valve.logger.error("send_flow_msgs: DP type is {}".format(ryu_dp))
             return
         valve.send_flows(ryu_dp, flow_msgs, time.time())
 

--- a/faucet/faucet.py
+++ b/faucet/faucet.py
@@ -218,9 +218,16 @@ class Faucet(OSKenAppBase):
             ryu_dp: Override datapath from DPSet.
         """
         if ryu_dp is None:
-            ryu_dp = self.dpset.get(valve.dp.dp_id)
+            try:
+                ryu_dp = self.dpset.get(valve.dp.dp_id)
+                valve.logger.warning("value of self.dpset.get_all is {}".format(self.dpset.get_all()))
+            except Exception as e:
+                valve.logger.warning(
+                    "error: {} when getting DP".format(e),
+                )
         if not ryu_dp:
             valve.logger.error("send_flow_msgs: DP not up")
+            valve.logger.error("send_flow_msgs: DP type is {}".format(ryu_dp))
             return
         valve.send_flows(ryu_dp, flow_msgs, time.time())
 

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -1621,7 +1621,6 @@ class Valve:
             added_vids: {},
             changed_acl_vlans: {},
             all_ports_changed: {},
-            _: {},
             deleted_meters: {},
             added_meters: {},
             changed_meters: {},
@@ -1635,7 +1634,6 @@ class Valve:
                 added_vids,
                 changed_acl_vlans,
                 all_ports_changed,
-                _,
                 deleted_meters,
                 added_meters,
                 changed_meters,
@@ -1759,10 +1757,7 @@ class Valve:
             elif restart_type == "warm":
                 # DP not currently up, so no messages to send.
                 if not self.dp.dyn_running:
-                    # TEST: Ensure we do a cold start if DP is not running.
-                    ofmsgs = None
-                    restart_type = "cold"
-                    self.logger.info("DP is not running, change restart_type from warm to cold")
+                    ofmsgs = []
         self.notify({"CONFIG_CHANGE": {"restart_type": restart_type}})
         return ofmsgs
 

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -1689,6 +1689,10 @@ class Valve:
         if self.acl_manager:
             if deleted_meters:
                 ofmsgs.extend(self.acl_manager.del_meters(deleted_meters))
+            if changed_acl_ports:
+                for port_num in changed_acl_ports:
+                    port = self.dp.ports[port_num]
+                    ofmsgs.extend(self.acl_manager.del_port_force(port))
 
         self.dp_init(new_dp, valves)
 
@@ -1708,7 +1712,7 @@ class Valve:
         if self.acl_manager and changed_acl_ports:
             for port_num in changed_acl_ports:
                 port = self.dp.ports[port_num]
-                ofmsgs.extend(self.acl_manager.cold_start_port(port))
+                ofmsgs.extend(self.acl_manager.add_port(port))
         if added_vids:
             added_vlans = [self.dp.vlans[vid] for vid in added_vids]
             ofmsgs.extend(self.add_vlans(added_vlans, cold_start=True))
@@ -1722,7 +1726,8 @@ class Valve:
             self.logger.debug("Number of added Openflow messages generated: {}".format(len(ofmsgs)))
         if self.stack_manager:
             ofmsgs.extend(self.stack_manager.add_tunnel_acls())
-        self.logger.info("Openflow messages generated: {}".format(len(ofmsgs)))
+        self.logger.info("Number of Openflow messages: {}".format(len(ofmsgs)))
+        self.logger.debug("Detail of generated Openflow messages: {}".format(ofmsgs))
         return restart_type, ofmsgs
 
     def reload_config(self, _now, new_dp, valves=None):

--- a/faucet/valve_acl.py
+++ b/faucet/valve_acl.py
@@ -507,6 +507,21 @@ class ValveAclManager(ValveManagerBase):
                 )
         return ofmsgs
 
+    def del_port_force(self, port):
+        """Force-delete all ACL flows for a port.
+
+        Uses a priority-less delete so the flowmodkey differs from
+        any subsequently-added default rule (which carries acl_priority), preventing
+        valve_flowreorder's remove_overlap_ofmsgs from suppressing this delete.
+        In OpenFlow, OFPFC_DELETE (non-strict) ignores priority and deletes all
+        matching flows regardless of their priority.
+        """
+        ofmsgs = []
+        if self._port_acls_allowed(port):
+            in_port_match = self.port_acl_table.match(in_port=port.number)
+            ofmsgs.append(self.port_acl_table.flowdel(in_port_match))
+        return ofmsgs
+
     def del_port(self, port):
         ofmsgs = []
         if self._port_acls_allowed(port):

--- a/faucet/valves_manager.py
+++ b/faucet/valves_manager.py
@@ -18,6 +18,7 @@
 # limitations under the License.
 
 from collections import defaultdict
+import time
 
 from faucet.conf import InvalidConfigError
 from faucet.config_parser_util import config_changed, CONFIG_HASH_FUNC
@@ -345,9 +346,14 @@ class ValvesManager:
         """Process a request to load config changes."""
         if self.config_watcher.content_changed(new_config_file):
             self.logger.info(
-                "configuration %s changed, analyzing differences", new_config_file
+                "configuration %s changed, start analyzing differences", new_config_file
             )
+            start_time = time.time()
             result = self.load_configs(now, new_config_file, delete_dp=delete_dp)
+            self.logger.info(
+                "configuration %s changed, analyzing duration is %.2f second",
+                new_config_file, time.time() - start_time
+            )
             self._notify(
                 {
                     "CONFIG_CHANGE": {

--- a/faucet/valves_manager.py
+++ b/faucet/valves_manager.py
@@ -307,7 +307,9 @@ class ValvesManager:
                 self.logger.info("Reconfiguring existing datapath %s", dpid_log(dp_id))
                 valve = self.valves[dp_id]
                 ofmsgs = valve.reload_config(now, new_dp, list(self.valves.values()))
+                start_time = time.time()
                 self.send_flows_to_dp_by_id(valve, ofmsgs)
+                self.logger.info("Rule application time: %.2f seconds", time.time() - start_time)
                 sent[dp_id] = valve.dp.dyn_running
             else:
                 self.logger.info("Add new datapath %s", dpid_log(new_dp.dp_id))

--- a/tests/integration/mininet_tests.py
+++ b/tests/integration/mininet_tests.py
@@ -3865,6 +3865,74 @@ class FaucetConfigReloadMACFlushTest(FaucetConfigReloadTestBase):
         self.assertLess(len(self.scrape_prometheus(var="learned_l2_port")), 4)
 
 
+class FaucetConfigReloadPortAclRemoveTest(FaucetConfigReloadTestBase):
+    CONFIG_GLOBAL = """
+vlans:
+    100:
+        description: "office network"
+"""
+    ACL = """
+acls:
+    block-ssl:
+        - rule:
+            dl_type: 0x800
+            ip_proto: 6
+            tcp_dst: 443
+            actions:
+                allow: 0
+    block-http:
+        - rule:
+            dl_type: 0x800
+            ip_proto: 6
+            tcp_dst: 80
+            actions:
+                allow: 0
+    block-ping:
+        - rule:
+            dl_type: 0x800
+            ip_proto: 1
+            actions:
+                allow: 0
+"""
+    CONFIG = """
+        interfaces:
+            %(port_1)d:
+                native_vlan: 100
+                acls_in: [block-ping]
+            %(port_2)d:
+                native_vlan: 100
+                acls_in: [block-ping, block-http, block-ssl]
+            %(port_3)d:
+                native_vlan: 100
+"""
+
+    def test_remove_port_acl(self):
+        hup = not self.STAT_RELOAD
+        first_host, second_host, third_host = self.hosts_name_ordered()[:3]
+        
+        # We don't really care about ping success, we care about flow existence.
+        # Check that port 2 has the block-ping rule
+        in_port_2_match = {
+            "in_port": int(self.port_map["port_2"]),
+            "eth_type": 0x800,
+            "ip_proto": 1,
+        }
+        self.wait_until_matching_flow(in_port_2_match, table_id=self._PORT_ACL_TABLE)
+        
+        # Remove the ACL from port 2 ONLY.
+        self.change_port_config(
+            self.port_map["port_2"],
+            "acls_in",
+            ["block-http", "block-ssl"],
+            restart=True,
+            cold_start=False,
+            hup=hup,
+        )
+        
+        # Verify port_2 no longer has the block-ping flow
+        self.wait_until_no_matching_flow(in_port_2_match, table_id=self._PORT_ACL_TABLE, timeout=30)
+
+
 class FaucetConfigReloadEmptyAclTest(FaucetConfigReloadTestBase):
     CONFIG = """
         interfaces:

--- a/tests/integration/mininet_tests.py
+++ b/tests/integration/mininet_tests.py
@@ -3297,7 +3297,8 @@ acls:
             new_yaml_acl_conf,
             self.acl_config_file,  # pytype: disable=attribute-error
             restart=True,
-            cold_start=True,
+            cold_start=False,
+            # cold_start=True,
         )
         self.wait_until_matching_flow({"dl_type": 0x800}, table_id=self._VLAN_ACL_TABLE)
         self.wait_until_matching_flow({"dl_type": 0x806}, table_id=self._VLAN_ACL_TABLE)
@@ -7727,7 +7728,8 @@ routers:
                 self._ip_neigh(second_host, second_faucet_vip.ip, 4), self.FAUCET_MAC2
             )
             self.change_vlan_config(
-                "vlanb", "vid", vlanb_vid, restart=True, cold_start=True
+                # "vlanb", "vid", vlanb_vid, restart=True, cold_start=True
+                "vlanb", "vid", vlanb_vid, restart=True, cold_start=False
             )
 
 
@@ -7793,7 +7795,8 @@ routers:
             self.port_map["port_3"],
             {"native_vlan": "vlana"},
             restart=True,
-            cold_start=True,
+            cold_start=False,
+            # cold_start=True,
         )
 
         test_connectivity(third_host, second_host)

--- a/tests/integration/mininet_tests.py
+++ b/tests/integration/mininet_tests.py
@@ -7728,8 +7728,7 @@ routers:
                 self._ip_neigh(second_host, second_faucet_vip.ip, 4), self.FAUCET_MAC2
             )
             self.change_vlan_config(
-                # "vlanb", "vid", vlanb_vid, restart=True, cold_start=True
-                "vlanb", "vid", vlanb_vid, restart=True, cold_start=False
+                "vlanb", "vid", vlanb_vid, restart=True, cold_start=True
             )
 
 
@@ -7795,8 +7794,7 @@ routers:
             self.port_map["port_3"],
             {"native_vlan": "vlana"},
             restart=True,
-            cold_start=False,
-            # cold_start=True,
+            cold_start=True,
         )
 
         test_connectivity(third_host, second_host)

--- a/tests/integration/mininet_tests.py
+++ b/tests/integration/mininet_tests.py
@@ -3308,7 +3308,7 @@ acls:
             orig_yaml_acl_conf,
             self.acl_config_file,  # pytype: disable=attribute-error
             restart=True,
-            cold_start=True,
+            cold_start=False,
         )
         self.wait_until_matching_flow({"dl_type": 0x800}, table_id=self._VLAN_ACL_TABLE)
         self.wait_until_no_matching_flow(

--- a/tests/unit/faucet/test_valve_config.py
+++ b/tests/unit/faucet/test_valve_config.py
@@ -186,7 +186,7 @@ dps:
 
     def test_change_vlan_acl(self):
         """Test vlan ACL change is detected."""
-        self.update_and_revert_config(self.CONFIG, self.MORE_CONFIG, "cold")
+        self.update_and_revert_config(self.CONFIG, self.MORE_CONFIG, "warm")
 
 
 class ValveChangePortTestCase(ValveTestBases.ValveTestNetwork):

--- a/tests/unit/faucet/test_valve_stack.py
+++ b/tests/unit/faucet/test_valve_stack.py
@@ -4046,7 +4046,7 @@ dps:
         for new_dp in new_dps:
             valve = self.valves_manager.valves[new_dp.dp_id]
             changes = valve.dp.get_config_changes(valve.logger, new_dp)
-            changed_ports, all_ports_changed = changes[1], changes[6]
+            changed_ports, all_ports_changed = changes[1], changes[8]
             for port in valve.dp.stack_ports():
                 if not all_ports_changed:
                     self.assertIn(


### PR DESCRIPTION
I want to perform a warm reload when the VLAN ACL changes, so I made the following updates:
- For port changes:
    - Handle ports in changed_vlans and added_vlans separately.
    - When a port ACL changes (changed_acl_ports), handle it later through Valve._apply_config_changes().
- For VLAN changes: add: added_vlans, changed_acl_vlans
- Lastly: optimize return OpenFlow messages in Valve _apply_config_change()