### PR TITLE
Allow warm restart for VLAN/VIP, router, and ACL configuration changes

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -26,6 +26,7 @@ Leo Scott <leo@sqi-inc.com>
 Mark Wutzke <mark.wutzke@alliedtelesis.co.nz>
 Michael Washer <michael.washer@icloud.com>
 Monkey <monkey@vandervecken.com>
+Nick Rogers <nick@sonoranet.com>
 Nisha Bhardwaj <nishu24nitjsr@gmail.com>
 Piyush Agarwal <agarwalpiyush@agarwalpiyush0.mtv.corp.google.com>
 Richard Sanger <rsanger@wand.net.nz>

--- a/faucet/dp.py
+++ b/faucet/dp.py
@@ -19,7 +19,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from collections import defaultdict
+from collections import defaultdict, namedtuple
 from collections.abc import Iterable
 import copy
 import random
@@ -36,6 +36,26 @@ from faucet.faucet_pipeline import ValveTableConfig
 from faucet.valve import SUPPORTED_HARDWARE
 from faucet.valve_table import ValveTable, ValveGroupTable
 from faucet.stack import Stack
+
+
+DPConfigChanges = namedtuple(
+    "DPConfigChanges",
+    (
+        "deleted_ports",
+        "changed_ports",
+        "added_ports",
+        "changed_acl_ports",
+        "deleted_vlans",
+        "changed_vlans",
+        "all_ports_changed",
+        "all_meters_changed",
+        "deleted_meters",
+        "added_meters",
+        "changed_meters",
+        "added_vlans",
+        "changed_acl_vlans",
+    ),
+)
 
 
 # Documentation generated using documentation_generator.py
@@ -1484,7 +1504,12 @@ class DP(Conf):
         Returns:
             changes (tuple) of:
                 deleted_vlans (set): deleted VLAN IDs.
-                changed_vlans (set): changed/added VLAN IDs.
+                changed_vlans (set): VLAN IDs with non-ACL config changes.
+                added_vlans (set): added VLAN IDs.
+                changed_acl_vlans (set): VLAN IDs whose only change is an
+                    ACL ref/edit (provisional -- get_config_changes may
+                    reduce this if port-level detection promotes a VLAN
+                    into changed_vlans).
         """
         (
             _,
@@ -1499,27 +1524,34 @@ class DP(Conf):
             self.vlans,
             new_dp.vlans,
             diff=True,
-            ignore_keys=frozenset(["acls_in"]),
+            ignore_keys=frozenset(["acls_in", "acls_out"]),
         )
-        changed_vlans = added_vlans.union(changed_vlans)
-        # TODO: optimize for warm start.
+        changed_acl_vlans = set()
         for vlan_id in same_vlans:
             old_vlan = self.vlans[vlan_id]
             new_vlan = new_dp.vlans[vlan_id]
-            if self._acl_ref_changes(
-                "VLAN %u" % vlan_id, old_vlan, new_vlan, changed_acls, logger
-            ):
-                changed_vlans.add(vlan_id)
-        return (deleted_vlans, changed_vlans)
+            for attr in ("acls_in", "acls_out"):
+                if self._acl_ref_changes(
+                    "VLAN %u %s" % (vlan_id, attr),
+                    old_vlan,
+                    new_vlan,
+                    changed_acls,
+                    logger,
+                    acl_attr=attr,
+                ):
+                    changed_acl_vlans.add(vlan_id)
+        return (deleted_vlans, changed_vlans, added_vlans, changed_acl_vlans)
 
-    def _acl_ref_changes(self, conf_desc, old_conf, new_conf, changed_acls, logger):
+    def _acl_ref_changes(
+        self, conf_desc, old_conf, new_conf, changed_acls, logger, acl_attr="acls_in"
+    ):
         changed = False
-        new_acl_ids = new_conf.acls_in
+        new_acl_ids = getattr(new_conf, acl_attr, None)
         conf_acls_changed = set()
         if new_acl_ids:
             new_acl_ids = [acl._id for acl in new_acl_ids]
             conf_acls_changed = set(new_acl_ids).intersection(changed_acls)
-        old_acl_ids = old_conf.acls_in
+        old_acl_ids = getattr(old_conf, acl_attr, None)
         if old_acl_ids:
             old_acl_ids = [acl._id for acl in old_acl_ids]
         if conf_acls_changed:
@@ -1536,14 +1568,15 @@ class DP(Conf):
         return changed
 
     def _get_port_config_changes(
-        self, logger, new_dp, changed_vlans, deleted_vlans, changed_acls
+        self, logger, new_dp, changed_vlans, added_vlans, deleted_vlans, changed_acls
     ):
         """Detect any config changes to ports.
 
         Args:
             logger (ValveLogger): logger instance.
             new_dp (DP): new dataplane configuration.
-            changed_vlans (set): changed/added VLAN IDs.
+            changed_vlans (set): changed VLAN IDs.
+            added_vlans (set): added VLAN IDs.
             deleted_vlans (set): deleted VLAN IDs.
             changed_acls (set): changed/added ACL IDs.
         Returns:
@@ -1553,7 +1586,7 @@ class DP(Conf):
                 changed_ports (set): changed port numbers.
                 added_ports (set): added port numbers.
                 changed_acl_ports (set): changed ACL only port numbers.
-                changed_vlans (set): changed/added VLAN IDs.
+                changed_vlans (set): changed VLAN IDs.
         """
         (
             _,
@@ -1588,18 +1621,27 @@ class DP(Conf):
             logger.info("Stack topology change detected, restarting stack ports")
             same_ports -= changed_ports
 
+        all_changed_or_added = changed_vlans | added_vlans
+        # Track VLANs changed by config (before port-level cross-VLAN detection)
+        config_changed_vlans = set(changed_vlans)
         if not same_ports:
             all_ports_changed = True
-        # TODO: optimize case where only VLAN ACL changed.
-        elif changed_vlans:
-            all_ports = frozenset(new_dp.ports.keys())
+        elif all_changed_or_added:
             new_changed_vlans = {
-                vlan for vlan in new_dp.vlans.values() if vlan.vid in changed_vlans
+                vlan
+                for vlan in new_dp.vlans.values()
+                if vlan.vid in all_changed_or_added
             }
             for vlan in new_changed_vlans:
                 changed_port_nums = {port.number for port in vlan.get_ports()}
                 changed_ports.update(changed_port_nums)
-            all_ports_changed = changed_ports == all_ports
+            # VID replacement restructures per-port classification flows;
+            # cold-start when the affected ports cover the DP. Pure config
+            # changes on existing VIDs are handled in the warm path.
+            if deleted_vlans and added_vlans:
+                all_ports = frozenset(new_dp.ports.keys())
+                if changed_ports == all_ports:
+                    all_ports_changed = True
 
         # Detect changes to VLANs and ACLs based on port changes.
         if not all_ports_changed:
@@ -1657,17 +1699,39 @@ class DP(Conf):
 
         same_ports -= changed_ports
         changed_vlans -= deleted_vlans
-        # TODO: limit scope to only routers that have affected VLANs.
-        changed_vlans_with_vips = []
-        for vid in changed_vlans:
-            vlan = new_dp.vlans[vid]
-            if vlan.faucet_vips:
-                changed_vlans_with_vips.append(vlan)
-        if changed_vlans_with_vips:
-            logger.info(
-                "forcing cold start because %s has routing" % changed_vlans_with_vips
-            )
-            all_ports_changed = True
+        changed_vlans -= added_vlans
+        # Sibling-VLAN expansion: a config-changed VLAN whose faucet_vips
+        # or faucet_mac shifted may have proactive-learn FIB entries on
+        # router-siblings that pointed at the old VIP/MAC; reinstall those
+        # too. Skip for other VLAN edits (description, max_hosts, etc.)
+        # since they don't invalidate sibling FIB. Skip for cross-VLAN
+        # port-detection promotions to avoid stacking-reparse feedback.
+        for vid in config_changed_vlans:
+            new_vlan = new_dp.vlans.get(vid)
+            old_vlan = self.vlans.get(vid)
+            if not (new_vlan and old_vlan and new_vlan.faucet_vips):
+                continue
+            if (
+                new_vlan.faucet_vips == old_vlan.faucet_vips
+                and new_vlan.faucet_mac == old_vlan.faucet_mac
+            ):
+                continue
+            for router in new_dp.routers.values():
+                if new_vlan in router.vlans:
+                    for sibling in router.vlans:
+                        changed_vlans.add(sibling.vid)
+        # Brand-new VIDs go through the added-VLAN path, not changed.
+        changed_vlans -= added_vlans
+        # Cross-VLAN-only detection on a routed set: force cold start to
+        # preserve historic behavior for stacking environments.
+        if changed_vlans and not config_changed_vlans and not added_vlans:
+            changed_vlans_with_vips = [
+                new_dp.vlans[vid]
+                for vid in changed_vlans
+                if vid in new_dp.vlans and new_dp.vlans[vid].faucet_vips
+            ]
+            if changed_vlans_with_vips:
+                all_ports_changed = True
 
         return (
             all_ports_changed,
@@ -1699,6 +1763,67 @@ class DP(Conf):
 
         return (all_meters_changed, deleted_meters, added_meters, changed_meters)
 
+    def _bgp_config_changed(self, new_dp):
+        """Return True if any router's BGP config changed."""
+        all_router_names = set(self.routers.keys()) | set(new_dp.routers.keys())
+        for rname in all_router_names:
+            old_router = self.routers.get(rname)
+            new_router = new_dp.routers.get(rname)
+            old_bgp = old_router.bgp if old_router else {}
+            new_bgp = new_router.bgp if new_router else {}
+            if old_bgp != new_bgp:
+                return True
+        return False
+
+    def _has_router_vlans_changed(self, new_dp):
+        """Return True if an existing router's resolved VID set changed.
+
+        Router.__eq__ compares orig_conf (VLAN names) and so misses pure
+        VID-renumbering on a name-stable router. Only detects changes on
+        routers present in both configs; add/remove handled elsewhere.
+        """
+        old_router_names = set(self.routers.keys())
+        new_router_names = set(new_dp.routers.keys())
+        if old_router_names != new_router_names:
+            return False
+        for rname in old_router_names:
+            old_vids = frozenset(v.vid for v in self.routers[rname].vlans)
+            new_vids = frozenset(v.vid for v in new_dp.routers[rname].vlans)
+            if old_vids != new_vids:
+                return True
+        return False
+
+    def _cold_start_changes(self):
+        return DPConfigChanges(
+            deleted_ports=set(),
+            changed_ports=set(),
+            added_ports=set(),
+            changed_acl_ports=set(),
+            deleted_vlans=set(),
+            changed_vlans=set(),
+            all_ports_changed=True,
+            all_meters_changed=True,
+            deleted_meters=set(),
+            added_meters=set(),
+            changed_meters=set(),
+            added_vlans=set(),
+            changed_acl_vlans=set(),
+        )
+
+    def _get_router_affected_vlans(self, new_dp):
+        """Return VIDs from all VLANs in any changed router (old + new)."""
+        affected_vids = set()
+        all_router_names = set(self.routers.keys()) | set(new_dp.routers.keys())
+        for rname in all_router_names:
+            old_router = self.routers.get(rname)
+            new_router = new_dp.routers.get(rname)
+            if old_router != new_router:
+                if old_router and old_router.vlans:
+                    affected_vids.update(v.vid for v in old_router.vlans)
+                if new_router and new_router.vlans:
+                    affected_vids.update(v.vid for v in new_router.vlans)
+        return affected_vids
+
     def get_config_changes(self, logger, new_dp):
         """Detect any config changes.
 
@@ -1706,19 +1831,21 @@ class DP(Conf):
             logger (ValveLogger): logger instance
             new_dp (DP): new dataplane configuration.
         Returns:
-            (tuple): changes tuple containing:
+            DPConfigChanges with fields:
 
                 deleted_ports (set): deleted port numbers.
                 changed_ports (set): changed port numbers.
                 added_ports (set): added port numbers.
                 changed_acl_ports (set): changed ACL only port numbers.
                 deleted_vlans (set): deleted VLAN IDs.
-                changed_vlans (set): changed/added VLAN IDs.
+                changed_vlans (set): changed VLAN IDs.
                 all_ports_changed (bool): True if all ports changed.
                 all_meters_changed (bool): True if all meters changed
                 deleted_meters (set): deleted meter numbers
                 added_meters (set): Added meter numbers
                 changed_meters (set): changed/added meter numbers
+                added_vlans (set): added VLAN IDs.
+                changed_acl_vlans (set): VLAN IDs whose only change is an ACL ref or referenced ACL's contents; eligible for granular ACL warm reload.
         """
         if (
             new_dp.stack
@@ -1726,8 +1853,15 @@ class DP(Conf):
             and new_dp.stack.root_name != self.stack.root_name
         ):
             logger.info("Stack root change - requires cold start")
-        elif new_dp.routers != self.routers:
-            logger.info("DP routers config changed - requires cold start")
+        elif self._bgp_config_changed(new_dp):
+            logger.info("BGP config changed - requires cold start")
+        elif set(self.routers.keys()) != set(new_dp.routers.keys()) and not any(
+            vlan.faucet_vips for vlan in self.vlans.values()
+        ):
+            # Routers added/removed with no existing routing tables requires
+            # cold start. When routing tables already exist (VIPs configured),
+            # router additions/removals can warm-start.
+            logger.info("DP routers added/removed (no routing) - requires cold start")
         elif not self.ignore_subconf(
             new_dp, ignore_keys=["interfaces", "interface_ranges", "routers"]
         ):
@@ -1736,9 +1870,12 @@ class DP(Conf):
             )
         else:
             changed_acls = self._get_acl_config_changes(logger, new_dp)
-            deleted_vlans, changed_vlans = self._get_vlan_config_changes(
-                logger, new_dp, changed_acls
-            )
+            (
+                deleted_vlans,
+                changed_vlans,
+                added_vlans,
+                changed_acl_vlans,
+            ) = self._get_vlan_config_changes(logger, new_dp, changed_acls)
             (
                 all_meters_changed,
                 deleted_meters,
@@ -1753,35 +1890,55 @@ class DP(Conf):
                 changed_acl_ports,
                 changed_vlans,
             ) = self._get_port_config_changes(
-                logger, new_dp, changed_vlans, deleted_vlans, changed_acls
-            )
-            return (
-                deleted_ports,
-                changed_ports,
-                added_ports,
-                changed_acl_ports,
-                deleted_vlans,
+                logger,
+                new_dp,
                 changed_vlans,
-                all_ports_changed,
-                all_meters_changed,
-                deleted_meters,
-                added_meters,
-                changed_meters,
+                added_vlans,
+                deleted_vlans,
+                changed_acls,
             )
-        # default cold start
-        return (
-            set(),
-            set(),
-            set(),
-            set(),
-            set(),
-            set(),
-            True,
-            True,
-            set(),
-            set(),
-            set(),
-        )
+            # Non-BGP router changes: expand changed_vlans to the router's
+            # affected VIDs. VID replacement that covers all DP ports stays
+            # cold. Router.__eq__ compares orig_conf names so misses pure
+            # VID renumbers; _has_router_vlans_changed catches those.
+            if self._has_router_vlans_changed(new_dp) or (
+                new_dp.routers != self.routers
+            ):
+                if deleted_vlans and added_vlans:
+                    logger.info(
+                        "DP routers config changed with VLAN replacement"
+                        " - requires cold start"
+                    )
+                    all_ports_changed = True
+                else:
+                    logger.info("DP routers config changed - warm start")
+                    affected_vids = self._get_router_affected_vlans(new_dp)
+                    affected_vids -= deleted_vlans
+                    affected_vids -= added_vlans
+                    changed_vlans.update(affected_vids)
+            # Heavy reinstall covers ACL flows; keep changed_acl_vlans
+            # disjoint from changed_vlans so the two paths don't double-emit.
+            # Done after router expansion so any router-affected VID that's
+            # also in changed_acl_vlans falls into the heavy path only.
+            changed_acl_vlans -= changed_vlans
+            if changed_acl_vlans:
+                logger.info("VLANs where ACL only changed: %s" % changed_acl_vlans)
+            return DPConfigChanges(
+                deleted_ports=deleted_ports,
+                changed_ports=changed_ports,
+                added_ports=added_ports,
+                changed_acl_ports=changed_acl_ports,
+                deleted_vlans=deleted_vlans,
+                changed_vlans=changed_vlans,
+                all_ports_changed=all_ports_changed,
+                all_meters_changed=all_meters_changed,
+                deleted_meters=deleted_meters,
+                added_meters=added_meters,
+                changed_meters=changed_meters,
+                added_vlans=added_vlans,
+                changed_acl_vlans=changed_acl_vlans,
+            )
+        return self._cold_start_changes()
 
     def get_tables(self):
         """Return tables as dict for API call."""

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -1569,42 +1569,52 @@ class Valve:
                 return True
         return False
 
+    def _apply_acl_diff(self, scope_label, scope_id, old_addmods, new_addmods):
+        """Diff old/new ACL addmods for one port or VLAN and return the
+        resulting flowdels + flowmods, logging the per-scope delta."""
+        table_lookup = (
+            self.acl_manager.table_for_id if self.acl_manager else lambda _: None
+        )
+        dels, adds = valve_acl.diff_addmods(
+            table_lookup, old_addmods, new_addmods, logger=self.logger
+        )
+        self.logger.info(
+            "%s %u ACL warm-reload: -%d +%d (old=%d new=%d total)"
+            % (
+                scope_label,
+                scope_id,
+                len(dels),
+                len(adds),
+                len(old_addmods),
+                len(new_addmods),
+            )
+        )
+        return dels + adds
+
     def _apply_config_changes(self, new_dp, changes, valves=None):
         """Apply any detected configuration changes.
 
         Args:
             new_dp: (DP): new dataplane configuration.
-            changes (tuple) of:
-                deleted_ports (set): deleted port numbers.
-                changed_ports (set): changed port numbers.
-                added_ports (set): added port numbers.
-                changed_acl_ports (set): changed ACL only port numbers.
-                deleted_vids (set): deleted VLAN IDs.
-                changed_vids (set): changed/added VLAN IDs.
-                all_ports_changed (bool): True if all ports changed.
-                all_meters_changed (bool): True if all meters changed.
-                deleted_meters: (set): deleted meter numbers.
-                changed_meters: (set): changed meter numbers.
-                added_meters: (set): added meter numbers.
+            changes (DPConfigChanges): output of DP.get_config_changes.
             valves (list): List of other running valves
         Returns:
             tuple:
                 restart_type (string or None)
                 ofmsgs (list): OpenFlow messages.
         """
-        (
-            deleted_ports,
-            changed_ports,
-            added_ports,
-            changed_acl_ports,
-            deleted_vids,
-            changed_vids,
-            all_ports_changed,
-            _,
-            deleted_meters,
-            added_meters,
-            changed_meters,
-        ) = changes
+        deleted_ports = changes.deleted_ports
+        changed_ports = changes.changed_ports
+        added_ports = changes.added_ports
+        changed_acl_ports = changes.changed_acl_ports
+        deleted_vids = changes.deleted_vlans
+        changed_vids = changes.changed_vlans
+        all_ports_changed = changes.all_ports_changed
+        deleted_meters = changes.deleted_meters
+        added_meters = changes.added_meters
+        changed_meters = changes.changed_meters
+        added_vids = changes.added_vlans
+        changed_acl_vlans = changes.changed_acl_vlans
         restart_type = "cold"
         ofmsgs = []
 
@@ -1629,6 +1639,20 @@ class Valve:
             self.dp_init(new_dp)
             return restart_type, ofmsgs
 
+        # Snapshot OLD-side ACL addmods (pure flowmod factories) before
+        # dp_init swaps acl_manager; diff against NEW-side snapshot after.
+        old_port_addmods = {}
+        old_vlan_addmods = {}
+        if self.acl_manager:
+            for port_num in changed_acl_ports:
+                old_port_addmods[port_num] = self.acl_manager.add_port(
+                    self.dp.ports[port_num]
+                )
+            for vid in changed_acl_vlans:
+                old_vlan_addmods[vid] = self.acl_manager.add_vlan(
+                    self.dp.vlans[vid], cold_start=False
+                )
+
         if deleted_ports:
             ofmsgs.extend(self.ports_delete(deleted_ports))
         if changed_ports:
@@ -1636,6 +1660,13 @@ class Valve:
         if deleted_vids:
             deleted_vlans = [self.dp.vlans[vid] for vid in deleted_vids]
             ofmsgs.extend(self.del_vlans(deleted_vlans))
+        # Delete changed VLANs BEFORE dp_init using OLD managers/VLAN objects
+        # so that old VIP/faucet_mac select_packets flows are properly cleaned up.
+        if changed_vids:
+            old_changed_vlans = [
+                self.dp.vlans[vid] for vid in changed_vids if vid in self.dp.vlans
+            ]
+            ofmsgs.extend(self.del_vlans(old_changed_vlans))
         # TODO: optimize for all meters being erased
         if changed_meters:
             # If a meter changed meter IDs, delete the old ID first and consider
@@ -1665,16 +1696,40 @@ class Valve:
                 port for port in changed_ports if port in self.dp.dyn_up_port_nos
             ]
             ofmsgs.extend(self.ports_add(all_up_port_nos))
-        if self.acl_manager and changed_acl_ports:
-            for port_num in changed_acl_ports:
-                port = self.dp.ports[port_num]
-                ofmsgs.extend(self.acl_manager.cold_start_port(port))
+        for port_num in changed_acl_ports:
+            ofmsgs.extend(
+                self._apply_acl_diff(
+                    "port",
+                    port_num,
+                    old_port_addmods.get(port_num, []),
+                    (
+                        self.acl_manager.add_port(self.dp.ports[port_num])
+                        if self.acl_manager
+                        else []
+                    ),
+                )
+            )
+        if added_vids:
+            new_added_vlans = [self.dp.vlans[vid] for vid in added_vids]
+            ofmsgs.extend(self.add_vlans(new_added_vlans, cold_start=True))
         if changed_vids:
-            changed_vlans = [self.dp.vlans[vid] for vid in changed_vids]
-            # TODO: handle change versus add separately so can avoid delete first.
-            ofmsgs.extend(self.del_vlans(changed_vlans))
-            # The proceeding delete operation means we don't have to generate more deletes.
+            changed_vlans = [
+                self.dp.vlans[vid] for vid in changed_vids if vid in self.dp.vlans
+            ]
             ofmsgs.extend(self.add_vlans(changed_vlans, cold_start=True))
+        for vid in changed_acl_vlans:
+            ofmsgs.extend(
+                self._apply_acl_diff(
+                    "VLAN",
+                    vid,
+                    old_vlan_addmods.get(vid, []),
+                    (
+                        self.acl_manager.add_vlan(self.dp.vlans[vid], cold_start=False)
+                        if self.acl_manager
+                        else []
+                    ),
+                )
+            )
         if self.stack_manager:
             ofmsgs.extend(self.stack_manager.add_tunnel_acls())
         return restart_type, ofmsgs

--- a/faucet/valve_acl.py
+++ b/faucet/valve_acl.py
@@ -432,6 +432,49 @@ def add_mac_address_to_match(match, eth_src):
     return valve_of.match_from_dict(dict_match)
 
 
+def diff_addmods(table_lookup, old_addmods, new_addmods, logger=None):
+    """Return (flowdels, flowmods) for the rule-level delta.
+
+    Flowdels use OFPFC_DELETE_STRICT so a less-specific rule doesn't
+    wildcard-delete more specific ones sharing its match prefix.
+    Non-flowmod ofmsgs (e.g. OFPGroupMod from `failover` actions) are
+    passed through unchanged on the add side and dropped on the del side."""
+    flowkey = valve_of._flowmodkey  # pylint: disable=protected-access
+    old_flowmods = [m for m in old_addmods if valve_of.is_flowmod(m)]
+    new_flowmods = [m for m in new_addmods if valve_of.is_flowmod(m)]
+    new_non_flowmods = [m for m in new_addmods if not valve_of.is_flowmod(m)]
+    old_by_key = {flowkey(m): m for m in old_flowmods}
+    new_by_key = {flowkey(m): m for m in new_flowmods}
+    unchanged = old_by_key.keys() & new_by_key.keys()
+    dels_by_table_id = {}
+    for key, addmod in old_by_key.items():
+        if key in unchanged:
+            continue
+        dels_by_table_id.setdefault(addmod.table_id, []).append(addmod)
+    flowdels = []
+    for table_id, group in dels_by_table_id.items():
+        table = table_lookup(table_id)
+        if table is None:
+            if logger is not None:
+                logger.warning(
+                    "diff_addmods: no table for id %s; dropping %d flowdels "
+                    "(stale flows may remain on the wire)" % (table_id, len(group))
+                )
+            continue
+        flowdels.extend(
+            table.flowdel(
+                match=addmod.match,
+                priority=addmod.priority,
+                cookie=addmod.cookie,
+                strict=True,
+            )
+            for addmod in group
+        )
+    flowmods = [m for key, m in new_by_key.items() if key not in unchanged]
+    flowmods.extend(new_non_flowmods)
+    return flowdels, flowmods
+
+
 class ValveAclManager(ValveManagerBase):
     """Handle installation of ACLs on a DP"""
 
@@ -477,6 +520,17 @@ class ValveAclManager(ValveManagerBase):
     def _port_acls_allowed(self, port):
         return not self.dp_acls and not port.output_only and self.port_acl_table
 
+    def table_for_id(self, table_id):
+        """Return whichever ACL table (port, vlan, egress) has the given id."""
+        for table in (
+            self.port_acl_table,
+            self.vlan_acl_table,
+            self.egress_acl_table,
+        ):
+            if table is not None and table.table_id == table_id:
+                return table
+        return None
+
     def add_port(self, port):
         """Install port acls if configured"""
         ofmsgs = []
@@ -512,14 +566,6 @@ class ValveAclManager(ValveManagerBase):
         if self._port_acls_allowed(port):
             in_port_match = self.port_acl_table.match(in_port=port.number)
             ofmsgs.append(self.port_acl_table.flowdel(in_port_match, self.acl_priority))
-        return ofmsgs
-
-    def cold_start_port(self, port):
-        """Reload acl for a port by deleting existing rules and calling
-        add_port"""
-        ofmsgs = []
-        ofmsgs.extend(self.del_port(port))
-        ofmsgs.extend(self.add_port(port))
         return ofmsgs
 
     def del_vlan(self, vlan):

--- a/faucet/valve_of.py
+++ b/faucet/valve_of.py
@@ -1143,7 +1143,25 @@ def _partition_ofmsgs(input_ofmsgs):
 
 
 def _flowmodkey(ofmsg):
-    return (ofmsg.match, ofmsg.cookie, ofmsg.priority, ofmsg.table_id)
+    # Canonicalises match contents (frozenset of items) and instructions
+    # (tuple of str). OFPMatch and OFPInstruction both fall back to
+    # identity __eq__, so the prior key shape (ofmsg.match, ...) treated
+    # two semantically-identical flowmods built in different call chains
+    # as distinct -- silently breaking dedup and overlap-cancellation.
+    # Including instructions also matters for diff_addmods: an ACL rule
+    # whose match is unchanged but whose action flipped (allow:0 ->
+    # allow:1) would otherwise look identical to its old form and leave
+    # the old action on the wire. Touching the global key (rather than
+    # introducing a diff-only key) so the same canonicalisation applies
+    # everywhere flowmod equality matters -- dedup, overlap cancellation,
+    # and the diff path -- with one definition.
+    return (
+        frozenset(ofmsg.match.items()),
+        ofmsg.cookie,
+        ofmsg.priority,
+        ofmsg.table_id,
+        tuple(str(inst) for inst in ofmsg.instructions),
+    )
 
 
 def _none_flowmodkey(ofmsg):

--- a/faucet/valve_pipeline.py
+++ b/faucet/valve_pipeline.py
@@ -226,6 +226,16 @@ class ValvePipeline(ValveManagerBase):
             )
         ]
 
+    def remove_select(self, match_dict, priority_offset=0):
+        """Remove a select_packets rule from the classification table."""
+        return [
+            self.classification_table.flowdel(
+                self.classification_table.match(**match_dict),
+                priority=self.select_priority + priority_offset,
+                strict=True,
+            )
+        ]
+
     def remove_filter(self, match_dict, strict=True, priority_offset=0):
         """retrieve flow mods to remove a filter from the classification table"""
         priority = None

--- a/faucet/valve_route.py
+++ b/faucet/valve_route.py
@@ -489,6 +489,9 @@ class ValveRouteManager(ValveManagerBase):
     def _add_faucet_vip_nd(self, vlan, priority, faucet_vip, faucet_vip_host):
         raise NotImplementedError  # pragma: no cover
 
+    def _del_faucet_vip_nd(self, vlan, faucet_vip):
+        raise NotImplementedError  # pragma: no cover
+
     def add_vlan(self, vlan, cold_start):
         """Add a VLAN."""
         ofmsgs = []
@@ -508,8 +511,22 @@ class ValveRouteManager(ValveManagerBase):
     def del_vlan(self, vlan):
         """Delete a VLAN."""
         ofmsgs = []
-        if vlan.faucet_vips_by_ipv:
-            ofmsgs.append(self.fib_table.flowdel(match=self.fib_table.match(vlan=vlan)))
+        if vlan.faucet_vips_by_ipv(self.IPV):
+            # Remove select_packets for IP-to-faucet-mac (mirrors _add_faucet_fib_to_vip)
+            ofmsgs.extend(
+                self.pipeline.remove_select(
+                    {
+                        "eth_type": self.ETH_TYPE,
+                        "eth_dst": vlan.faucet_mac,
+                        "vlan": vlan,
+                    }
+                )
+            )
+        for faucet_vip in vlan.faucet_vips_by_ipv(self.IPV):
+            # Remove select_packets for ND/ARP (mirrors _add_faucet_vip_nd)
+            ofmsgs.extend(self._del_faucet_vip_nd(vlan, faucet_vip))
+        # Remove FIB table flows for this VLAN
+        ofmsgs.append(self.fib_table.flowdel(match=self.fib_table.match(vlan=vlan)))
         return ofmsgs
 
     def _add_resolved_route(self, vlan, ip_gw, ip_dst, eth_dst, is_updated):
@@ -1003,6 +1020,12 @@ class ValveIPv4RouteManager(ValveRouteManager):
     def _vlan_nexthop_cache_limit(self, vlan):
         return vlan.proactive_arp_limit
 
+    def _del_faucet_vip_nd(self, vlan, faucet_vip):
+        # Remove select_packets for ARP (mirrors _add_faucet_vip_nd)
+        return self.pipeline.remove_select(
+            {"eth_type": valve_of.ether.ETH_TYPE_ARP, "vlan": vlan}
+        )
+
     def _add_faucet_vip_nd(self, vlan, priority, faucet_vip, faucet_vip_host):
         ofmsgs = []
         # ARP
@@ -1167,6 +1190,34 @@ class ValveIPv6RouteManager(ValveRouteManager):
 
     def _vlan_nexthop_cache_limit(self, vlan):
         return vlan.proactive_nd_limit
+
+    def _del_faucet_vip_nd(self, vlan, faucet_vip):
+        ofmsgs = []
+        faucet_vip_host_nd_mcast = valve_packet.ipv6_link_eth_mcast(
+            valve_packet.ipv6_solicited_node_from_ucast(faucet_vip.ip)
+        )
+        # Remove select_packets for router solicitation (link-local only)
+        if faucet_vip.ip.is_link_local:
+            ofmsgs.extend(
+                self.pipeline.remove_select(
+                    {
+                        "eth_type": self.ETH_TYPE,
+                        "eth_dst": valve_packet.IPV6_ALL_ROUTERS_MCAST,
+                        "vlan": vlan,
+                    }
+                )
+            )
+        # Remove select_packets for ND solicitation
+        ofmsgs.extend(
+            self.pipeline.remove_select(
+                {
+                    "eth_type": self.ETH_TYPE,
+                    "eth_dst": faucet_vip_host_nd_mcast,
+                    "vlan": vlan,
+                }
+            )
+        )
+        return ofmsgs
 
     def _add_faucet_vip_nd(self, vlan, priority, faucet_vip, faucet_vip_host):
         faucet_vip_host_nd_mcast = valve_packet.ipv6_link_eth_mcast(

--- a/faucet/valve_table.py
+++ b/faucet/valve_table.py
@@ -268,9 +268,18 @@ class ValveTable:  # pylint: disable=too-many-arguments,too-many-instance-attrib
         return flowmod
 
     def flowdel(
-        self, match=None, priority=None, out_port=valve_of.ofp.OFPP_ANY, strict=False
+        self,
+        match=None,
+        priority=None,
+        out_port=valve_of.ofp.OFPP_ANY,
+        strict=False,
+        cookie=None,
     ):
-        """Delete matching flows from a table."""
+        """Delete matching flows from a table.
+
+        cookie is for the python-level overlap check in valve_flowreorder
+        only; OF-level deletion ignores cookie at cookie_mask=0.
+        """
         command = valve_of.ofp.OFPFC_DELETE
         if strict:
             command = valve_of.ofp.OFPFC_DELETE_STRICT
@@ -280,6 +289,7 @@ class ValveTable:  # pylint: disable=too-many-arguments,too-many-instance-attrib
             command=command,
             out_port=out_port,
             out_group=valve_of.ofp.OFPG_ANY,
+            cookie=cookie,
         )
 
     def flowdrop(self, match=None, priority=None, hard_timeout=0):

--- a/tests/integration/mininet_tests.py
+++ b/tests/integration/mininet_tests.py
@@ -3297,7 +3297,7 @@ acls:
             new_yaml_acl_conf,
             self.acl_config_file,  # pytype: disable=attribute-error
             restart=True,
-            cold_start=True,
+            cold_start=False,
         )
         self.wait_until_matching_flow({"dl_type": 0x800}, table_id=self._VLAN_ACL_TABLE)
         self.wait_until_matching_flow({"dl_type": 0x806}, table_id=self._VLAN_ACL_TABLE)
@@ -3307,7 +3307,7 @@ acls:
             orig_yaml_acl_conf,
             self.acl_config_file,  # pytype: disable=attribute-error
             restart=True,
-            cold_start=True,
+            cold_start=False,
         )
         self.wait_until_matching_flow({"dl_type": 0x800}, table_id=self._VLAN_ACL_TABLE)
         self.wait_until_no_matching_flow(
@@ -3788,6 +3788,42 @@ class FaucetRouterConfigReloadTest(FaucetConfigReloadTestBase):
         )
 
 
+class FaucetVIPChangeWarmStartTest(FaucetConfigReloadTestBase):
+    """Changing only a VLAN's VIP must warm-restart even when the VLAN owns
+    every port on the DP."""
+
+    CONFIG_GLOBAL = """
+vlans:
+    100:
+        description: "office"
+        faucet_vips: ["10.0.0.254/24"]
+        faucet_mac: "00:00:00:00:00:11"
+"""
+    CONFIG = """
+        interfaces:
+            %(port_1)d:
+                native_vlan: 100
+            %(port_2)d:
+                native_vlan: 100
+            %(port_3)d:
+                native_vlan: 100
+            %(port_4)d:
+                native_vlan: 100
+"""
+
+    def test_change_vip_warm_restart(self):
+        self.ping_all_when_learned()
+        conf = self._get_faucet_conf()
+        conf["vlans"][100]["faucet_vips"] = ["10.0.0.253/24"]
+        self.reload_conf(
+            conf,
+            self.faucet_config_path,
+            restart=True,
+            cold_start=False,
+            change_expected=True,
+        )
+
+
 class FaucetConfigReloadAclTest(FaucetConfigReloadTestBase):
     CONFIG = """
         interfaces:
@@ -3862,6 +3898,146 @@ class FaucetConfigReloadMACFlushTest(FaucetConfigReloadTestBase):
             actions=["SET_FIELD: {vlan_vid:4296}"],
         )
         self.assertLess(len(self.scrape_prometheus(var="learned_l2_port")), 4)
+
+
+class FaucetConfigReloadVlanAclChangeTest(FaucetConfigReloadTestBase):
+    """Granular warm-reload of a VLAN ACL: changing one rule inside an
+    ACL referenced by a VLAN should leave all other VLAN flows
+    untouched and only churn the changed rule's flow."""
+
+    CONFIG_GLOBAL = """
+vlans:
+    100:
+        description: "office network"
+        acls_in: [vlan-block-icmp]
+"""
+    ACL = """
+acls:
+    vlan-block-icmp:
+        - rule:
+            dl_type: 0x800
+            ip_proto: 1
+            actions:
+                allow: 0
+        - rule:
+            actions:
+                allow: 1
+"""
+    CONFIG = """
+        interfaces:
+            %(port_1)d:
+                native_vlan: 100
+            %(port_2)d:
+                native_vlan: 100
+            %(port_3)d:
+                native_vlan: 100
+            %(port_4)d:
+                native_vlan: 100
+"""
+
+    NEW_ACL = """
+acls:
+    vlan-block-icmp:
+        - rule:
+            dl_type: 0x800
+            ip_proto: 1
+            actions:
+                allow: 0
+        - rule:
+            dl_type: 0x806
+            actions:
+                allow: 0
+        - rule:
+            actions:
+                allow: 1
+"""
+
+    def test_vlan_acl_warm_reload(self):
+        self.wait_until_matching_flow(
+            {"dl_type": 0x800, "ip_proto": 1},
+            table_id=self._VLAN_ACL_TABLE,
+        )
+
+        new_yaml_acl_conf = yaml_load(self.NEW_ACL)
+        self.reload_conf(
+            new_yaml_acl_conf,
+            self.acl_config_file,  # pytype: disable=attribute-error
+            restart=True,
+            cold_start=False,
+        )
+
+        self.wait_until_matching_flow(
+            {"dl_type": 0x800, "ip_proto": 1},
+            table_id=self._VLAN_ACL_TABLE,
+        )
+        self.wait_until_matching_flow(
+            {"dl_type": 0x806},
+            table_id=self._VLAN_ACL_TABLE,
+        )
+
+
+class FaucetConfigReloadPortAclRemoveTest(FaucetConfigReloadTestBase):
+    CONFIG_GLOBAL = """
+vlans:
+    100:
+        description: "office network"
+"""
+    ACL = """
+acls:
+    block-ssl:
+        - rule:
+            dl_type: 0x800
+            ip_proto: 6
+            tcp_dst: 443
+            actions:
+                allow: 0
+    block-http:
+        - rule:
+            dl_type: 0x800
+            ip_proto: 6
+            tcp_dst: 80
+            actions:
+                allow: 0
+    block-ping:
+        - rule:
+            dl_type: 0x800
+            ip_proto: 1
+            actions:
+                allow: 0
+"""
+    CONFIG = """
+        interfaces:
+            %(port_1)d:
+                native_vlan: 100
+                acls_in: [block-ping]
+            %(port_2)d:
+                native_vlan: 100
+                acls_in: [block-ping, block-http, block-ssl]
+            %(port_3)d:
+                native_vlan: 100
+"""
+
+    def test_remove_port_acl(self):
+        hup = not self.STAT_RELOAD
+        in_port_2_match = {
+            "in_port": int(self.port_map["port_2"]),
+            "eth_type": 0x800,
+            "ip_proto": 1,
+        }
+        self.wait_until_matching_flow(in_port_2_match, table_id=self._PORT_ACL_TABLE)
+
+        self.change_port_config(
+            self.port_map["port_2"],
+            "acls_in",
+            ["block-http", "block-ssl"],
+            restart=True,
+            cold_start=False,
+            hup=hup,
+        )
+
+        self.wait_until_no_matching_flow(
+            in_port_2_match, table_id=self._PORT_ACL_TABLE, timeout=30
+        )
 
 
 class FaucetConfigReloadEmptyAclTest(FaucetConfigReloadTestBase):

--- a/tests/unit/faucet/test_valve_config.py
+++ b/tests/unit/faucet/test_valve_config.py
@@ -23,12 +23,15 @@
 from functools import partial
 import copy
 import hashlib
+import os
 import unittest
 import time
 
 from os_ken.ofproto import ofproto_v1_3 as ofp
 
+from faucet import config_parser
 from faucet import config_parser_util
+from faucet import valve_acl
 from faucet import valve_of
 
 from clib.fakeoftable import CONTROLLER_PORT
@@ -186,7 +189,796 @@ dps:
 
     def test_change_vlan_acl(self):
         """Test vlan ACL change is detected."""
-        self.update_and_revert_config(self.CONFIG, self.MORE_CONFIG, "cold")
+        self.update_and_revert_config(self.CONFIG, self.MORE_CONFIG, "warm")
+
+
+class ValveRemovePortAclWarmStartTestCase(ValveTestBases.ValveTestNetwork):
+    """Removing all ACLs from a port warm-restarts and clears the
+    per-port ACL flows (no stale block-ping flow remaining)."""
+
+    CONFIG = (
+        """
+acls:
+    block-ping:
+        - rule:
+            dl_type: 0x800
+            ip_proto: 1
+            actions:
+                allow: 0
+vlans:
+    office:
+        vid: 100
+dps:
+    s1:
+%s
+        interfaces:
+            1:
+                native_vlan: office
+                acls_in: [block-ping]
+            2:
+                native_vlan: office
+                acls_in: [block-ping]
+"""
+        % DP1_CONFIG
+    )
+
+    REMOVE_ACL_CONFIG = (
+        """
+acls:
+    block-ping:
+        - rule:
+            dl_type: 0x800
+            ip_proto: 1
+            actions:
+                allow: 0
+vlans:
+    office:
+        vid: 100
+dps:
+    s1:
+%s
+        interfaces:
+            1:
+                native_vlan: office
+                acls_in: [block-ping]
+            2:
+                native_vlan: office
+"""
+        % DP1_CONFIG
+    )
+
+    def setUp(self):
+        """Set up DP with two ports, both with the same port-level ACL."""
+        self.setup_valves(self.CONFIG)
+
+    def _port_acl_table_flows(self, port_num):
+        """Return all flows in port_acl_table that match in_port=port_num."""
+        valve = self.valves_manager.valves[self.DP_ID]
+        port_acl_table_id = valve.acl_manager.port_acl_table.table_id
+        ftes = self.network.tables[self.DP_ID].tables[port_acl_table_id]
+        results = []
+        for fte in ftes:
+            in_port_bits = fte.match_values.get("in_port")
+            if in_port_bits is None:
+                continue
+            try:
+                if int(in_port_bits.bin, 2) == port_num:
+                    results.append(fte)
+            except (AttributeError, ValueError):
+                pass
+        return results
+
+    def test_remove_port_acl(self):
+        """Removing port 2's ACL leaves no stale block-ping flow."""
+        port2_flows = self._port_acl_table_flows(2)
+        self.assertTrue(
+            any(
+                flow.match_values.get("ip_proto") is not None
+                and int(flow.match_values["ip_proto"].bin, 2) == 1
+                for flow in port2_flows
+            ),
+            "block-ping flow not present on port 2 before reload",
+        )
+
+        self.update_config(self.REMOVE_ACL_CONFIG, reload_type="warm")
+
+        port2_flows = self._port_acl_table_flows(2)
+        for flow in port2_flows:
+            ip_proto_bits = flow.match_values.get("ip_proto")
+            if ip_proto_bits is None:
+                continue
+            self.assertNotEqual(
+                int(ip_proto_bits.bin, 2),
+                1,
+                "stale block-ping flow remains on port 2 after warm reload: %s" % flow,
+            )
+
+
+class ValveAddPortAclToBarePortTestCase(ValveTestBases.ValveTestNetwork):
+    """Adding an ACL to a previously-bare port must warm-restart and
+    replace the default goto-vlan flow with the new ACL's flow."""
+
+    CONFIG = (
+        """
+acls:
+    block-ping:
+        - rule:
+            dl_type: 0x800
+            ip_proto: 1
+            actions:
+                allow: 0
+vlans:
+    office:
+        vid: 100
+dps:
+    s1:
+%s
+        interfaces:
+            1:
+                native_vlan: office
+                acls_in: [block-ping]
+            2:
+                native_vlan: office
+"""
+        % DP1_CONFIG
+    )
+
+    ADD_ACL_CONFIG = (
+        """
+acls:
+    block-ping:
+        - rule:
+            dl_type: 0x800
+            ip_proto: 1
+            actions:
+                allow: 0
+vlans:
+    office:
+        vid: 100
+dps:
+    s1:
+%s
+        interfaces:
+            1:
+                native_vlan: office
+                acls_in: [block-ping]
+            2:
+                native_vlan: office
+                acls_in: [block-ping]
+"""
+        % DP1_CONFIG
+    )
+
+    def setUp(self):
+        """Set up DP where port 1 has an ACL and port 2 does not."""
+        self.setup_valves(self.CONFIG)
+
+    def test_add_port_acl(self):
+        """Adding an ACL to a previously-bare port warm-restarts cleanly."""
+        self.update_and_revert_config(self.CONFIG, self.ADD_ACL_CONFIG, "warm")
+
+
+class ValveDiffAddmodsGroupModTestCase(unittest.TestCase):
+    """diff_addmods must tolerate OFPGroupMod entries in the addmod
+    list (produced by ACL rules with `failover` actions) instead of
+    AttributeError on .match / .cookie / etc. Group mods pass through
+    on the add side; old-side group mods are dropped."""
+
+    def test_groupmod_passthrough(self):
+        from os_ken.ofproto import (
+            ofproto_v1_3_parser as parser,
+        )  # pylint: disable=import-outside-toplevel
+
+        bucket = parser.OFPBucket(watch_port=1, actions=[parser.OFPActionOutput(1)])
+        group_add = parser.OFPGroupMod(
+            datapath=None,
+            command=ofp.OFPGC_ADD,
+            type_=ofp.OFPGT_FF,
+            group_id=42,
+            buckets=[bucket],
+        )
+        flow_add = parser.OFPFlowMod(
+            datapath=None,
+            cookie=0,
+            command=ofp.OFPFC_ADD,
+            table_id=0,
+            priority=100,
+            match=parser.OFPMatch(eth_type=0x800),
+            instructions=[],
+        )
+
+        dels, adds = valve_acl.diff_addmods(
+            lambda _tid: None,
+            old_addmods=[group_add, flow_add],
+            new_addmods=[group_add, flow_add],
+        )
+        # The group_add on new side flows through as an add; old side dropped.
+        self.assertIn(group_add, adds, "group mod should pass through as add")
+        self.assertEqual(
+            [],
+            dels,
+            "no flowdels expected when old and new are identical flows",
+        )
+
+
+class ValveGranularPortAclWarmReloadTestCase(ValveTestBases.ValveTestNetwork):
+    """Editing a single ACL rule emits one flowdel for the changed
+    rule's old form plus one flowmod for the new form. Unchanged rules
+    emit nothing (diff_addmods skips matching keys)."""
+
+    CONFIG = (
+        """
+acls:
+    multi-rule:
+        - rule:
+            dl_type: 0x800
+            ip_proto: 6
+            tcp_dst: 80
+            actions:
+                allow: 0
+        - rule:
+            dl_type: 0x800
+            ip_proto: 6
+            tcp_dst: 443
+            actions:
+                allow: 0
+        - rule:
+            dl_type: 0x800
+            ip_proto: 1
+            actions:
+                allow: 0
+        - rule:
+            actions:
+                allow: 1
+vlans:
+    office:
+        vid: 100
+dps:
+    s1:
+%s
+        interfaces:
+            1:
+                native_vlan: office
+                acls_in: [multi-rule]
+"""
+        % DP1_CONFIG
+    )
+
+    NEW_CONFIG = (
+        """
+acls:
+    multi-rule:
+        - rule:
+            dl_type: 0x800
+            ip_proto: 6
+            tcp_dst: 80
+            actions:
+                allow: 0
+        - rule:
+            dl_type: 0x800
+            ip_proto: 6
+            tcp_dst: 8080
+            actions:
+                allow: 0
+        - rule:
+            dl_type: 0x800
+            ip_proto: 1
+            actions:
+                allow: 0
+        - rule:
+            actions:
+                allow: 1
+vlans:
+    office:
+        vid: 100
+dps:
+    s1:
+%s
+        interfaces:
+            1:
+                native_vlan: office
+                acls_in: [multi-rule]
+"""
+        % DP1_CONFIG
+    )
+
+    def setUp(self):
+        """Set up DP with a port carrying a 4-rule ACL."""
+        self.setup_valves(self.CONFIG)
+
+    def test_granular_emits_old_dels_and_new_adds(self):
+        """Editing rule 2 emits exactly 1 flowdel for old rule 2 and 1
+        flowmod for new rule 2. Unchanged rules (tcp_dst=80, ip_proto=1,
+        default) emit nothing on either side -- the diff key for an
+        unchanged rule is identical between old and new addmod lists,
+        so diff_addmods skips it."""
+        valve = self.valves_manager.valves[self.DP_ID]
+        port_acl_table_id = valve.acl_manager.port_acl_table.table_id
+
+        self.update_config(self.NEW_CONFIG, reload_type="warm")
+
+        sent = self.last_flows_to_dp[self.DP_ID]
+        port_acl_msgs = [
+            msg
+            for msg in sent
+            if hasattr(msg, "table_id") and msg.table_id == port_acl_table_id
+        ]
+        old_rule2_dels = [
+            m
+            for m in port_acl_msgs
+            if m.command == ofp.OFPFC_DELETE_STRICT
+            and dict(m.match.items()).get("tcp_dst") == 443
+        ]
+        new_rule2_adds = [
+            m
+            for m in port_acl_msgs
+            if m.command == ofp.OFPFC_ADD
+            and dict(m.match.items()).get("tcp_dst") == 8080
+        ]
+        self.assertEqual(
+            1,
+            len(old_rule2_dels),
+            "expected exactly 1 flowdel for old rule 2 (tcp_dst=443)",
+        )
+        self.assertEqual(
+            1,
+            len(new_rule2_adds),
+            "expected exactly 1 flowmod for new rule 2 (tcp_dst=8080)",
+        )
+
+        # Unchanged rules: no flowmods or flowdels should reference them.
+        for unchanged_match in (
+            {"tcp_dst": 80},
+            {"ip_proto": 1, "tcp_dst": None},
+        ):
+            for msg in port_acl_msgs:
+                msg_match = dict(msg.match.items())
+                if "tcp_dst" in unchanged_match and unchanged_match["tcp_dst"] is None:
+                    if msg_match.get("ip_proto") == 1 and "tcp_dst" not in msg_match:
+                        self.fail(
+                            "unchanged ICMP rule emitted a flowmod/flowdel: %s" % msg
+                        )
+                elif msg_match.get("tcp_dst") == unchanged_match.get("tcp_dst"):
+                    self.fail(
+                        "unchanged rule (tcp_dst=%s) emitted a "
+                        "flowmod/flowdel: %s" % (unchanged_match["tcp_dst"], msg)
+                    )
+
+    def test_granular_reload_emits_only_delta(self):
+        """A 1-rule edit in a 4-rule ACL emits exactly 2 ofmsgs (1 del +
+        1 add) regardless of N. This property is what makes granular
+        reload viable for VLANs that carry hundreds of ACL rules: cost
+        scales with k (rules changed), not N (rules total)."""
+        valve = self.valves_manager.valves[self.DP_ID]
+        port_acl_table_id = valve.acl_manager.port_acl_table.table_id
+
+        self.update_config(self.NEW_CONFIG, reload_type="warm")
+
+        sent = self.last_flows_to_dp[self.DP_ID]
+        port_acl_msgs = [
+            msg
+            for msg in sent
+            if hasattr(msg, "table_id") and msg.table_id == port_acl_table_id
+        ]
+        self.assertEqual(
+            2,
+            len(port_acl_msgs),
+            "diff_addmods should emit exactly 1 del + 1 add for a "
+            "1-rule edit; got %d port_acl ofmsgs: %s"
+            % (len(port_acl_msgs), port_acl_msgs),
+        )
+
+
+class ValveAclActionOnlyChangeWarmReloadTestCase(ValveTestBases.ValveTestNetwork):
+    """When an ACL rule's match is unchanged but its action flips
+    (e.g. allow:0 -> allow:1), granular reload must still emit a
+    flowdel for the old form and a flowmod for the new. The diff key
+    must include instructions; otherwise the rule is mistakenly
+    considered unchanged and the old action stays on the wire.
+    Regression for FaucetStringOfDPACLOverrideTest."""
+
+    CONFIG = (
+        """
+acls:
+    override:
+        - rule:
+            dl_type: 0x800
+            ip_proto: 6
+            tcp_dst: 5001
+            actions:
+                allow: 0
+        - rule:
+            actions:
+                allow: 1
+vlans:
+    office:
+        vid: 100
+dps:
+    s1:
+%s
+        interfaces:
+            1:
+                native_vlan: office
+                acls_in: [override]
+"""
+        % DP1_CONFIG
+    )
+
+    NEW_CONFIG = (
+        """
+acls:
+    override:
+        - rule:
+            dl_type: 0x800
+            ip_proto: 6
+            tcp_dst: 5001
+            actions:
+                allow: 1
+        - rule:
+            actions:
+                allow: 1
+vlans:
+    office:
+        vid: 100
+dps:
+    s1:
+%s
+        interfaces:
+            1:
+                native_vlan: office
+                acls_in: [override]
+"""
+        % DP1_CONFIG
+    )
+
+    def setUp(self):
+        """Set up DP with a port-level ACL that blocks tcp_dst=5001."""
+        self.setup_valves(self.CONFIG)
+
+    def _tcp_dst_5001_inst(self):
+        """Return the instructions installed in port_acl_table for the
+        flow matching tcp_dst=5001. None if no such flow exists."""
+        valve = self.valves_manager.valves[self.DP_ID]
+        port_acl_table_id = valve.acl_manager.port_acl_table.table_id
+        ftes = self.network.tables[self.DP_ID].tables[port_acl_table_id]
+        for fte in ftes:
+            tcp_dst_bits = fte.match_values.get("tcp_dst")
+            if tcp_dst_bits is None:
+                continue
+            try:
+                if int(tcp_dst_bits.bin, 2) == 5001:
+                    return fte.instructions
+            except (AttributeError, ValueError):
+                pass
+        return None
+
+    def test_action_flip_takes_effect(self):
+        """The blocked rule (allow:0) installs no goto/apply-action
+        instructions; the allow rule (allow:1) installs at least one
+        instruction. After flipping the action, the on-wire flow's
+        instructions must reflect the NEW action -- otherwise the
+        granular reload silently kept the old action."""
+        before_inst = self._tcp_dst_5001_inst()
+        self.assertIsNotNone(before_inst, "blocked rule flow not installed")
+        before_inst_count = len(before_inst)
+
+        self.update_config(self.NEW_CONFIG, reload_type="warm")
+
+        after_inst = self._tcp_dst_5001_inst()
+        self.assertIsNotNone(after_inst, "rule flow disappeared after granular reload")
+        self.assertGreater(
+            len(after_inst),
+            before_inst_count,
+            "action flip allow:0 -> allow:1 did not change instructions; "
+            "granular reload missed the action change",
+        )
+
+    def test_action_flip_emits_one_add(self):
+        """Action-only change must emit exactly one OFPFC_ADD for the
+        changed rule's match -- the new rule's flowmod."""
+        valve = self.valves_manager.valves[self.DP_ID]
+        port_acl_table_id = valve.acl_manager.port_acl_table.table_id
+
+        self.update_config(self.NEW_CONFIG, reload_type="warm")
+
+        sent = self.last_flows_to_dp[self.DP_ID]
+        adds_for_5001 = [
+            msg
+            for msg in sent
+            if hasattr(msg, "table_id")
+            and msg.table_id == port_acl_table_id
+            and msg.command == ofp.OFPFC_ADD
+            and dict(msg.match.items()).get("tcp_dst") == 5001
+        ]
+        self.assertEqual(
+            1,
+            len(adds_for_5001),
+            "expected 1 flowmod for new action; got %d" % len(adds_for_5001),
+        )
+
+
+class ValveCombinedVlanAclAndConfigChangeTestCase(ValveTestBases.ValveTestNetwork):
+    """A VLAN with both ACL and non-ACL changes takes the heavy
+    reinstall path; granular ACL is skipped to avoid double-writing."""
+
+    CONFIG = (
+        """
+acls:
+    block-ping:
+        - rule:
+            dl_type: 0x800
+            ip_proto: 1
+            actions:
+                allow: 0
+vlans:
+    office:
+        vid: 100
+        description: "old"
+        acls_in: [block-ping]
+dps:
+    s1:
+%s
+        interfaces:
+            1:
+                native_vlan: office
+"""
+        % DP1_CONFIG
+    )
+
+    NEW_CONFIG = (
+        """
+acls:
+    block-ping:
+        - rule:
+            dl_type: 0x800
+            ip_proto: 1
+            actions:
+                allow: 0
+        - rule:
+            dl_type: 0x800
+            ip_proto: 6
+            actions:
+                allow: 1
+vlans:
+    office:
+        vid: 100
+        description: "new"
+        acls_in: [block-ping]
+        unicast_flood: false
+dps:
+    s1:
+%s
+        interfaces:
+            1:
+                native_vlan: office
+"""
+        % DP1_CONFIG
+    )
+
+    def setUp(self):
+        """Set up DP with one VLAN carrying an ACL."""
+        self.setup_valves(self.CONFIG)
+
+    def test_combined_change_takes_heavy_path(self):
+        """ACL+config combined VLAN change still warm-restarts cleanly."""
+        self.update_and_revert_config(self.CONFIG, self.NEW_CONFIG, "warm")
+
+
+class ValveVlanAclEgressChangeTestCase(ValveTestBases.ValveTestNetwork):
+    """Granular warm reload must handle VLAN egress ACL changes
+    (acls_out) the same as ingress (acls_in)."""
+
+    CONFIG = (
+        """
+acls:
+    egress-block:
+        - rule:
+            dl_type: 0x800
+            ip_proto: 1
+            actions:
+                allow: 0
+        - rule:
+            actions:
+                allow: 1
+vlans:
+    office:
+        vid: 100
+        acls_out: [egress-block]
+dps:
+    s1:
+%s
+        egress_pipeline: True
+        interfaces:
+            1:
+                native_vlan: office
+"""
+        % DP1_CONFIG
+    )
+
+    NEW_CONFIG = (
+        """
+acls:
+    egress-block:
+        - rule:
+            dl_type: 0x800
+            ip_proto: 1
+            actions:
+                allow: 0
+        - rule:
+            dl_type: 0x800
+            ip_proto: 17
+            actions:
+                allow: 0
+        - rule:
+            actions:
+                allow: 1
+vlans:
+    office:
+        vid: 100
+        acls_out: [egress-block]
+dps:
+    s1:
+%s
+        egress_pipeline: True
+        interfaces:
+            1:
+                native_vlan: office
+"""
+        % DP1_CONFIG
+    )
+
+    def setUp(self):
+        """Set up DP with VLAN egress ACL configured."""
+        self.setup_valves(self.CONFIG)
+
+    def _egress_acl_flows_with_ip_proto(self, ip_proto):
+        valve = self.valves_manager.valves[self.DP_ID]
+        egress_table_id = valve.acl_manager.egress_acl_table.table_id
+        ftes = self.network.tables[self.DP_ID].tables[egress_table_id]
+        results = []
+        for fte in ftes:
+            ip_proto_bits = fte.match_values.get("ip_proto")
+            if ip_proto_bits is None:
+                continue
+            try:
+                if int(ip_proto_bits.bin, 2) == ip_proto:
+                    results.append(fte)
+            except (AttributeError, ValueError):
+                pass
+        return results
+
+    def test_egress_acl_change(self):
+        """Editing rules of a VLAN egress ACL is warm-restartable."""
+        self.update_and_revert_config(self.CONFIG, self.NEW_CONFIG, "warm")
+
+    def test_egress_acl_new_rule_lands_in_egress_table(self):
+        """After adding a UDP-drop rule, the egress ACL table holds both
+        the unchanged ICMP flow and the new UDP flow."""
+        self.assertTrue(
+            self._egress_acl_flows_with_ip_proto(1),
+            "ICMP egress flow not present before reload",
+        )
+        self.assertFalse(
+            self._egress_acl_flows_with_ip_proto(17),
+            "UDP egress flow already present before reload",
+        )
+
+        self.update_config(self.NEW_CONFIG, reload_type="warm")
+
+        self.assertTrue(
+            self._egress_acl_flows_with_ip_proto(1),
+            "ICMP egress flow disappeared after granular warm reload",
+        )
+        self.assertTrue(
+            self._egress_acl_flows_with_ip_proto(17),
+            "UDP egress flow not installed after granular warm reload",
+        )
+
+
+class ValveVlanAclRuleRemovedWarmReloadTestCase(ValveTestBases.ValveTestNetwork):
+    """Granular VLAN ACL reload removes flows for rules dropped from
+    the new ACL -- not just additive. Symmetric to
+    ValveRemovePortAclWarmStartTestCase but for VLAN ACLs."""
+
+    CONFIG = (
+        """
+acls:
+    multi-rule:
+        - rule:
+            dl_type: 0x800
+            ip_proto: 1
+            actions:
+                allow: 0
+        - rule:
+            dl_type: 0x806
+            actions:
+                allow: 0
+        - rule:
+            actions:
+                allow: 1
+vlans:
+    office:
+        vid: 100
+        acls_in: [multi-rule]
+dps:
+    s1:
+%s
+        interfaces:
+            1:
+                native_vlan: office
+"""
+        % DP1_CONFIG
+    )
+
+    NEW_CONFIG = (
+        """
+acls:
+    multi-rule:
+        - rule:
+            dl_type: 0x800
+            ip_proto: 1
+            actions:
+                allow: 0
+        - rule:
+            actions:
+                allow: 1
+vlans:
+    office:
+        vid: 100
+        acls_in: [multi-rule]
+dps:
+    s1:
+%s
+        interfaces:
+            1:
+                native_vlan: office
+"""
+        % DP1_CONFIG
+    )
+
+    def setUp(self):
+        """Set up DP with a VLAN ACL containing an ARP-drop rule."""
+        self.setup_valves(self.CONFIG)
+
+    def _vlan_acl_flows_with_dl_type(self, dl_type):
+        valve = self.valves_manager.valves[self.DP_ID]
+        vlan_acl_table_id = valve.acl_manager.vlan_acl_table.table_id
+        ftes = self.network.tables[self.DP_ID].tables[vlan_acl_table_id]
+        results = []
+        for fte in ftes:
+            eth_type_bits = fte.match_values.get("eth_type")
+            if eth_type_bits is None:
+                continue
+            try:
+                if int(eth_type_bits.bin, 2) == dl_type:
+                    results.append(fte)
+            except (AttributeError, ValueError):
+                pass
+        return results
+
+    def test_removed_rule_flow_disappears(self):
+        """Dropping the ARP rule from the VLAN ACL must clear the
+        corresponding flow from vlan_acl_table; the ICMP rule stays."""
+        self.assertTrue(
+            self._vlan_acl_flows_with_dl_type(0x806),
+            "ARP rule's flow not present before reload",
+        )
+        self.assertTrue(
+            self._vlan_acl_flows_with_dl_type(0x800),
+            "ICMP rule's flow not present before reload",
+        )
+
+        self.update_config(self.NEW_CONFIG, reload_type="warm")
+
+        self.assertFalse(
+            self._vlan_acl_flows_with_dl_type(0x806),
+            "stale ARP rule flow remains in vlan_acl_table after granular reload",
+        )
+        self.assertTrue(
+            self._vlan_acl_flows_with_dl_type(0x800),
+            "ICMP rule's flow disappeared after granular reload "
+            "(should be unchanged)",
+        )
 
 
 class ValveChangePortTestCase(ValveTestBases.ValveTestNetwork):
@@ -585,6 +1377,785 @@ dps:
         verify_func()
         self.update_config(self.WARM_CONFIG, reload_type="warm")
         verify_func()
+
+
+class ValveChangeVIPWarmStartTestCase(ValveTestBases.ValveTestNetwork):
+    """Test changing VIP address on a VLAN is a warm start."""
+
+    CONFIG = (
+        """
+dps:
+    s1:
+%s
+        interfaces:
+            p1:
+                number: 1
+                native_vlan: 0x100
+            p2:
+                number: 2
+                native_vlan: 0x200
+vlans:
+    v100:
+        vid: 0x100
+        faucet_vips: ['10.0.0.254/24']
+    v200:
+        vid: 0x200
+        faucet_vips: ['10.0.1.254/24']
+routers:
+    router1:
+        vlans: [v100, v200]
+"""
+        % DP1_CONFIG
+    )
+
+    NEW_VIP_CONFIG = (
+        """
+dps:
+    s1:
+%s
+        interfaces:
+            p1:
+                number: 1
+                native_vlan: 0x100
+            p2:
+                number: 2
+                native_vlan: 0x200
+vlans:
+    v100:
+        vid: 0x100
+        faucet_vips: ['10.0.0.253/24']
+    v200:
+        vid: 0x200
+        faucet_vips: ['10.0.1.254/24']
+routers:
+    router1:
+        vlans: [v100, v200]
+"""
+        % DP1_CONFIG
+    )
+
+    def setUp(self):
+        self.setup_valves(self.CONFIG)
+
+    def test_change_vip(self):
+        """Test changing a VIP address is warm startable."""
+        self.update_and_revert_config(self.CONFIG, self.NEW_VIP_CONFIG, "warm")
+
+
+class ValveChangeVIPSingleVLANAllPortsWarmStartTestCase(
+    ValveTestBases.ValveTestNetwork
+):
+    """VIP change on a DP whose only VLAN owns every port must warm restart."""
+
+    CONFIG = (
+        """
+dps:
+    s1:
+%s
+        interfaces:
+            p1:
+                number: 1
+                native_vlan: office
+            p2:
+                number: 2
+                native_vlan: office
+vlans:
+    office:
+        vid: 100
+        faucet_vips: ['10.0.0.1/24']
+        faucet_mac: '00:00:00:00:00:11'
+"""
+        % DP1_CONFIG
+    )
+
+    NEW_VIP_CONFIG = (
+        """
+dps:
+    s1:
+%s
+        interfaces:
+            p1:
+                number: 1
+                native_vlan: office
+            p2:
+                number: 2
+                native_vlan: office
+vlans:
+    office:
+        vid: 100
+        faucet_vips: ['10.0.0.2/24']
+        faucet_mac: '00:00:00:00:00:11'
+"""
+        % DP1_CONFIG
+    )
+
+    def setUp(self):
+        self.setup_valves(self.CONFIG)
+
+    def test_change_vip(self):
+        """Test changing a VIP address with single VLAN owning all ports is warm."""
+        self.update_and_revert_config(self.CONFIG, self.NEW_VIP_CONFIG, "warm")
+
+
+class ValveChangeRouterWarmStartTestCase(ValveTestBases.ValveTestNetwork):
+    """Test changing router VLAN membership is a warm start."""
+
+    CONFIG = (
+        """
+dps:
+    s1:
+%s
+        interfaces:
+            p1:
+                number: 1
+                native_vlan: 0x100
+            p2:
+                number: 2
+                native_vlan: 0x200
+            p3:
+                number: 3
+                native_vlan: 0x300
+vlans:
+    v100:
+        vid: 0x100
+        faucet_vips: ['10.0.0.254/24']
+    v200:
+        vid: 0x200
+        faucet_vips: ['10.0.1.254/24']
+    v300:
+        vid: 0x300
+        faucet_vips: ['10.0.2.254/24']
+routers:
+    router1:
+        vlans: [v100, v200]
+"""
+        % DP1_CONFIG
+    )
+
+    NEW_ROUTER_CONFIG = (
+        """
+dps:
+    s1:
+%s
+        interfaces:
+            p1:
+                number: 1
+                native_vlan: 0x100
+            p2:
+                number: 2
+                native_vlan: 0x200
+            p3:
+                number: 3
+                native_vlan: 0x300
+vlans:
+    v100:
+        vid: 0x100
+        faucet_vips: ['10.0.0.254/24']
+    v200:
+        vid: 0x200
+        faucet_vips: ['10.0.1.254/24']
+    v300:
+        vid: 0x300
+        faucet_vips: ['10.0.2.254/24']
+routers:
+    router1:
+        vlans: [v100, v200, v300]
+"""
+        % DP1_CONFIG
+    )
+
+    def setUp(self):
+        self.setup_valves(self.CONFIG)
+
+    def test_change_router_membership(self):
+        """Test changing router VLAN membership is warm startable."""
+        self.update_and_revert_config(self.CONFIG, self.NEW_ROUTER_CONFIG, "warm")
+
+
+class ValveAddRouterWithNewVlanWarmStartTestCase(ValveTestBases.ValveTestNetwork):
+    """A router membership change that simultaneously adds a brand-new
+    VLAN must put the new VID in added_vlans only; the router-affected
+    expansion must not also place it in changed_vlans (otherwise the
+    valve.py reload path runs add_vlans for it twice)."""
+
+    CONFIG = (
+        """
+dps:
+    s1:
+%s
+        interfaces:
+            p1:
+                number: 1
+                tagged_vlans: [0x100, 0x200]
+            p2:
+                number: 2
+                tagged_vlans: [0x100, 0x200]
+vlans:
+    v100:
+        vid: 0x100
+        faucet_vips: ['10.0.0.254/24']
+    v200:
+        vid: 0x200
+        faucet_vips: ['10.0.1.254/24']
+routers:
+    router1:
+        vlans: [v100, v200]
+"""
+        % DP1_CONFIG
+    )
+
+    NEW_CONFIG = (
+        """
+dps:
+    s1:
+%s
+        interfaces:
+            p1:
+                number: 1
+                tagged_vlans: [0x100, 0x200, 0x300]
+            p2:
+                number: 2
+                tagged_vlans: [0x100, 0x200, 0x300]
+vlans:
+    v100:
+        vid: 0x100
+        faucet_vips: ['10.0.0.254/24']
+    v200:
+        vid: 0x200
+        faucet_vips: ['10.0.1.254/24']
+    v300:
+        vid: 0x300
+        faucet_vips: ['10.0.2.254/24']
+routers:
+    router1:
+        vlans: [v100, v200, v300]
+"""
+        % DP1_CONFIG
+    )
+
+    def setUp(self):
+        self.setup_valves(self.CONFIG)
+
+    def test_disjoint_added_and_changed(self):
+        """get_config_changes must return v300 in added_vlans only,
+        not in changed_vlans."""
+        new_dp = _parse_dp(self.tmpdir, "new.yaml", self.NEW_CONFIG)
+        old_dp = self.valves_manager.valves[self.DP_ID].dp
+        changes = old_dp.get_config_changes(
+            self.valves_manager.valves[self.DP_ID].logger, new_dp
+        )
+        self.assertIn(0x300, changes.added_vlans, "new VID should land in added_vlans")
+        self.assertNotIn(
+            0x300,
+            changes.changed_vlans,
+            "new VID must not also be in changed_vlans (would cause "
+            "redundant add_vlans pass)",
+        )
+
+
+class ValveRouterAclCombinedChangeDisjointnessTestCase(ValveTestBases.ValveTestNetwork):
+    """When a router-membership change pulls a VID into changed_vlans via
+    affected-VLAN expansion, and that same VID's only direct change is an
+    ACL ref, the VID must end up in changed_vlans only -- not also in
+    changed_acl_vlans -- otherwise the heavy reinstall path and the
+    granular ACL path both fire and double-emit ACL flows."""
+
+    CONFIG = (
+        """
+acls:
+    block-ping:
+        - rule:
+            dl_type: 0x800
+            ip_proto: 1
+            actions:
+                allow: 0
+vlans:
+    v100:
+        vid: 0x100
+        faucet_vips: ['10.0.0.254/24']
+        acls_in: [block-ping]
+    v200:
+        vid: 0x200
+        faucet_vips: ['10.0.1.254/24']
+dps:
+    s1:
+%s
+        interfaces:
+            p1:
+                number: 1
+                tagged_vlans: [0x100, 0x200]
+            p2:
+                number: 2
+                tagged_vlans: [0x100, 0x200]
+routers:
+    router1:
+        vlans: [v100]
+"""
+        % DP1_CONFIG
+    )
+
+    NEW_CONFIG = (
+        """
+acls:
+    block-ping:
+        - rule:
+            dl_type: 0x800
+            ip_proto: 1
+            actions:
+                allow: 0
+        - rule:
+            dl_type: 0x800
+            ip_proto: 6
+            actions:
+                allow: 0
+vlans:
+    v100:
+        vid: 0x100
+        faucet_vips: ['10.0.0.254/24']
+        acls_in: [block-ping]
+    v200:
+        vid: 0x200
+        faucet_vips: ['10.0.1.254/24']
+dps:
+    s1:
+%s
+        interfaces:
+            p1:
+                number: 1
+                tagged_vlans: [0x100, 0x200]
+            p2:
+                number: 2
+                tagged_vlans: [0x100, 0x200]
+routers:
+    router1:
+        vlans: [v100, v200]
+"""
+        % DP1_CONFIG
+    )
+
+    def setUp(self):
+        self.setup_valves(self.CONFIG)
+
+    def test_router_expansion_does_not_violate_disjointness(self):
+        new_dp = _parse_dp(self.tmpdir, "router_acl.yaml", self.NEW_CONFIG)
+        old_dp = self.valves_manager.valves[self.DP_ID].dp
+        changes = old_dp.get_config_changes(
+            self.valves_manager.valves[self.DP_ID].logger, new_dp
+        )
+        # Router membership expanded changed_vlans to include v100; v100 was
+        # also flagged as ACL-only. Disjointness must put it in the heavy
+        # path only.
+        self.assertIn(0x100, changes.changed_vlans, "router-affected VID missing")
+        self.assertNotIn(
+            0x100,
+            changes.changed_acl_vlans,
+            "VID is in BOTH changed_vlans (heavy reinstall) and "
+            "changed_acl_vlans (granular reload); both paths would fire "
+            "and double-emit ACL flows",
+        )
+
+
+def _parse_dp(tmpdir, filename, config):
+    """Parse `config` to a DP via dp_parser, using a temp file under tmpdir."""
+    path = os.path.join(tmpdir, filename)
+    with open(path, "w", encoding="utf-8") as fh:
+        fh.write(config)
+    _, _, dps, _ = config_parser.dp_parser(path, "test")
+    return dps[0]
+
+
+class ValveRemoveVIPWarmStartTestCase(ValveTestBases.ValveTestNetwork):
+    """Test removing VIPs from a VLAN is a warm start (when routing tables remain)."""
+
+    CONFIG = (
+        """
+dps:
+    s1:
+%s
+        interfaces:
+            p1:
+                number: 1
+                native_vlan: 0x100
+            p2:
+                number: 2
+                native_vlan: 0x200
+vlans:
+    v100:
+        vid: 0x100
+        faucet_vips: ['10.0.0.254/24']
+    v200:
+        vid: 0x200
+        faucet_vips: ['10.0.1.254/24']
+routers:
+    router1:
+        vlans: [v100, v200]
+"""
+        % DP1_CONFIG
+    )
+
+    LESS_VIP_CONFIG = (
+        """
+dps:
+    s1:
+%s
+        interfaces:
+            p1:
+                number: 1
+                native_vlan: 0x100
+            p2:
+                number: 2
+                native_vlan: 0x200
+vlans:
+    v100:
+        vid: 0x100
+        faucet_vips: ['10.0.0.254/24']
+    v200:
+        vid: 0x200
+routers:
+    router1:
+        vlans: [v100]
+"""
+        % DP1_CONFIG
+    )
+
+    def setUp(self):
+        self.setup_valves(self.CONFIG)
+
+    def test_remove_vip(self):
+        """Test removing VIPs from a VLAN is warm startable."""
+        self.update_and_revert_config(self.CONFIG, self.LESS_VIP_CONFIG, "warm")
+
+
+class ValveDeleteRoutedVLANTestCase(ValveTestBases.ValveTestNetwork):
+    """Test deleting a VLAN referenced by a router doesn't crash."""
+
+    CONFIG = (
+        """
+dps:
+    s1:
+%s
+        interfaces:
+            p1:
+                number: 1
+                native_vlan: 0x100
+            p2:
+                number: 2
+                native_vlan: 0x200
+            p3:
+                number: 3
+                native_vlan: 0x300
+vlans:
+    v100:
+        vid: 0x100
+        faucet_vips: ['10.0.0.254/24']
+    v200:
+        vid: 0x200
+        faucet_vips: ['10.0.1.254/24']
+    v300:
+        vid: 0x300
+        faucet_vips: ['10.0.2.254/24']
+routers:
+    router1:
+        vlans: [v100, v200, v300]
+"""
+        % DP1_CONFIG
+    )
+
+    DELETE_VLAN_CONFIG = (
+        """
+dps:
+    s1:
+%s
+        interfaces:
+            p1:
+                number: 1
+                native_vlan: 0x100
+            p2:
+                number: 2
+                native_vlan: 0x200
+vlans:
+    v100:
+        vid: 0x100
+        faucet_vips: ['10.0.0.254/24']
+    v200:
+        vid: 0x200
+        faucet_vips: ['10.0.1.254/24']
+routers:
+    router1:
+        vlans: [v100, v200]
+"""
+        % DP1_CONFIG
+    )
+
+    def setUp(self):
+        self.setup_valves(self.CONFIG)
+
+    def test_delete_routed_vlan(self):
+        """Test deleting a VLAN referenced by a router doesn't crash."""
+        self.update_and_revert_config(self.CONFIG, self.DELETE_VLAN_CONFIG, "cold")
+
+
+class ValveChangeIPv6VIPWarmStartTestCase(ValveTestBases.ValveTestNetwork):
+    """Test changing an IPv6 VIP is a warm start."""
+
+    CONFIG = (
+        """
+dps:
+    s1:
+%s
+        interfaces:
+            p1:
+                number: 1
+                native_vlan: 0x100
+            p2:
+                number: 2
+                native_vlan: 0x200
+vlans:
+    v100:
+        vid: 0x100
+        faucet_vips: ['fc00::1:254/112', 'fe80::1:254/64']
+    v200:
+        vid: 0x200
+        faucet_vips: ['fc00::2:254/112', 'fe80::2:254/64']
+routers:
+    router1:
+        vlans: [v100, v200]
+"""
+        % DP1_CONFIG
+    )
+
+    NEW_VIP_CONFIG = (
+        """
+dps:
+    s1:
+%s
+        interfaces:
+            p1:
+                number: 1
+                native_vlan: 0x100
+            p2:
+                number: 2
+                native_vlan: 0x200
+vlans:
+    v100:
+        vid: 0x100
+        faucet_vips: ['fc00::1:253/112', 'fe80::1:254/64']
+    v200:
+        vid: 0x200
+        faucet_vips: ['fc00::2:254/112', 'fe80::2:254/64']
+routers:
+    router1:
+        vlans: [v100, v200]
+"""
+        % DP1_CONFIG
+    )
+
+    def setUp(self):
+        self.setup_valves(self.CONFIG)
+
+    def test_change_ipv6_vip(self):
+        """Test changing an IPv6 VIP address is warm startable."""
+        self.update_and_revert_config(self.CONFIG, self.NEW_VIP_CONFIG, "warm")
+
+
+class ValveAddRouterWithExistingVipsWarmStartTestCase(ValveTestBases.ValveTestNetwork):
+    """Adding a router when VLANs already have VIPs warm-restarts.
+    The "no existing routing tables" cold-start gate must NOT fire when
+    any OLD VLAN already has faucet_vips configured."""
+
+    CONFIG = (
+        """
+dps:
+    s1:
+%s
+        interfaces:
+            p1:
+                number: 1
+                native_vlan: 0x100
+            p2:
+                number: 2
+                native_vlan: 0x200
+vlans:
+    v100:
+        vid: 0x100
+        faucet_vips: ['10.0.0.254/24']
+    v200:
+        vid: 0x200
+        faucet_vips: ['10.0.1.254/24']
+"""
+        % DP1_CONFIG
+    )
+
+    ADD_ROUTER_CONFIG = (
+        """
+dps:
+    s1:
+%s
+        interfaces:
+            p1:
+                number: 1
+                native_vlan: 0x100
+            p2:
+                number: 2
+                native_vlan: 0x200
+vlans:
+    v100:
+        vid: 0x100
+        faucet_vips: ['10.0.0.254/24']
+    v200:
+        vid: 0x200
+        faucet_vips: ['10.0.1.254/24']
+routers:
+    router1:
+        vlans: [v100, v200]
+"""
+        % DP1_CONFIG
+    )
+
+    def setUp(self):
+        self.setup_valves(self.CONFIG)
+
+    def test_add_router_with_existing_vips(self):
+        self.update_and_revert_config(self.CONFIG, self.ADD_ROUTER_CONFIG, "warm")
+
+
+class ValveAddRouterNoVipsColdStartTestCase(ValveTestBases.ValveTestNetwork):
+    """Adding a router when no VLAN has VIPs must cold-restart.
+    The "no existing routing tables" gate exists because routing
+    infrastructure (FIB tables, VIP select_packets flows) has to be
+    built from scratch on first introduction."""
+
+    CONFIG = (
+        """
+dps:
+    s1:
+%s
+        interfaces:
+            p1:
+                number: 1
+                native_vlan: 0x100
+            p2:
+                number: 2
+                native_vlan: 0x200
+vlans:
+    v100:
+        vid: 0x100
+    v200:
+        vid: 0x200
+"""
+        % DP1_CONFIG
+    )
+
+    ADD_ROUTER_CONFIG = (
+        """
+dps:
+    s1:
+%s
+        interfaces:
+            p1:
+                number: 1
+                native_vlan: 0x100
+            p2:
+                number: 2
+                native_vlan: 0x200
+vlans:
+    v100:
+        vid: 0x100
+        faucet_vips: ['10.0.0.254/24']
+    v200:
+        vid: 0x200
+        faucet_vips: ['10.0.1.254/24']
+routers:
+    router1:
+        vlans: [v100, v200]
+"""
+        % DP1_CONFIG
+    )
+
+    def setUp(self):
+        self.setup_valves(self.CONFIG)
+
+    def test_add_router_no_old_vips(self):
+        self.update_and_revert_config(self.CONFIG, self.ADD_ROUTER_CONFIG, "cold")
+
+
+class ValveBGPColdStartTestCase(ValveTestBases.ValveTestNetwork):
+    """Test that BGP config changes still trigger cold start."""
+
+    CONFIG = (
+        """
+dps:
+    s1:
+%s
+        interfaces:
+            p1:
+                number: 1
+                native_vlan: 0x100
+            p2:
+                number: 2
+                native_vlan: 0x200
+vlans:
+    v100:
+        vid: 0x100
+        faucet_vips: ['10.0.0.254/24']
+    v200:
+        vid: 0x200
+routers:
+    router1:
+        vlans: [v100, v200]
+        bgp:
+            as: 1
+            connect_mode: passive
+            neighbor_addresses: ['127.0.0.1']
+            neighbor_as: 2
+            port: 9179
+            routerid: '1.1.1.1'
+            server_addresses: ['127.0.0.1']
+            vlan: v100
+"""
+        % DP1_CONFIG
+    )
+
+    BGP_CHANGE_CONFIG = (
+        """
+dps:
+    s1:
+%s
+        interfaces:
+            p1:
+                number: 1
+                native_vlan: 0x100
+            p2:
+                number: 2
+                native_vlan: 0x200
+vlans:
+    v100:
+        vid: 0x100
+        faucet_vips: ['10.0.0.254/24']
+    v200:
+        vid: 0x200
+routers:
+    router1:
+        vlans: [v100, v200]
+        bgp:
+            as: 1
+            connect_mode: passive
+            neighbor_addresses: ['127.0.0.1']
+            neighbor_as: 3
+            port: 9179
+            routerid: '1.1.1.1'
+            server_addresses: ['127.0.0.1']
+            vlan: v100
+"""
+        % DP1_CONFIG
+    )
+
+    def setUp(self):
+        self.setup_valves(self.CONFIG)
+
+    def test_bgp_change_cold_start(self):
+        """Test that changing BGP config still requires cold start."""
+        self.update_and_revert_config(self.CONFIG, self.BGP_CHANGE_CONFIG, "cold")
 
 
 class ValveDeleteVLANTestCase(ValveTestBases.ValveTestNetwork):

--- a/tests/unit/faucet/test_valve_stack.py
+++ b/tests/unit/faucet/test_valve_stack.py
@@ -4046,12 +4046,11 @@ dps:
         for new_dp in new_dps:
             valve = self.valves_manager.valves[new_dp.dp_id]
             changes = valve.dp.get_config_changes(valve.logger, new_dp)
-            changed_ports, all_ports_changed = changes[1], changes[6]
             for port in valve.dp.stack_ports():
-                if not all_ports_changed:
+                if not changes.all_ports_changed:
                     self.assertIn(
                         port.number,
-                        changed_ports,
+                        changes.changed_ports,
                         "Stack port not detected as changed on topology change",
                     )
 
@@ -4082,11 +4081,10 @@ dps:
         for new_dp in new_dps:
             valve = self.valves_manager.valves[new_dp.dp_id]
             changed = valve.dp.get_config_changes(valve.logger, new_dp)
-            changed_ports = changed[1]
             for port in valve.dp.stack_ports():
                 self.assertNotIn(
                     port.number,
-                    changed_ports,
+                    changed.changed_ports,
                     "Stack port detected as changed on non-topology change",
                 )
 


### PR DESCRIPTION
## Summary

Changes to a VLAN's VIPs, router configuration, or ACL configuration currently force a cold restart — full datapath reconnection and a flow-table wipe. This is unnecessarily disruptive for deployments that update these dynamically (tenant provisioning, IPAM-driven VIP changes, dynamic router membership, ACL edits).

The warm-restart path (`del_vlan` + `dp_init` + `add_vlan`) already handles VLAN-level changes; two guards in `dp.py` were short-circuiting to cold, and ACL-only changes still went through `cold_start_port` which left stale flows on the wire. This PR removes the guards, fixes the cleanup, and replaces the ACL cold-start path with a diff-at-source granular reload that emits only changed rules — cost is O(k) where k = rules changed, regardless of total ACL size.

### What warm-starts now (previously cold)

| Scenario | Before | After |
|----------|--------|-------|
| Change VIP address on VLAN | Cold | **Warm** |
| Add/remove VIPs on existing VLAN (routing tables exist) | Cold | **Warm** |
| Change router VLAN membership (non-BGP) | Cold | **Warm** |
| Add/remove router (routing tables exist) | Cold | **Warm** |
| Add new VLAN with VIPs (OVS, routing tables exist) | Cold | **Warm** |
| Change a port's `acls_in` | Cold | **Warm** |
| Change a VLAN's `acls_in` / `acls_out` | Cold | **Warm** |
| Edit rules of an ACL referenced by a port or VLAN | Cold | **Warm** |

### What still cold-starts

- BGP config changes
- Router add/remove with no existing routing tables
- VID replacement when affected ports cover the DP
- Pipeline changes (e.g. first-ever VIP adds `ipv4_fib` / `vip` tables)
- TFM table-size changes (out of scope)
- All ports changed

### Scope rationale

VLAN/VIP and router warm-restart are inseparable: VIP changes must propagate to router-sibling VLANs for FIB consistency, and router membership changes drive the same VLAN reinstall plumbing. ACL warm-restart is technically a separable follow-up but rides the same `del_vlan / dp_init / add_vlan` infrastructure — absorbing it here (per offline thread with @gizmoguy) obsoletes #4733 in one merge instead of two.

`_flowmodkey` canonicalises match contents and instructions because OFPMatch and OFPInstruction fall back to identity `__eq__`. Without canonicalisation the OLD/NEW addmod snapshots wouldn't diff structurally, and an ACL rule whose action flipped (e.g. `allow:0 → allow:1`, same match) would look unchanged on the wire. The canonicalisation is global rather than a diff-only key so it applies everywhere flowmod equality matters (dedup, overlap-cancellation).

### Relation to #4733

This PR now incorporates #4733's goals. Instead of looping per-ACL with `del_port_acl` / `add_port_acl`, it snapshots the addmods that `add_port` / `add_vlan` would emit and diffs them — the priority/cookie scheme matches what cold-start install put on the table by construction, which the per-ACL helpers don't (they reset priority per-ACL). `FaucetConfigReloadPortAclRemoveTest` is included verbatim with `Co-Authored-By: hieunt79`. The stale-`block-ping` flow @gizmoguy reproduced is fixed.

If merged, #4733 can be closed.
