### PR TITLE
clib: integration-test reliability fixes (retry tmpdir, ofctl JSON, gauge baseline, OFP listener wait)

### DIFF
--- a/clib/mininet_test_base.py
+++ b/clib/mininet_test_base.py
@@ -427,6 +427,8 @@ class FaucetTestBase(unittest.TestCase):
 
     def _tmpdir_name(self):
         tmpdir = os.path.join(self.root_tmpdir, self._test_name())
+        if os.path.exists(tmpdir):
+            shutil.rmtree(tmpdir)
         os.mkdir(tmpdir)
         return tmpdir
 
@@ -862,7 +864,10 @@ class FaucetTestBase(unittest.TestCase):
             params = {}
         try:
             ofctl_result = requests.get(req, params=params).json()
-        except requests.exceptions.ConnectionError:
+        except (requests.exceptions.ConnectionError, ValueError):
+            # ValueError covers JSONDecodeError when the REST endpoint
+            # is up but answers with an empty/non-JSON body (e.g. during
+            # osken-manager startup). _ofctl_get retries on None.
             return None
         return ofctl_result
 
@@ -1603,7 +1608,16 @@ dbs:
             for port in ports_not_updated:
                 first = first_counters[port]
                 now = now_counters[port]
-                not_updated = [var for var, val in now.items() if val <= first[var]]
+                # first_counters is scraped tolerantly (assert_present=False), so a
+                # baseline var may still be None if the gauge watcher hadn't exported
+                # it before the wait loop above timed out. Treat a missing baseline as
+                # "not updated" so we keep polling and eventually return False (a clean
+                # caller-side failure) rather than raising TypeError on None <= int.
+                not_updated = [
+                    var
+                    for var, val in now.items()
+                    if first[var] is None or val <= first[var]
+                ]
                 if not_updated:
                     break
                 updated_ports.add(port)

--- a/clib/mininet_test_topo.py
+++ b/clib/mininet_test_topo.py
@@ -801,6 +801,22 @@ socket_timeout=15
         self.cached_ryu_pid = None
         self._start_tcpdump()
         super().start()
+        # ``net.start()`` will start the OVS switches the moment we
+        # return, and OVS connects to the controller immediately. If
+        # Faucet hasn't yet bound its OFP listener port the connect gets
+        # ECONNREFUSED and OVS falls into 1/2/4/8/16s exponential
+        # backoff retries -- 30s+ before the controller-ready check has
+        # any chance of seeing ESTABLISHED. Block here until the listener
+        # is up so the next switch.start() lands a clean SYN.
+        deadline = time.time() + 30
+        while time.time() < deadline:
+            if self.listening():
+                return
+            time.sleep(0.1)
+        error(
+            "controller %s not listening on port %u after 30s\n"
+            % (self.name, self.port)
+        )
 
     def _stop_cap(self):
         """Stop tcpdump for OF port."""


### PR DESCRIPTION
Four small, independent fixes to the integration-test harness that harden it against races exposed by the faster controller-startup waits landed in #4801 / #4804 / #4809. All are net additions; none change existing passing behaviour. These have been running in a downstream fork against the same test base for a while.

### `clib/mininet_test_base.py`

- **`_tmpdir_name`** — `rmtree` a stale per-test dir before `mkdir`. When a test is retried (e.g. after a flake), the second attempt currently dies in `setUp` with `FileExistsError: .../<TestName>` because the previous attempt's tmpdir still exists — so the retry that was supposed to recover the flake can never pass. Remove the stale dir first.

- **`_ofctl_get`** — also catch `ValueError` (i.e. `JSONDecodeError`). When the ofctl REST endpoint is up but answers with an empty/non-JSON body during osken-manager startup, `.json()` raises and aborts the test instead of being retried. `_ofctl_get` already retries on `None`, so return `None` here too.

- **`wait_ports_updating`** — the baseline counters are now scraped tolerantly (`assert_present=False`), so a baseline var can legitimately be `None` if the gauge watcher hadn't exported it before the wait loop timed out. The increase check then does `val <= first[var]` → `int <= None` → `TypeError`, crashing instead of failing cleanly. Treat a missing baseline as "not updated" so the function returns `False` and the caller reports the intended "counters not increasing" failure.

### `clib/mininet_test_topo.py`

- **`BaseFAUCET.start`** — after `super().start()`, block (≤30s) until the controller's OFP listener is actually up. Otherwise `net.start()` races the listener bind: OVS connects immediately, hits `ECONNREFUSED`, and falls into 1/2/4/8/16s exponential backoff — 30s+ before the controller-ready check can see `ESTABLISHED`.

### Testing

`black`/syntax clean. The full integration suite requires the privileged mininet/OVS test environment; CI will exercise it here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)