### PR TITLE
Fix deleting final ACL from a port

### DIFF
--- a/faucet/valve_acl.py
+++ b/faucet/valve_acl.py
@@ -511,7 +511,7 @@ class ValveAclManager(ValveManagerBase):
         ofmsgs = []
         if self._port_acls_allowed(port):
             in_port_match = self.port_acl_table.match(in_port=port.number)
-            ofmsgs.append(self.port_acl_table.flowdel(in_port_match, self.acl_priority))
+            ofmsgs.append(self.port_acl_table.flowdel(in_port_match))
         return ofmsgs
 
     def cold_start_port(self, port):

--- a/faucet/valve_of.py
+++ b/faucet/valve_of.py
@@ -1143,7 +1143,7 @@ def _partition_ofmsgs(input_ofmsgs):
 
 
 def _flowmodkey(ofmsg):
-    return (ofmsg.match, ofmsg.cookie, ofmsg.priority, ofmsg.table_id)
+    return (tuple(ofmsg.match.items()), ofmsg.cookie, ofmsg.priority, ofmsg.table_id)
 
 
 def _none_flowmodkey(ofmsg):

--- a/tests/unit/faucet/test_valve_config.py
+++ b/tests/unit/faucet/test_valve_config.py
@@ -721,6 +721,93 @@ dps:
         self.update_and_revert_config(self.CONFIG, self.MORE_CONFIG, "cold")
 
 
+class ValveAddACLTestCase(ValveTestBases.ValveTestNetwork):
+    """Test addition of an ACL to a port."""
+
+    ACLS = """
+    acl_a:
+      - rule:
+        eth_type: 0x0804
+        actions:
+          allow: 0
+      - rule:
+        actions:
+          allow: 1
+"""
+
+    CONFIG = """
+acls:
+%s
+dps:
+    s1:
+%s
+        interfaces:
+            p1:
+                number: 1
+                native_vlan: 0x100
+                acl_in: acl_a
+            p2:
+                number: 2
+                native_vlan: 0x200
+""" % (
+        ACLS,
+        DP1_CONFIG,
+    )
+
+    ADD_ACL_P2_CONFIG = """
+acls:
+%s
+dps:
+    s1:
+%s
+        interfaces:
+            p1:
+                number: 1
+                native_vlan: 0x100
+                acl_in: acl_a
+            p2:
+                number: 2
+                native_vlan: 0x200
+                acl_in: acl_a
+""" % (
+        ACLS,
+        DP1_CONFIG,
+    )
+
+    def setUp(self):
+        """Setup basic ACL config"""
+        self.setup_valves(self.CONFIG)
+
+    def test_add_port_acl(self):
+        """Test port ACL can be added."""
+        table = self.network.tables[self.DP_ID]
+
+        self.assertFalse(
+            table.is_output({"in_port": 1, "vlan_vid": 0, "eth_type": 0x0804}),
+            msg="Packet not blocked by ACL",
+        )
+        self.assertTrue(
+            table.is_output({"in_port": 2, "vlan_vid": 0, "eth_type": 0x0804}),
+            msg="Packet not allowed by ACL",
+        )
+
+        def verify_func():
+            for port in [1, 2]:
+                self.assertFalse(
+                    table.is_output(
+                        {"in_port": port, "vlan_vid": 0, "eth_type": 0x0804}
+                    ),
+                    msg="Packet not blocked by ACL",
+                )
+
+        self.update_and_revert_config(
+            self.CONFIG,
+            self.ADD_ACL_P2_CONFIG,
+            reload_type="warm",
+            verify_func=verify_func,
+        )
+
+
 class ValveChangeACLTestCase(ValveTestBases.ValveTestNetwork):
     """Test changes to ACL on a port."""
 
@@ -846,6 +933,91 @@ dps:
         # ACL changed but we kept the learn cache.
         self.update_config(self.DIFF_CONTENT_CONFIG, reload_type="warm")
         verify_func()
+
+
+class ValveDeleteACLTestCase(ValveTestBases.ValveTestNetwork):
+    """Test deletion of an ACL from a port."""
+
+    ACLS = """
+    acl_a:
+      - rule:
+        eth_type: 0x0804
+        actions:
+          allow: 0
+      - rule:
+        actions:
+          allow: 1
+"""
+
+    CONFIG = """
+acls:
+%s
+dps:
+    s1:
+%s
+        interfaces:
+            p1:
+                number: 1
+                native_vlan: 0x100
+                acl_in: acl_a
+            p2:
+                number: 2
+                native_vlan: 0x200
+                acl_in: acl_a
+""" % (
+        ACLS,
+        DP1_CONFIG,
+    )
+
+    DELETE_ACL_P2_CONFIG = """
+acls:
+%s
+dps:
+    s1:
+%s
+        interfaces:
+            p1:
+                number: 1
+                native_vlan: 0x100
+                acl_in: acl_a
+            p2:
+                number: 2
+                native_vlan: 0x200
+""" % (
+        ACLS,
+        DP1_CONFIG,
+    )
+
+    def setUp(self):
+        """Setup basic ACL config"""
+        self.setup_valves(self.CONFIG)
+
+    def test_delete_port_acl(self):
+        """Test port ACL can be deleted."""
+        table = self.network.tables[self.DP_ID]
+
+        for port in [1, 2]:
+            self.assertFalse(
+                table.is_output({"in_port": port, "vlan_vid": 0, "eth_type": 0x0804}),
+                msg="Packet not blocked by ACL",
+            )
+
+        def verify_func():
+            self.assertFalse(
+                table.is_output({"in_port": 1, "vlan_vid": 0, "eth_type": 0x0804}),
+                msg="Packet not blocked by ACL",
+            )
+            self.assertTrue(
+                table.is_output({"in_port": 2, "vlan_vid": 0, "eth_type": 0x0804}),
+                msg="Packet not allowed by ACL",
+            )
+
+        self.update_and_revert_config(
+            self.CONFIG,
+            self.DELETE_ACL_P2_CONFIG,
+            reload_type="warm",
+            verify_func=verify_func,
+        )
 
 
 class ValveChangeMirrorTestCase(ValveTestBases.ValveTestNetwork):


### PR DESCRIPTION
While reviewing #4733 a bug was discovered when deleting the final ACL from a port and warm reloading faucet. The bug caused the flow rules for the deleted ACL to remain on the datapath after the warm reload.

When the ACL configuration for a port changes, `ValveAclManager.cold_start_port()` will be called which sends a delete flowmod followed by the new ACL flowmods. In the case the final ACL is removed an implicit allow ACL rule is added, on the wire this looks like this:

```
OFPFlowMod(buffer_id=4294967295,command=3,cookie=1524372928,cookie_mask=0,flags=0,hard_timeout=0,idle_timeout=0,instructions=[],match=OFPMatch(oxm_fields={'in_port': 2}),out_group=4294967295,out_port=4294967295,priority=20480,table_id=0)
OFPFlowMod(buffer_id=4294967295,command=0,cookie=1524372928,cookie_mask=0,flags=0,hard_timeout=0,idle_timeout=0,instructions=(OFPInstructionGotoTable(len=8,table_id=1,type=1),),match=OFPMatch(oxm_fields={'in_port': 2}),out_group=0,out_port=0,priority=20480,table_id=0)
```

When flowmods are pushed to the dp, overlapping delete/adds that share match/cookie/priority/table_id (see: ece834d3fdbe669518b431ba2fbe37a90bf6e6b6) are suppressed by `remove_overlap_ofmsgs()`. Because these two flowmods share the same value for all these fields the port cold start only partially occurs, as the implicit allow rule is added but the old flow rules are not deleted because the flowdel is suppressed and not actually sent to the dp.

To fix this issue, the priority is removed from the port ACL flowdel, so that flow rules will be correctly deleted and re-added.

I also found during testing that modifying an existing ACL worked fine and did not experience this bug because the key that was used to compare flowmods for overlap included an OFPMatch object (which lacks `___eq___` or `___hash___`) so will only ever be equal with itself. Replacing this with a tuple of the flow match key/values makes the flow overlap suppression work in all cases.