### PR TITLE
Always warm start for ACL-only VLAN configuration change

### DIFF
--- a/faucet/dp.py
+++ b/faucet/dp.py
@@ -1485,6 +1485,7 @@ class DP(Conf):
             changes (tuple) of:
                 deleted_vlans (set): deleted VLAN IDs.
                 changed_vlans (set): changed/added VLAN IDs.
+                changed_acl_vlans (set): changed ACL only VLAN IDs.
         """
         (
             _,
@@ -1502,15 +1503,20 @@ class DP(Conf):
             ignore_keys=frozenset(["acls_in"]),
         )
         changed_vlans = added_vlans.union(changed_vlans)
-        # TODO: optimize for warm start.
+        changed_acl_vlans = set()
         for vlan_id in same_vlans:
             old_vlan = self.vlans[vlan_id]
             new_vlan = new_dp.vlans[vlan_id]
             if self._acl_ref_changes(
                 "VLAN %u" % vlan_id, old_vlan, new_vlan, changed_acls, logger
             ):
-                changed_vlans.add(vlan_id)
-        return (deleted_vlans, changed_vlans)
+                changed_acl_vlans.add(vlan_id)
+
+        if changed_acl_vlans:
+            same_vlans -= changed_acl_vlans
+            logger.info("vlans where ACL only changed: %s" % changed_acl_vlans)
+
+        return (deleted_vlans, changed_vlans, changed_acl_vlans)
 
     def _acl_ref_changes(self, conf_desc, old_conf, new_conf, changed_acls, logger):
         changed = False
@@ -1536,7 +1542,13 @@ class DP(Conf):
         return changed
 
     def _get_port_config_changes(
-        self, logger, new_dp, changed_vlans, deleted_vlans, changed_acls
+        self,
+        logger,
+        new_dp,
+        changed_vlans,
+        deleted_vlans,
+        changed_acl_vlans,
+        changed_acls,
     ):
         """Detect any config changes to ports.
 
@@ -1545,6 +1557,7 @@ class DP(Conf):
             new_dp (DP): new dataplane configuration.
             changed_vlans (set): changed/added VLAN IDs.
             deleted_vlans (set): deleted VLAN IDs.
+            changed_acl_vlans (set): changed ACL only VLAN IDs.
             changed_acls (set): changed/added ACL IDs.
         Returns:
             changes (tuple) of:
@@ -1590,16 +1603,28 @@ class DP(Conf):
 
         if not same_ports:
             all_ports_changed = True
-        # TODO: optimize case where only VLAN ACL changed.
-        elif changed_vlans:
-            all_ports = frozenset(new_dp.ports.keys())
-            new_changed_vlans = {
-                vlan for vlan in new_dp.vlans.values() if vlan.vid in changed_vlans
-            }
-            for vlan in new_changed_vlans:
-                changed_port_nums = {port.number for port in vlan.get_ports()}
-                changed_ports.update(changed_port_nums)
-            all_ports_changed = changed_ports == all_ports
+        else:
+            if changed_vlans:
+                all_ports = frozenset(new_dp.ports.keys())
+                new_changed_vlans = {
+                    vlan for vlan in new_dp.vlans.values() if vlan.vid in changed_vlans
+                }
+                for vlan in new_changed_vlans:
+                    changed_port_nums = {port.number for port in vlan.get_ports()}
+                    changed_ports.update(changed_port_nums)
+                all_ports_changed = changed_ports == all_ports
+            if changed_acl_vlans:
+                # Adding first VLAN ACL or deleting final VLAN ACL affects
+                # whether packets for port need to use the VLAN ACL table or not,
+                # so add ports whose VLAN had an ACL change to the changed ports list
+                acl_changed_vlans = {
+                    vlan
+                    for vlan in new_dp.vlans.values()
+                    if vlan.vid in changed_acl_vlans
+                }
+                for vlan in acl_changed_vlans:
+                    changed_acl_port_nums = {port.number for port in vlan.get_ports()}
+                    changed_ports.update(changed_acl_port_nums)
 
         # Detect changes to VLANs and ACLs based on port changes.
         if not all_ports_changed:
@@ -1714,6 +1739,7 @@ class DP(Conf):
                 changed_acl_ports (set): changed ACL only port numbers.
                 deleted_vlans (set): deleted VLAN IDs.
                 changed_vlans (set): changed/added VLAN IDs.
+                changed_acl_vlans (set): changed ACL only VLAN IDs.
                 all_ports_changed (bool): True if all ports changed.
                 all_meters_changed (bool): True if all meters changed
                 deleted_meters (set): deleted meter numbers
@@ -1736,8 +1762,8 @@ class DP(Conf):
             )
         else:
             changed_acls = self._get_acl_config_changes(logger, new_dp)
-            deleted_vlans, changed_vlans = self._get_vlan_config_changes(
-                logger, new_dp, changed_acls
+            deleted_vlans, changed_vlans, changed_acl_vlans = (
+                self._get_vlan_config_changes(logger, new_dp, changed_acls)
             )
             (
                 all_meters_changed,
@@ -1753,7 +1779,12 @@ class DP(Conf):
                 changed_acl_ports,
                 changed_vlans,
             ) = self._get_port_config_changes(
-                logger, new_dp, changed_vlans, deleted_vlans, changed_acls
+                logger,
+                new_dp,
+                changed_vlans,
+                deleted_vlans,
+                changed_acl_vlans,
+                changed_acls,
             )
             return (
                 deleted_ports,
@@ -1762,6 +1793,7 @@ class DP(Conf):
                 changed_acl_ports,
                 deleted_vlans,
                 changed_vlans,
+                changed_acl_vlans,
                 all_ports_changed,
                 all_meters_changed,
                 deleted_meters,
@@ -1770,6 +1802,7 @@ class DP(Conf):
             )
         # default cold start
         return (
+            set(),
             set(),
             set(),
             set(),

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -1599,6 +1599,7 @@ class Valve:
             changed_acl_ports,
             deleted_vids,
             changed_vids,
+            changed_acl_vlans,
             all_ports_changed,
             _,
             deleted_meters,
@@ -1665,10 +1666,16 @@ class Valve:
                 port for port in changed_ports if port in self.dp.dyn_up_port_nos
             ]
             ofmsgs.extend(self.ports_add(all_up_port_nos))
-        if self.acl_manager and changed_acl_ports:
-            for port_num in changed_acl_ports:
-                port = self.dp.ports[port_num]
-                ofmsgs.extend(self.acl_manager.cold_start_port(port))
+        if self.acl_manager:
+            if changed_acl_ports:
+                for port_num in changed_acl_ports:
+                    port = self.dp.ports[port_num]
+                    ofmsgs.extend(self.acl_manager.cold_start_port(port))
+            if changed_acl_vlans:
+                for vid in changed_acl_vlans:
+                    vlan = self.dp.vlans[vid]
+                    ofmsgs.extend(self.acl_manager.del_vlan(vlan))
+                    ofmsgs.extend(self.acl_manager.add_vlan(vlan, False))
         if changed_vids:
             changed_vlans = [self.dp.vlans[vid] for vid in changed_vids]
             # TODO: handle change versus add separately so can avoid delete first.

--- a/tests/integration/mininet_tests.py
+++ b/tests/integration/mininet_tests.py
@@ -3297,7 +3297,7 @@ acls:
             new_yaml_acl_conf,
             self.acl_config_file,  # pytype: disable=attribute-error
             restart=True,
-            cold_start=True,
+            cold_start=False,
         )
         self.wait_until_matching_flow({"dl_type": 0x800}, table_id=self._VLAN_ACL_TABLE)
         self.wait_until_matching_flow({"dl_type": 0x806}, table_id=self._VLAN_ACL_TABLE)
@@ -3307,7 +3307,7 @@ acls:
             orig_yaml_acl_conf,
             self.acl_config_file,  # pytype: disable=attribute-error
             restart=True,
-            cold_start=True,
+            cold_start=False,
         )
         self.wait_until_matching_flow({"dl_type": 0x800}, table_id=self._VLAN_ACL_TABLE)
         self.wait_until_no_matching_flow(

--- a/tests/unit/faucet/test_valve_config.py
+++ b/tests/unit/faucet/test_valve_config.py
@@ -129,7 +129,109 @@ dps: {}
             )
 
 
+class ValveAddVLANACLTestCase(ValveTestBases.ValveTestNetwork):
+    """Test addition of an ACL to a VLAN."""
+
+    ACLS = """
+    acl_a:
+      - rule:
+        eth_type: 0x0804
+        actions:
+          allow: 0
+      - rule:
+        actions:
+          allow: 1
+"""
+
+    CONFIG = """
+acls:
+%s
+vlans:
+  vlan1:
+    acls_in:
+    - acl_a
+    vid: 0x100
+  vlan2:
+    vid: 0x200
+dps:
+    s1:
+%s
+        interfaces:
+            p1:
+                number: 1
+                native_vlan: vlan1
+            p2:
+                number: 2
+                native_vlan: vlan2
+""" % (
+        ACLS,
+        DP1_CONFIG,
+    )
+
+    ADD_ACL_VLAN2_CONFIG = """
+acls:
+%s
+vlans:
+  vlan1:
+    acls_in:
+    - acl_a
+    vid: 0x100
+  vlan2:
+    acls_in:
+    - acl_a
+    vid: 0x200
+dps:
+    s1:
+%s
+        interfaces:
+            p1:
+                number: 1
+                native_vlan: vlan1
+            p2:
+                number: 2
+                native_vlan: vlan2
+""" % (
+        ACLS,
+        DP1_CONFIG,
+    )
+
+    def setUp(self):
+        """Setup basic ACL config"""
+        self.setup_valves(self.CONFIG)
+
+    def test_add_vlan_acl(self):
+        """Test VLAN ACL can be added."""
+        table = self.network.tables[self.DP_ID]
+
+        self.assertFalse(
+            table.is_output({"in_port": 1, "vlan_vid": 0, "eth_type": 0x0804}),
+            msg="Packet not blocked by ACL",
+        )
+        self.assertTrue(
+            table.is_output({"in_port": 2, "vlan_vid": 0, "eth_type": 0x0804}),
+            msg="Packet not allowed by ACL",
+        )
+
+        def verify_func():
+            for port in [1, 2]:
+                self.assertFalse(
+                    table.is_output(
+                        {"in_port": port, "vlan_vid": 0, "eth_type": 0x0804}
+                    ),
+                    msg="Packet not blocked by ACL",
+                )
+
+        self.update_and_revert_config(
+            self.CONFIG,
+            self.ADD_ACL_VLAN2_CONFIG,
+            reload_type="warm",
+            verify_func=verify_func,
+        )
+
+
 class ValveChangeVLANACLTestCase(ValveTestBases.ValveTestNetwork):
+    """Test changing an ACL on a VLAN."""
+
     CONFIG = (
         """
 acls:
@@ -185,8 +287,125 @@ dps:
         self.setup_valves(self.CONFIG)
 
     def test_change_vlan_acl(self):
-        """Test vlan ACL change is detected."""
-        self.update_and_revert_config(self.CONFIG, self.MORE_CONFIG, "cold")
+        """Test vlan ACL change is detected and packets are correctly allowed/blocked."""
+        table = self.network.tables[self.DP_ID]
+
+        self.assertTrue(
+            table.is_output({"in_port": 1, "vlan_vid": 0, "eth_type": 0x0806}),
+            msg="Packet not allowed by ACL",
+        )
+
+        def verify_func():
+            self.assertTrue(
+                table.is_output({"in_port": 1, "vlan_vid": 0, "eth_type": 0x0806}),
+                msg="Packet not allowed by ACL",
+            )
+            self.assertFalse(
+                table.is_output({"in_port": 1, "vlan_vid": 0, "eth_type": 0x0800}),
+                msg="Packet not blocked by ACL",
+            )
+
+        self.update_and_revert_config(
+            self.CONFIG, self.MORE_CONFIG, "warm", verify_func=verify_func
+        )
+
+
+class ValveDeleteVLANACLTestCase(ValveTestBases.ValveTestNetwork):
+    """Test deletion of an ACL from a VLAN."""
+
+    ACLS = """
+    acl_a:
+      - rule:
+        eth_type: 0x0804
+        actions:
+          allow: 0
+      - rule:
+        actions:
+          allow: 1
+"""
+
+    CONFIG = """
+acls:
+%s
+vlans:
+  vlan1:
+    acls_in:
+    - acl_a
+    vid: 0x100
+  vlan2:
+    acls_in:
+    - acl_a
+    vid: 0x200
+dps:
+    s1:
+%s
+        interfaces:
+            p1:
+                number: 1
+                native_vlan: vlan1
+            p2:
+                number: 2
+                native_vlan: vlan2
+""" % (
+        ACLS,
+        DP1_CONFIG,
+    )
+
+    DELETE_ACL_VLAN2_CONFIG = """
+acls:
+%s
+vlans:
+  vlan1:
+    acls_in:
+    - acl_a
+    vid: 0x100
+  vlan2:
+    vid: 0x200
+dps:
+    s1:
+%s
+        interfaces:
+            p1:
+                number: 1
+                native_vlan: vlan1
+            p2:
+                number: 2
+                native_vlan: vlan2
+""" % (
+        ACLS,
+        DP1_CONFIG,
+    )
+
+    def setUp(self):
+        """Setup basic ACL config"""
+        self.setup_valves(self.CONFIG)
+
+    def test_delete_vlan_acl(self):
+        """Test VLAN ACL can be deleted."""
+        table = self.network.tables[self.DP_ID]
+
+        for port in [1, 2]:
+            self.assertFalse(
+                table.is_output({"in_port": port, "vlan_vid": 0, "eth_type": 0x0804}),
+                msg="Packet not blocked by ACL",
+            )
+
+        def verify_func():
+            self.assertFalse(
+                table.is_output({"in_port": 1, "vlan_vid": 0, "eth_type": 0x0804}),
+                msg="Packet not blocked by ACL",
+            )
+            self.assertTrue(
+                table.is_output({"in_port": 2, "vlan_vid": 0, "eth_type": 0x0804}),
+                msg="Packet not allowed by ACL",
+            )
+
+        self.update_and_revert_config(
+            self.CONFIG,
+            self.DELETE_ACL_VLAN2_CONFIG,
+            reload_type="warm",
+            verify_func=verify_func,
+        )
 
 
 class ValveChangePortTestCase(ValveTestBases.ValveTestNetwork):

--- a/tests/unit/faucet/test_valve_stack.py
+++ b/tests/unit/faucet/test_valve_stack.py
@@ -4046,7 +4046,7 @@ dps:
         for new_dp in new_dps:
             valve = self.valves_manager.valves[new_dp.dp_id]
             changes = valve.dp.get_config_changes(valve.logger, new_dp)
-            changed_ports, all_ports_changed = changes[1], changes[6]
+            changed_ports, all_ports_changed = changes[1], changes[7]
             for port in valve.dp.stack_ports():
                 if not all_ports_changed:
                     self.assertIn(


### PR DESCRIPTION
When detecting config changes on SIGHUP, treat VLANs with an ACL-only change the same as ports with an ACL-only change and warm start.

supersedes #4733