### PR TITLE
Fix crash in _check_table_difference() when table hashes aren't equal

### DIFF
--- a/clib/fakeoftable.py
+++ b/clib/fakeoftable.py
@@ -232,7 +232,7 @@ class FakeOFNetwork:
 
     def hash_table(self, dp_id):
         """Return a hash of a single FakeOFTable"""
-        return self.tables[dp_id].__hash__()
+        return hash(self.tables[dp_id])
 
 
 class FakeOFTable:
@@ -252,12 +252,26 @@ class FakeOFTable:
 
     def table_state(self):
         """Return tuple of table hash & table str"""
-        table_str = str(self.tables)
-        return (hash(frozenset(table_str)), table_str)
+        return (hash(self), str(self))
 
     def __hash__(self):
         """Return a host of the tables"""
-        return hash(frozenset(str(self.tables)))
+        return hash(
+            tuple(
+                tuple(
+                    sorted(
+                        table,
+                        key=lambda x: (
+                            x.priority,
+                            tuple(
+                                (k, str(v)) for k, v in sorted(x.match_values.items())
+                            ),
+                        ),
+                    )
+                )
+                for table in self.tables
+            )
+        )
 
     def _apply_groupmod(self, ofmsg):
         """Maintain group table."""
@@ -1051,10 +1065,10 @@ class FlowMod:
         return hash(
             (
                 self.priority,
-                self.match_values,
-                self.match_masks,
+                tuple(sorted(self.match_values.items())),
+                tuple(sorted(self.match_masks.items())),
                 self.out_port,
-                self.instructions,
+                str(self.instructions),
             )
         )
 

--- a/clib/fakeoftable.py
+++ b/clib/fakeoftable.py
@@ -877,7 +877,20 @@ class FakeOFTable:
         string = ""
         for table_id, table in enumerate(self.tables):
             string += "\n----- Table %u -----\n" % (table_id)
-            string += "\n".join(sorted([str(flowmod) for flowmod in table]))
+            string += "\n".join(
+                [
+                    str(flowmod)
+                    for flowmod in sorted(
+                        table,
+                        key=lambda x: (
+                            x.priority,
+                            tuple(
+                                (k, str(v)) for k, v in sorted(x.match_values.items())
+                            ),
+                        ),
+                    )
+                ]
+            )
         return string
 
     def sort_tables(self):

--- a/clib/valve_test_lib.py
+++ b/clib/valve_test_lib.py
@@ -781,11 +781,7 @@ class ValveTestBases:
                 diff = difflib.unified_diff(
                     before_str.splitlines(), after_str.splitlines()
                 )
-                self.assertEqual(
-                    before_hash,
-                    after_hash,
-                    msg="%s != %s\n".join(diff) % (before_hash, after_hash),
-                )
+                self.assertEqual(before_hash, after_hash, msg="\n" + "\n".join(diff))
 
         def _verify_redundant_safe_offset_ofmsgs(self, ofmsgs, dp_id, offset=1):
             """


### PR DESCRIPTION
Fixes this crash in `_check_table_difference()`:

```
  File "/faucet-src/clib/valve_test_lib.py", line 787, in _check_table_difference
    msg="%s != %s\n".join(diff) % (before_hash, after_hash),
        ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~
TypeError: not enough arguments for format string
```

Also as it turns out, hashing of FakeOFTable objects was broken which meant that `_check_table_difference()` would not always detect a difference between two different table states. The hash was created based on a frozenset of a string:

```return hash(frozenset(str(self.tables)))```

This effectively just counted unique characters in the string representation of a table, and only if there was a new character present in one of the table states would a different hash be calculated.

Also made a few formatting improvements, firstly `table_state()` was modified to return the prettified representation of table state which matches the format that `_check_table_difference()` uses for diffing. Secondly, the order in which flowmods are printed for a table is now sorted by priority then by match.