### PR TITLE
Fix comparison of masked flowmod matches in FakeOF

### DIFF
--- a/clib/fakeoftable.py
+++ b/clib/fakeoftable.py
@@ -954,7 +954,8 @@ class FlowMod:
             if key not in pkt_dict:
                 return False
             val_bits = self.match_to_bits(key, pkt_dict[key])
-            if val_bits != (val & self.match_masks[key]):
+            mask = self.match_masks[key]
+            if (val_bits & mask) != (val & mask):
                 return False
         return True
 


### PR DESCRIPTION
Mask was not applied to both sides of value check, so checking if `packet_dict={'ipv4_dst': '10.10.0.1'}` matched a flowmod with match `ipv4_dst=10.10.0.0/24` would fail.