### PR TITLE
Fix integration test retry for single test runners

### DIFF
--- a/clib/clib_mininet_test_main.py
+++ b/clib/clib_mininet_test_main.py
@@ -582,7 +582,7 @@ def run_single_test_suites(debug, root_tmpdir, resultclass, single_tests, retrie
             sys.excepthook = oldexcepthook
         else:
             for _ in range(retries):
-                test_results = single_runner.run(single_tests)
+                test_results = single_runner.run(copy.deepcopy(single_tests))
                 if all_tests_successful([test_results]):
                     break
             results.append(test_results)


### PR DESCRIPTION
#4496 added default retries for integration test runners, this worked for parallel test runners, but for the single test runners this crash was introduced:

```
FAILED (failures=1)
Traceback (most recent call last):
  File "/faucet-src/tests/integration/./mininet_main.py", line 19, in <module>
    test_main([mininet_tests.__name__, mininet_multidp_tests.__name__])
  File "/faucet-src/clib/clib_mininet_test_main.py", line 1069, in test_main
    run_tests(
  File "/faucet-src/clib/clib_mininet_test_main.py", line 805, in run_tests
    all_successful = run_test_suites(
                     ^^^^^^^^^^^^^^^^
  File "/faucet-src/clib/clib_mininet_test_main.py", line 665, in run_test_suites
    run_single_test_suites(debug, root_tmpdir, resultclass, single_tests, retries)
  File "/faucet-src/clib/clib_mininet_test_main.py", line 586, in run_single_test_suites
    test_results = single_runner.run(single_tests)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/unittest/runner.py", line 217, in run
    test(result)
  File "/usr/lib/python3.11/unittest/suite.py", line 84, in __call__
    return self.run(*args, **kwds)
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/unittest/suite.py", line 122, in run
    test(result)
TypeError: 'NoneType' object is not callable
```

This patch provides each single test runner a fresh copy of the tests object to prevent a test runner from modifying the object which causes a subsequent runner to crash.